### PR TITLE
Move the bulk lookup API to /bulk_lookup

### DIFF
--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -44,6 +44,7 @@ class ClientApiHttpServer:
         getValidated3pid = self.sydent.servlets.getValidated3pid
 
         lookup = self.sydent.servlets.lookup
+        bulk_lookup = self.sydent.servlets.bulk_lookup
 
         threepid = Resource()
         bind = self.sydent.servlets.threepidBind
@@ -63,6 +64,7 @@ class ClientApiHttpServer:
         validate.putChild('msisdn', msisdn)
 
         v1.putChild('lookup', lookup)
+        v1.putChild('bulk_lookup', bulk_lookup)
 
         v1.putChild('pubkey', pubkey)
         pubkey.putChild('isvalid', self.sydent.servlets.pubkeyIsValid)

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -39,6 +39,7 @@ class BulkLookupServlet(Resource):
         Params: 'threepids': list of threepids, each of which is a list of medium, address
         Returns: Object with key 'threepids', which is a list of results where each result
                  is a 3 item list of medium, address, mxid
+                 Note that results are not streamed to the client.
         Threepids for which no mapping is found are omitted.
         """
         send_cors(request)

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 OpenMarket Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from twisted.web.resource import Resource
+from sydent.db.threepid_associations import GlobalAssociationStore
+
+import logging
+import json
+import signedjson.sign
+
+from sydent.http.servlets import get_args, jsonwrap, send_cors
+
+
+logger = logging.getLogger(__name__)
+
+
+class BulkLookupServlet(Resource):
+    isLeaf = True
+
+    def __init__(self, syd):
+        self.sydent = syd
+
+    def render_POST(self, request):
+        """
+        Bulk-lookup for threepids.
+        Params: 'threepids': list of threepids, each of which is a list of medium, address
+        Returns: Object with key 'threepids', which is a list of results where each result
+                 is a 3 item list of medium, address, mxid
+        Threepids for which no mapping is found are omitted.
+        """
+        send_cors(request)
+        err, args = get_args(request, ('threepids',))
+        if err:
+            return err
+
+        threepids = args['threepids']
+        if not isinstance(threepids, list):
+            request.setResponseCode(400)
+            return {'errcode': 'M_INVALID_PARAM', 'error': 'threepids must be a list'}, None
+
+        logger.info("Bulk lookup of %d threepids: %r", len(threepids), threepids)
+
+        globalAssocStore = GlobalAssociationStore(self.sydent)
+        results = globalAssocStore.getMxids(threepids)
+
+        return json.dumps({ 'threepids': results })
+
+
+    @jsonwrap
+    def render_OPTIONS(self, request):
+        send_cors(request)
+        request.setResponseCode(200)
+        return {}

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014 OpenMarket Ltd
+# Copyright 2017 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -84,6 +84,8 @@ class LookupServlet(Resource):
     def render_POST(self, request):
         """
         Bulk-lookup for threepids.
+        ** DEPRECATED **
+        Use /bulk_lookup which returns the result encapsulated in a dict
         Params: 'threepids': list of threepids, each of which is a list of medium, address
         Returns: List of results where each result is a 3 item list of medium, address, mxid
         Threepids for which no mapping is found are omitted.

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2017 OpenMarket Ltd
+# Copyright 2014,2017 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -36,6 +36,7 @@ from sign.ed25519 import SydentEd25519
 from http.servlets.emailservlet import EmailRequestCodeServlet, EmailValidateCodeServlet
 from http.servlets.msisdnservlet import MsisdnRequestCodeServlet, MsisdnValidateCodeServlet
 from http.servlets.lookupservlet import LookupServlet
+from http.servlets.bulklookupservlet import BulkLookupServlet
 from http.servlets.pubkeyservlets import Ed25519Servlet
 from http.servlets.threepidbindservlet import ThreePidBindServlet
 from http.servlets.replication import ReplicationPushServlet
@@ -115,6 +116,7 @@ class Sydent:
         self.servlets.msisdnRequestCode = MsisdnRequestCodeServlet(self)
         self.servlets.msisdnValidate = MsisdnValidateCodeServlet(self)
         self.servlets.lookup = LookupServlet(self)
+        self.servlets.bulk_lookup = BulkLookupServlet(self)
         self.servlets.pubkey_ed25519 = Ed25519Servlet(self)
         self.servlets.pubkeyIsValid = PubkeyIsValidServlet(self)
         self.servlets.ephemeralPubkeyIsValid = EphemeralPubkeyIsValidServlet(self)


### PR DESCRIPTION
So we can change it to return an object rather than an array

Leave the old one as-is