### PR TITLE
Sort out encodings in the email messages

### DIFF
--- a/res/invite_template_vector.eml
+++ b/res/invite_template_vector.eml
@@ -2,7 +2,7 @@ Date: %(date)s
 From: %(from)s
 To: %(to)s
 Message-ID: %(messageid)s
-Subject: %(sender_display_name)s has invited you to a room on Vector
+Subject: %(subject_header_value)s
 MIME-Version: 1.0
 Content-Type: multipart/alternative; 
 	boundary="7REaIwWQCioQ6NaBlAQlg8ztbUQj6PKJ"
@@ -16,7 +16,7 @@ Hi,
 %(sender_display_name)s has invited you into a room %(bracketed_room_name)s on
 Vector. To join the conversation please follow the link below.
 
-https://vector.im/#/room/%(room_id)s?email=%(to)s&signurl=https%%3A%%2F%%2Fvector.im%%2F_matrix%%2Fidentity%%2Fapi%%2Fv1%%2Fsign-ed25519%%3Ftoken%%3D%(token)s%%26private_key%%3D%(ephemeral_private_key)s&room_name=%(room_name)s&room_avatar_url=%(room_avatar_url)s&inviter_name=%(sender_display_name)s&guest_access_token=%(guest_access_token)s&guest_user_id=%(guest_user_id)s
+https://vector.im/#/room/%(room_id_forurl)s?email=%(to_forurl)s&signurl=https%%3A%%2F%%2Fvector.im%%2F_matrix%%2Fidentity%%2Fapi%%2Fv1%%2Fsign-ed25519%%3Ftoken%%3D%(token)s%%26private_key%%3D%(ephemeral_private_key)s&room_name=%(room_name_forurl)s&room_avatar_url=%(room_avatar_url_forurl)s&inviter_name=%(sender_display_name_forurl)s&guest_access_token=%(guest_access_token_forurl)s&guest_user_id=%(guest_user_id_forurl)s
 
 Please note that you will need to use Chrome, Firefox or Safari.
 
@@ -57,12 +57,12 @@ body {
 <div id="page">
 <p>Hi,</p>
 
-<p>%(sender_display_name)s has invited you into a room %(bracketed_room_name)s on
+<p>%(sender_display_name_forhtml)s has invited you into a room %(bracketed_room_name_forhtml)s on
 Vector.</p>
 
 <p>
     <a
-    href="https://vector.im/#/room/%(room_id)s?email=%(to)s&signurl=https%%3A%%2F%%2Fvector.im%%2F_matrix%%2Fidentity%%2Fapi%%2Fv1%%2Fsign-ed25519%%3Ftoken%%3D%(token)s%%26private_key%%3D%(ephemeral_private_key)s&room_name=%(room_name)s&room_avatar_url=%(room_avatar_url)s&inviter_name=%(sender_display_name)s&guest_access_token=%(guest_access_token)s&guest_user_id=%(guest_user_id)s">Join the conversation.</a>
+    href="https://vector.im/#/room/%(room_id_forurl)s?email=%(to_forurl)s&signurl=https%%3A%%2F%%2Fvector.im%%2F_matrix%%2Fidentity%%2Fapi%%2Fv1%%2Fsign-ed25519%%3Ftoken%%3D%(token)s%%26private_key%%3D%(ephemeral_private_key)s&room_name=%(room_name_forurl)s&room_avatar_url=%(room_avatar_url_forurl)s&inviter_name=%(sender_display_name_forurl)s&guest_access_token=%(guest_access_token_forurl)s&guest_user_id=%(guest_user_id_forurl)s">Join the conversation.</a>
 </p>
 
 <p>Please note that you will need to use Chrome, Firefox or Safari.</p>

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -13,10 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import cgi
 import nacl.signing
 import random
 import string
+from email.header import Header
 
 from twisted.web.resource import Resource
 from unpaddedbase64 import encode_base64
@@ -76,7 +76,7 @@ class StoreInviteServlet(Resource):
         substitutions = {}
         for key, values in request.args.items():
             if len(values) == 1 and type(values[0]) == str:
-                substitutions[key] = cgi.escape(values[0])
+                substitutions[key] = values[0]
         substitutions["token"] = token
 
         required = [
@@ -96,6 +96,8 @@ class StoreInviteServlet(Resource):
         if substitutions["room_name"] != '':
             substitutions["bracketed_room_name"] = "(%s)" % substitutions["room_name"]
 
+        subject_header = Header(self.sydent.cfg.get('email', 'email.invite.subject', raw=True) % substitutions, 'utf8')
+        substitutions["subject_header_value"] = subject_header.encode()
 
         sendEmail(self.sydent, "email.invite_template", address, substitutions)
 

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -60,6 +60,7 @@ class Sydent:
         'email.template': 'res/email.template',
         'email.from': 'Sydent Validation <noreply@{hostname}>',
         'email.subject': 'Your Validation Token',
+        'email.invite.subject': '%(sender_display_name)s has invited you to chat',
         'email.smtphost': 'localhost',
         'log.path': '',
         'ed25519.signingkey': '',

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -21,6 +21,8 @@ import smtplib
 import email.utils
 import string
 import twisted.python.log
+import cgi
+import urllib
 
 import email.utils
 
@@ -45,6 +47,12 @@ def sendEmail(sydent, templateName, mailTo, substitutions):
             'to': mailTo,
             'from': mailFrom,
         })
+
+        for k,v in allSubstitutions.items():
+            allSubstitutions[k] = v.decode('utf8')
+            allSubstitutions[k+"_forhtml"] = cgi.escape(v.decode('utf8'))
+            allSubstitutions[k+"_forurl"] = urllib.quote(v)
+
         mailString = open(mailTemplateFile).read() % allSubstitutions
         rawFrom = email.utils.parseaddr(mailFrom)[1]
         rawTo = email.utils.parseaddr(mailTo)[1]
@@ -55,7 +63,7 @@ def sendEmail(sydent, templateName, mailTo, substitutions):
         logger.info("Sending mail to %s with mail server: %s" % (mailTo, mailServer,))
         try:
             smtp = smtplib.SMTP(mailServer)
-            smtp.sendmail(rawFrom, rawTo, mailString)
+            smtp.sendmail(rawFrom, rawTo, mailString.encode('utf-8'))
             smtp.quit()
         except Exception as origException:
             twisted.python.log.err()


### PR DESCRIPTION
encode unicodes to strings where necessary, have differently encoded versions of the substitutions for use in the different places and use the email header library to generate the appropriately encoded header.

This a) stops us crashing now I've fixed synapse to actually send utf-8 correctly and b) makes unicode appear correctly in the invite emails (which contain input from the user, where the validation email never did)