### PR TITLE
Don't use UPDATE...LIMIT syntax

### DIFF
--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -77,8 +77,7 @@ class JoinTokenStore(object):
         cur.execute(
             "UPDATE ephemeral_public_keys"
             " SET verify_count = verify_count + 1"
-            " WHERE public_key = ?"
-            " LIMIT 1",
+            " WHERE public_key = ?",
             (publicKey,)
         )
         self.sydent.db.commit()


### PR DESCRIPTION
sqlite doesn't support this unless it's specifically compiled with support for it (for some reason). It should be unnecessary since this table has a unique index on `public_key` so there can only be one row anyway.