### PR TITLE
Add support for rejecting sms reqs to countries

### DIFF
--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -19,7 +19,9 @@ import logging
 from twisted.web.resource import Resource
 import phonenumbers
 
-from sydent.validators import IncorrectClientSecretException, SessionExpiredException
+from sydent.validators import (
+    IncorrectClientSecretException, SessionExpiredException, DestinationRejectedException
+)
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 
@@ -70,6 +72,10 @@ class MsisdnRequestCodeServlet(Resource):
             sid = self.sydent.validators.msisdn.requestToken(
                 phone_number_object, clientSecret, sendAttempt, None
             )
+        except DestinationRejectedException:
+            logger.error("Destination rejected for number: %s", msisdn);
+            request.setResponseCode(400)
+            resp = {'errcode': 'M_DESTINATION_REJECTED', 'error': 'Phone numbers in this country are not currently supported'}
         except Exception as e:
             logger.error("Exception sending SMS: %r", e);
             request.setResponseCode(500)

--- a/sydent/validators/__init__.py
+++ b/sydent/validators/__init__.py
@@ -45,3 +45,7 @@ class InvalidSessionIdException(Exception):
 
 class SessionNotValidatedException(Exception):
     pass
+
+
+class DestinationRejectedException(Exception):
+    pass

--- a/sydent/validators/msisdnvalidator.py
+++ b/sydent/validators/msisdnvalidator.py
@@ -60,7 +60,7 @@ class MsisdnValidator:
                 action = self.sydent.cfg.get('sms', opt)
 
                 if action not in ['allow', 'reject']:
-                    raise Exception("Invalid SMS rule action: %s, expecting 'allow' or 'deny'" % action)
+                    raise Exception("Invalid SMS rule action: %s, expecting 'allow' or 'reject'" % action)
 
                 self.smsRules[country] = action
 


### PR DESCRIPTION
Reject requests to send SMS to countries based on rules in the
config file

https://github.com/vector-im/riot-web/issues/3542

Requires https://github.com/matrix-org/synapse/pull/2147 (but can be merged without)