### PR TITLE
Generate public/private keypairs for 3pid invites

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     description="Reference Synapse Identity Verification and Lookup Server",
     install_requires=[
         "signedjson==1.0.0",
-        "unpaddedbase64==1.0.1",
+        "unpaddedbase64==1.1.0",
         "Twisted>=14.0.0",
         "service_identity>=1.0.0",
         "pyasn1",

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -61,3 +61,25 @@ class JoinTokenStore(object):
             (int(time.time()), medium, address,)
         )
         self.sydent.db.commit()
+
+    def storeEphemeralPublicKey(self, publicKey):
+        cur = self.sydent.db.cursor()
+        cur.execute(
+            "INSERT INTO ephemeral_public_keys"
+            " (public_key, persistence_ts)"
+            " VALUES (?, ?)",
+            (publicKey, int(time.time()))
+        )
+        self.sydent.db.commit()
+
+    def validateEphemeralPublicKey(self, publicKey):
+        cur = self.sydent.db.cursor()
+        cur.execute(
+            "UPDATE ephemeral_public_keys"
+            " SET verify_count = verify_count + 1"
+            " WHERE public_key = ?"
+            " LIMIT 1",
+            (publicKey,)
+        )
+        self.sydent.db.commit()
+        return cur.rowcount > 0

--- a/sydent/db/invite_tokens.sql
+++ b/sydent/db/invite_tokens.sql
@@ -24,4 +24,13 @@ CREATE TABLE IF NOT EXISTS invite_tokens (
     received_ts bigint, -- When the invite was received by us from the homeserver
     sent_ts bigint -- When the token was sent by us to the user
 );
-CREATE UNIQUE INDEX IF NOT EXISTS medium_address on invite_tokens(medium, address);
+CREATE INDEX IF NOT EXISTS invite_token_medium_address on invite_tokens(medium, address);
+
+CREATE TABLE IF NOT EXISTS ephemeral_public_keys(
+    id integer primary key,
+    public_key varchar(256) not null,
+    verify_count bigint default 0,
+    persistence_ts bigint
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ephemeral_public_keys_index on ephemeral_public_keys(public_key);

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -46,6 +46,8 @@ class ClientApiHttpServer:
         bind = self.sydent.servlets.threepidBind
 
         pubkey = Resource()
+        ephemeralPubkey = Resource()
+
         pk_ed25519 = self.sydent.servlets.pubkey_ed25519
 
         root.putChild('_matrix', matrix)
@@ -61,6 +63,8 @@ class ClientApiHttpServer:
         v1.putChild('pubkey', pubkey)
         pubkey.putChild('isvalid', self.sydent.servlets.pubkeyIsValid)
         pubkey.putChild('ed25519:0', pk_ed25519)
+        pubkey.putChild('ephemeral', ephemeralPubkey)
+        ephemeralPubkey.putChild('isvalid', self.sydent.servlets.ephemeralPubkeyIsValid)
 
         v1.putChild('3pid', threepid)
         threepid.putChild('bind', bind)

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -26,7 +26,7 @@ from db.sqlitedb import SqliteDatabase
 from http.httpcommon import SslComponents
 from http.httpserver import ClientApiHttpServer, ReplicationHttpsServer
 from http.httpsclient import ReplicationHttpsClient
-from http.servlets.pubkeyservlets import PubkeyIsValidServlet
+from http.servlets.pubkeyservlets import EphemeralPubkeyIsValidServlet, PubkeyIsValidServlet
 from validators.emailvalidator import EmailValidator
 
 from sign.ed25519 import SydentEd25519
@@ -102,6 +102,7 @@ class Sydent:
         self.servlets.lookup = LookupServlet(self)
         self.servlets.pubkey_ed25519 = Ed25519Servlet(self)
         self.servlets.pubkeyIsValid = PubkeyIsValidServlet(self)
+        self.servlets.ephemeralPubkeyIsValid = EphemeralPubkeyIsValidServlet(self)
         self.servlets.threepidBind = ThreePidBindServlet(self)
         self.servlets.replicationPush = ReplicationPushServlet(self)
         self.servlets.getValidated3pid = GetValidated3pidServlet(self)


### PR DESCRIPTION
Optionally include private keys in emails.

Perpetually serve up 'yes of course it's valid' to any public keys we
have issued, and hand them to the invite storer.

The fact that this currently re-implements truncated base64 encoding is
sad but we need it to be urlsafe and apparently we don't do that
anywhere else.