### PR TITLE
LDAP support (for enterprise usage)

### DIFF
--- a/LDAP.rst
+++ b/LDAP.rst
@@ -1,0 +1,34 @@
+LDAP configuration
+==================
+
+If you don't need LDAP
+----------------------
+
+If ``uri`` parameter is not specified in the ``[ldap]`` config section, LDAP functional will be skipped.
+
+Purpose
+-------
+LDAP configuration allow perform ldap lookup for matrix id by mail address.
+
+The addresses found in the LDAP address do not need to be assigneed and verified: it is assumed that the LDAP is a trusted store.
+
+Other third party ids (that not found in LDAP) can be assigned and verifed classical way (they will be saved to the database)
+
+Example LDAP config section
+---------------------------
+
+.. code:: 
+
+    [ldap]
+    uri = ldap://example.com:389/
+    startls =  false
+    base = dc=example,dc=com
+    mail_attr = mail
+    id_attr = samaccountname
+    # if hs_name empty we assume that id_attr contain users matrix id
+    # othercase we generate matrix id as @id_attr:hs_name
+    hs_name = example.com
+    bind_dn = cn=namager,cn=users,dc=example,dc=com
+    bind_pw = secret
+    filter = (&(objectClass=user)(objectCategory=person))
+

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,49 @@
+Sydent purpose
+==============
+
+In you there is no need to install this component on your server. As an identity server, it is recommended to use matrix.org
+
+You may need to install the sender, for example, if you deploy an isolated system and users will not be able to access the matrix.org
+
 Installation
+============
+
+1. Сheck that your system has ``sqlite3 >= 3.12`` (Otherwise there will be syntax errors when working with the database)
+
+2. Run ``pip install https://github.com/matrix-org/sydent/tarball/master``
+
+3. Create user ``useradd -r matrix-sydent`` if not exists
+
+4. ``cp sydent.example.conf /etc/matrix-synapse/sydent.conf`` and edit
+
+5. Copy ``res\verify_response_page_template`` to verify_response_template path 
+
+6. Copy ``res\verification_template.eml`` to email.template path
+
+7. Check that pidfile.path writable by created ``matrix-sydent`` user (e.g. it not created with other owner when you test sydent)
+
+8. Check that log.path exists and writable by created ``matrix-sydent`` user
+
+9. Create sqlite database ``cat ./sydent/db/*.sql | sed 's/IF\sNOT\sEXISTS\s//i' | sqlite3 /var/lib/matrix-synapse/sydent.db``
+
+10. Check that db.file writable by created ``matrix-sydent`` user
+
+11. Check ownership ``chown -R matrix-synapse <path to templates>``
+
+12. Check ownership ``chown -R matrix-synapse /etc/matrix-sydent/``
+
+13. Config systemd ``cp /systemd/matrix-sydent.service /lib/systemd/system/`` and edit it: 
+
+- check that WorkingDirectory exists and writable; 
+- check that EnvironmentFile exists; 
+- check that service will be run on behalf of the created user
+
+14. After edit do not foget ``systemctl daemon-reload``
+
+15. Start service with ``systemctl start matrix-sydent``
+
+
+Run for test
 ============
 
 Dependencies can be installed using setup.py in the same way as synapse: see synapse/README.rst.
@@ -8,6 +53,11 @@ Having installed dependencies, you can run sydent using::
     $ python -m sydent.sydent
 
 This will create a configuration file in sydent.conf with some defaults. You'll most likely want to change the server name and specify a mail relay.
+
+LDAP configuration
+==================
+
+See `<LDAP.rst>`_ for details.
 
 Requests
 ========
@@ -37,4 +87,3 @@ curl 'http://localhost:8090/_matrix/identity/api/v1/lookup?medium=email&address=
 # fetch pubkey key for a server
 
 curl http://localhost:8090/_matrix/identity/api/v1/pubkey/ed25519
-

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "pynacl",
         "daemonize",
         "phonenumbers",
+        "ldap3",
     ],
     setup_requires=[
         "setuptools_trial",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
     setup_requires=[
         "setuptools_trial",
         "setuptools>=1.0.0", # Needs setuptools that supports git+ssh. It's not obvious when support for this was introduced.
-        "mock"
+        "mock",
+        "ldap3"
     ],
     include_package_data=True,
     long_description=read("README.rst"),

--- a/sydent.example.conf
+++ b/sydent.example.conf
@@ -1,0 +1,52 @@
+[DEFAULT]
+
+[general]
+server.name = example.com
+log.path = /var/log/matrix-synapse/sydent.log
+pidfile.path = /run/sydent.pid
+
+
+[db]
+db.file = /var/lib/matrix-synapse/sydent.db
+
+[http]
+client_http_base = http://example.com
+clientapi.http.port = 8090
+verify_response_template = /var/lib/matrix-synapse/res/verify_response.template
+replication.https.certfile = /etc/matrix-synapse/sydent.cert
+replication.https.port = 4434
+replication.https.cacert = 
+obey_x_forwarded_for = True
+
+[email]
+email.from = Sydent Validation <sydent@example.com>
+email.smtpport = 25
+email.subject = Your Validation Token
+email.template = /var/lib/matrix-synapse/res/res/email.template
+email.smtphost = mail.example.com
+email.tlsmode = 0
+email.smtppassword = somesecret
+email.hostname = example.com
+email.smtpusername = username
+email.invite.subject = %(sender_display_name)s has invited you to chat
+token.length = 6
+
+
+[crypto]
+ed25519.signingkey =
+
+[sms]
+
+# # Uncoment if you need ldap support
+# [ldap]
+# uri = ldap://example.com:389/
+# startls =  false
+# base = dc=cexample,dc=com
+# mail_attr = mail
+# id_attr = samaccountname
+# # if hs_name empty we assume that id_attr contain users matrix id
+# # othercase we generate matrix id as @id_attr:hs_name
+# hs_name = example.com
+# bind_dn = cn=namager,cn=users,dc=example,dc=com
+# bind_pw = secret
+# filter = (&(objectClass=user)(objectCategory=person))

--- a/sydent/db/ldap.py
+++ b/sydent/db/ldap.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import ldap3
-# import ldap3.core.exceptions
 import logging
 import os
 

--- a/sydent/db/ldap.py
+++ b/sydent/db/ldap.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2014 OpenMarket Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# import ldap3
+# import ldap3.core.exceptions
+import logging
+import os
+
+
+try:
+    import ldap3
+    import ldap3.core.exceptions
+    import ldapurl
+
+    # ldap3 v2 changed ldap3.AUTH_SIMPLE -> ldap3.SIMPLE
+    try:
+        LDAP_AUTH_SIMPLE = ldap3.AUTH_SIMPLE
+    except AttributeError:
+        LDAP_AUTH_SIMPLE = ldap3.SIMPLE
+except ImportError:
+    ldap3 = None
+    pass
+
+# Config example
+# [ldap]
+# uri = ldap://example.com:389/
+# startls =  false
+# base = dc=example,dc=com
+# mail_attr = mail
+# id_attr = samAccountName
+# # if hs_name empty we assume that id_attr contain users matrix id
+# # othercase we generate matrix id as @id_attr:hs_name
+# hs_name = example.com
+# bind_dn = cn=manager,cn=Users,dc=example,dc=com
+# bind_pw = some_secret
+# filter = (&(objectClass=user)(objectCategory=person))
+
+
+logger = logging.getLogger(__name__)
+
+class LDAPDatabase:
+    def __init__(self, syd):
+        if not ldap3:
+            logger.info("Missing ldap3 library. This is required for LDAP integration")
+            return
+
+        self.sydent = syd
+
+        self.ldap_uri = self.sydent.cfg.get("ldap", "uri")
+        self.start_tls = self.sydent.cfg.get("ldap", "startls")
+        self.base = self.sydent.cfg.get("ldap", "base")
+        self.mail_attr = self.sydent.cfg.get("ldap", "mail_attr")
+        self.id_attr = self.sydent.cfg.get("ldap", "id_attr").replace('"','').replace("'","")
+        self.hs_name = self.sydent.cfg.get("ldap", "hs_name").replace('"','').replace("'","")
+        self.bind_dn = self.sydent.cfg.get("ldap", "bind_dn")
+        self.bind_pw = self.sydent.cfg.get("ldap", "bind_pw")
+        self.ldap_filter = self.sydent.cfg.get("ldap", "filter").replace('"','').replace("'","")
+
+    def HasLdapConfiguration(self):
+        if (not self.ldap_uri):
+            # No configuration
+            return False
+        else:
+            logger.info("Exists LDAP configuration.")
+            return True
+
+    def getMxid(self,medium,address):
+        if (not medium == "email"):
+            # Support only Email from LDAP
+            return None
+        try:
+            # URI support
+            ldap_url = ldapurl.LDAPUrl(self.ldap_uri.lower())
+            use_ssl = False
+            if (ldap_url.urlscheme == "ldaps"):
+                use_ssl = True
+            if (":" not in ldap_url.hostport):
+                ldap_host = ldap_url.hostport
+                if use_ssl:
+                    ldap_port = 636
+                else:
+                    ldap_port = 389
+            else:
+                ldap_host = ldap_url.hostport.split(':')[0]
+                ldap_port = ldap_url.hostport.split(':')[1]
+
+            server = ldap3.Server(
+                host = ldap_host,
+                port = ldap_port,
+                use_ssl=use_ssl,
+                get_info=None
+            )
+            logger.debug(
+                "Attempting LDAP connection with %s",
+                self.ldap_uri
+            )
+            conn = ldap3.Connection(server, user=self.bind_dn, password=self.bind_pw, auto_bind='NONE')
+            if (not conn):
+                logger.debug("Can't connect to %s", self.ldap_uri)
+                return None
+            if self.start_tls:
+                conn.open
+                conn.start_tls
+            if (conn.bind()):
+                logger.debug("LDAP bind succefull as %s", self.bind_dn)
+            else:
+                logger.debug("LDAP bind as %s error: %s", self.bind_dn, conn.result['description'])
+            conn.search(search_base=self.base,
+                 search_filter="(&(" + self.mail_attr + "=" + address + ")" + self.ldap_filter + ")",
+                 attributes=[self.mail_attr, self.id_attr]
+            )
+            responses = [
+                response
+                for response
+                in conn.response
+                if response['type'] == 'searchResEntry'
+            ]
+
+            logger.debug("LDAP return %d records for filter: %s", len(responses), "(&(" + self.mail_attr + "=" + address + ")" + self.ldap_filter + ")")
+
+            if len(responses) == 1:
+                logger.debug("LDAP found one record with %s = %s", self.mail_attr, address)
+                # # if hs_name empty we assume that id_attr contain users matrix id
+                # # othercase we generate matrix id as @id_attr:hs_name
+                if (self.hs_name):
+                    mxid = "@" + responses[0]['attributes'][self.id_attr][0] +  ":" + self.hs_name
+                else:
+                    mxid = responses[0]['attributes'][self.id_attr][0]
+                conn.unbind
+                return (medium, address, mxid)
+
+            conn.unbind
+            return None
+
+        except ldap3.core.exceptions.LDAPException as e:
+            logger.error("Error during LDAP operation: %r", e)
+            return None

--- a/sydent/db/ldap.py
+++ b/sydent/db/ldap.py
@@ -21,7 +21,6 @@ import os
 try:
     import ldap3
     import ldap3.core.exceptions
-    import ldapurl
 
     # ldap3 v2 changed ldap3.AUTH_SIMPLE -> ldap3.SIMPLE
     try:
@@ -55,6 +54,8 @@ class LDAPDatabase:
             logger.info("Missing ldap3 library. This is required for LDAP integration")
             return
 
+
+
         self.sydent = syd
 
         self.ldap_uri = self.sydent.cfg.get("ldap", "uri")
@@ -68,37 +69,20 @@ class LDAPDatabase:
         self.ldap_filter = self.sydent.cfg.get("ldap", "filter").replace('"','').replace("'","")
 
     def HasLdapConfiguration(self):
-        if (not self.ldap_uri):
-            # No configuration
-            return False
-        else:
+        if hasattr(self, 'ldap_uri'):
             logger.info("Exists LDAP configuration.")
             return True
+        else:
+            # No configuration
+            return False
 
     def getMxid(self,medium,address):
         if (not medium == "email"):
             # Support only Email from LDAP
             return None
         try:
-            # URI support
-            ldap_url = ldapurl.LDAPUrl(self.ldap_uri.lower())
-            use_ssl = False
-            if (ldap_url.urlscheme == "ldaps"):
-                use_ssl = True
-            if (":" not in ldap_url.hostport):
-                ldap_host = ldap_url.hostport
-                if use_ssl:
-                    ldap_port = 636
-                else:
-                    ldap_port = 389
-            else:
-                ldap_host = ldap_url.hostport.split(':')[0]
-                ldap_port = ldap_url.hostport.split(':')[1]
-
             server = ldap3.Server(
-                host = ldap_host,
-                port = ldap_port,
-                use_ssl=use_ssl,
+                host = self.ldap_uri.lower(),
                 get_info=None
             )
             logger.debug(

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import ConfigParser
+import argparse
 import logging
 import os
 
@@ -85,7 +86,20 @@ class Sydent:
     }
 
     def __init__(self):
-        logger.info("Starting Sydent server")
+        parser = argparse.ArgumentParser()
+
+        parser.add_argument(
+            "configfile",
+            nargs='?',
+            default="sydent.conf",
+            help="the sydent config file, defaults to sydent.conf",
+        )
+
+        options = parser.parse_args()
+
+        self.configfile = options.configfile
+
+        logger.info("Starting Sydent server with config %s", self.configfile)
         self.parse_config()
 
         logPath = self.cfg.get('general', "log.path")
@@ -153,10 +167,10 @@ class Sydent:
                 self.cfg.add_section(sect)
             except ConfigParser.DuplicateSectionError:
                 pass
-        self.cfg.read("sydent.conf")
+        self.cfg.read(self.configfile)
 
     def save_config(self):
-        fp = open("sydent.conf", 'w')
+        fp = open(self.configfile, 'w')
         self.cfg.write(fp)
         fp.close()
 

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -22,6 +22,7 @@ import twisted.internet.reactor
 from twisted.python import log
 
 from db.sqlitedb import SqliteDatabase
+from db.ldap import LDAPDatabase
 
 from http.httpcommon import SslComponents
 from http.httpserver import ClientApiHttpServer, ReplicationHttpsServer
@@ -51,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 
 class Sydent:
-    CONFIG_SECTIONS = ['general', 'db', 'http', 'email', 'crypto', 'sms']
+    CONFIG_SECTIONS = ['general', 'db', 'http', 'email', 'crypto', 'sms', 'ldap']
     CONFIG_DEFAULTS = {
         # general
         'server.name': '',
@@ -99,6 +100,8 @@ class Sydent:
         observer.start()
 
         self.db = SqliteDatabase(self).db
+
+        self.ldap = LDAPDatabase(self)
 
         self.server_name = self.cfg.get('general', 'server.name')
         if self.server_name == '':

--- a/systemd/matrix-sydent.service
+++ b/systemd/matrix-sydent.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Sydent Matrix Identity Server
+
+[Service]
+Type=simple
+User=matrix-sydent
+WorkingDirectory=/var/lib/matrix-sydent
+EnvironmentFile=/etc/default/matrix-sydent
+ExecStart=/usr/bin/python -m sydent.sydent /etc/matrix-synapse/sydent.conf
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/matrix-sydent.service
+++ b/systemd/matrix-sydent.service
@@ -6,7 +6,7 @@ Type=simple
 User=matrix-sydent
 WorkingDirectory=/var/lib/matrix-sydent
 EnvironmentFile=/etc/default/matrix-sydent
-ExecStart=/usr/bin/python -m sydent.sydent /etc/matrix-synapse/sydent.conf
+ExecStart=/usr/bin/python -m sydent.sydent /etc/matrix-sydent/sydent.conf
 Restart=always
 RestartSec=3
 


### PR DESCRIPTION
I added initial LDAP support.
Works only if the corresponding section is present in the configuration.
The LDAP search is performed only by e-mail (it may be modified to support any other 3pid)
Mxid can be read from configured user attribute (if `hs_name` in config ommited), or generated (id attribut + homeserver name from configuration)
3pids not found in LDAP are searched in the database.
E-mail from LDAP is always validated.

These improvements, in combination with [matrix-synapse-ldap3](https://github.com/matrix-org/matrix-synapse-ldap3/pull/26), allow the use of a synapse + sident for mesenging in the enterprise network.
