### PR TITLE
Accept JSON on all client facing endpoints

### DIFF
--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -19,7 +19,7 @@ import json
 import signedjson.key
 import signedjson.sign
 from sydent.db.invite_tokens import JoinTokenStore
-from sydent.http.servlets import require_args, jsonwrap, send_cors
+from sydent.http.servlets import get_args, jsonwrap, send_cors
 
 
 class BlindlySignStuffServlet(Resource):
@@ -31,13 +31,13 @@ class BlindlySignStuffServlet(Resource):
 
     def render_POST(self, request):
         send_cors(request)
-        err = require_args(request, ("private_key", "token", "mxid"))
+        err, args = get_args(request, ("private_key", "token", "mxid"))
         if err:
             return json.dumps(err)
 
-        private_key_base64 = request.args['private_key'][0]
-        token = request.args['token'][0]
-        mxid = request.args['mxid'][0]
+        private_key_base64 = args['private_key']
+        token = args['token']
+        mxid = args['mxid']
 
         sender = self.tokenStore.getSenderForToken(token)
         if sender is None:

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -62,7 +62,7 @@ class EmailRequestCodeServlet(Resource):
             resp = {'errcode': 'M_EMAIL_SEND_ERROR', 'error': 'Failed to send email'}
 
         if not resp:
-            resp = {'success': True, 'sid': sid}
+            resp = {'success': True, 'sid': str(sid)}
 
         return resp
 

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -20,7 +20,7 @@ from sydent.util.emailutils import EmailAddressException, EmailSendException
 from sydent.validators.emailvalidator import SessionExpiredException
 from sydent.validators.emailvalidator import IncorrectClientSecretException
 
-from sydent.http.servlets import require_args, jsonwrap, send_cors
+from sydent.http.servlets import get_args, jsonwrap, send_cors
 
 
 class EmailRequestCodeServlet(Resource):
@@ -33,36 +33,20 @@ class EmailRequestCodeServlet(Resource):
     def render_POST(self, request):
         send_cors(request)
 
-        # error = require_args(request, ('email', 'client_secret', 'send_attempt'))
-        error = require_args(request, ('email',))
+        error, args = get_args(request, ('email', 'client_secret', 'send_attempt'))
         if error:
             request.setResponseCode(400)
             return error
 
-        # look for both camelcase and underscores for transition
-        if 'client_secret' in request.args:
-            clientSecret = request.args['client_secret'][0]
-        elif 'clientSecret' in request.args:
-            clientSecret = request.args['clientSecret'][0]
-        else:
-            request.setResponseCode(400)
-            return {'errcode': 'M_MISSING_PARAM', 'error':'No client_secret'}
-
-        if 'send_attempt' in request.args:
-            sendAttempt = request.args['send_attempt'][0]
-        elif 'sendAttempt' in request.args:
-            sendAttempt = request.args['sendAttempt'][0]
-        else:
-            request.setResponseCode(400)
-            return {'errcode': 'M_MISSING_PARAM', 'error':'No send_attempt'}
-
-        email = request.args['email'][0]
+        email = args['email']
+        clientSecret = args['client_secret']
+        sendAttempt = args['send_attempt']
 
         ipaddress = self.sydent.ip_from_request(request)
 
         nextLink = None
-        if 'next_link' in request.args:
-            nextLink = request.args['next_link'][0]
+        if 'next_link' in args:
+            nextLink = args['next_link']
 
         resp = None
 

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -18,7 +18,7 @@
 
 from twisted.web.resource import Resource
 
-from sydent.http.servlets import jsonwrap, require_args
+from sydent.http.servlets import jsonwrap, get_args
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.validators import SessionExpiredException, IncorrectClientSecretException, InvalidSessionIdException,\
     SessionNotValidatedException
@@ -31,21 +31,12 @@ class GetValidated3pidServlet(Resource):
 
     @jsonwrap
     def render_GET(self, request):
-        # err = require_args(request, ('sid', 'client_secret'))
-        err = require_args(request, ('sid',))
+        err, args = require_args(request, ('sid', 'client_secret'))
         if err:
             return err
 
-        sid = request.args['sid'][0]
-        #clientSecret = request.args['client_secret'][0]
-
-        if 'client_secret' in request.args:
-            clientSecret = request.args['client_secret'][0]
-        elif 'clientSecret' in request.args:
-            clientSecret = request.args['clientSecret'][0]
-        else:
-            request.setResponseCode(400)
-            return {'errcode': 'M_MISSING_PARAM', 'error':'No client_secret'}
+        sid = args['sid']
+        clientSecret = args['client_secret']
 
         valSessionStore = ThreePidValSessionStore(self.sydent)
 

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -20,7 +20,7 @@ from sydent.db.threepid_associations import GlobalAssociationStore
 import json
 import signedjson.sign
 
-from sydent.http.servlets import require_args, jsonwrap, send_cors
+from sydent.http.servlets import get_args, jsonwrap, send_cors
 
 class LookupServlet(Resource):
     isLeaf = True
@@ -30,12 +30,12 @@ class LookupServlet(Resource):
 
     def render_GET(self, request):
         send_cors(request)
-        err = require_args(request, ('medium', 'address'))
+        err, args = get_args(request, ('medium', 'address'))
         if err:
             return err
 
-        medium = request.args['medium'][0]
-        address = request.args['address'][0]
+        medium = args['medium']
+        address = args['address']
 
         globalAssocStore = GlobalAssociationStore(self.sydent)
 

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -70,7 +70,7 @@ class MsisdnRequestCodeServlet(Resource):
             resp = {'errcode': 'M_UNKNOWN', 'error':'Internal Server Error'}
 
         if not resp:
-            resp = {'success': True, 'sid': sid}
+            resp = {'success': True, 'sid': str(sid)}
 
         return resp
 

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -18,7 +18,7 @@ from unpaddedbase64 import encode_base64
 
 import json
 from sydent.db.invite_tokens import JoinTokenStore
-from sydent.http.servlets import require_args
+from sydent.http.servlets import get_args
 
 
 class Ed25519Servlet(Resource):
@@ -40,14 +40,14 @@ class PubkeyIsValidServlet(Resource):
         self.sydent = syd
 
     def render_GET(self, request):
-        err = require_args(request, ("public_key",))
+        err, args = get_args(request, ("public_key",))
         if err:
             return json.dumps(err)
 
         pubKey = self.sydent.keyring.ed25519.verify_key
         pubKeyBase64 = encode_base64(pubKey.encode())
 
-        return json.dumps({'valid': request.args["public_key"][0] == pubKeyBase64})
+        return json.dumps({'valid': args["public_key"] == pubKeyBase64})
 
 
 class EphemeralPubkeyIsValidServlet(Resource):
@@ -57,10 +57,10 @@ class EphemeralPubkeyIsValidServlet(Resource):
         self.joinTokenStore = JoinTokenStore(syd)
 
     def render_GET(self, request):
-        err = require_args(request, ("public_key",))
+        err, args = get_args(request, ("public_key",))
         if err:
             return json.dumps(err)
-        publicKey = request.args["public_key"][0]
+        publicKey = args["public_key"]
 
         return json.dumps({
             'valid': self.joinTokenStore.validateEphemeralPublicKey(publicKey),

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -16,7 +16,7 @@
 
 import twisted.python.log
 from twisted.web.resource import Resource
-from sydent.http.servlets import require_args, jsonwrap
+from sydent.http.servlets import jsonwrap
 from sydent.threepid import threePidAssocFromDict
 from sydent.db.peers import PeerStore
 from sydent.db.threepid_associations import GlobalAssociationStore

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -25,7 +25,7 @@ import json
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.db.threepid_associations import GlobalAssociationStore
 
-from sydent.http.servlets import require_args, send_cors
+from sydent.http.servlets import get_args, send_cors
 from sydent.util.emailutils import sendEmail
 
 
@@ -38,10 +38,10 @@ class StoreInviteServlet(Resource):
         err = require_args(request, ("medium", "address", "room_id", "sender",))
         if err:
             return json.dumps(err)
-        medium = request.args["medium"][0]
-        address = request.args["address"][0]
-        roomId = request.args["room_id"][0]
-        sender = request.args["sender"][0]
+        medium = args["medium"]
+        address = args["address"]
+        roomId = args["room_id"]
+        sender = args["sender"]
 
         globalAssocStore = GlobalAssociationStore(self.sydent)
         mxid = globalAssocStore.getMxid(medium, address)

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -16,7 +16,7 @@
 
 from twisted.web.resource import Resource
 
-from sydent.http.servlets import require_args, jsonwrap, send_cors
+from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.validators import SessionExpiredException, IncorrectClientSecretException, InvalidSessionIdException,\
     SessionNotValidatedException
 
@@ -27,20 +27,13 @@ class ThreePidBindServlet(Resource):
     @jsonwrap
     def render_POST(self, request):
         send_cors(request)
-        #err = require_args(request, ('sid', 'client_secret', 'mxid'))
-        err = require_args(request, ('sid', 'mxid'))
+        err, args = get_args(request, ('sid', 'client_secret', 'mxid'))
         if err:
             return err
 
-        sid = request.args['sid'][0]
-        mxid = request.args['mxid'][0]
-        if 'client_secret' in request.args:
-            clientSecret = request.args['client_secret'][0]
-        elif 'clientSecret' in request.args:
-            clientSecret = request.args['clientSecret'][0]
-        else:
-            request.setResponseCode(400)
-            return {'errcode': 'M_MISSING_PARAM', 'error':'No client_secret'}
+        sid = args['sid']
+        mxid = args['mxid']
+        clientSecret = args['client_secret']
 
         # Return the same error for not found / bad client secret otherwise people can get information about
         # sessions without knowing the secret


### PR DESCRIPTION
In addition to x-form-www-urlencoded, based on what content type
the client sends. This will allow us to migrate to JSON to be
consistent with the client/server API.

Also remove support for camelcase parameters like sendAttempt and
clientSecret as all clients moved over to using the underscored
versions long ago so there should be no clients sending camelcase
in the wild by now.