### PR TITLE
Perform onBind callbacks whenever you see a new association (local or global)

### DIFF
--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -81,6 +81,11 @@ class ReplicationPushServlet(Resource):
 
                 globalAssocsStore.addAssociation(assocObj, json.dumps(sgAssoc), peer.servername, originId, commit=False)
                 logger.info("Stored association origin ID %s from %s", originId, peer.servername)
+
+                # if this is an association that matches one of our invite_tokens then we should call the onBind callback
+                # at this point, in order to tell the inviting HS that someone out there has just bound the 3PID.
+                sydent.threepidBinder.notifyPendingInvites(assocObj)
+
             except:
                 failedIds.append(originId)
                 logger.warn("Failed to verify signed association from %s with origin ID %s",

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -84,7 +84,7 @@ class ReplicationPushServlet(Resource):
 
                 # if this is an association that matches one of our invite_tokens then we should call the onBind callback
                 # at this point, in order to tell the inviting HS that someone out there has just bound the 3PID.
-                sydent.threepidBinder.notifyPendingInvites(assocObj)
+                self.sydent.threepidBinder.notifyPendingInvites(assocObj)
 
             except:
                 failedIds.append(originId)

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -67,6 +67,10 @@ class LocalPeer(Peer):
                 globalAssocStore.addAssociation(assocObj, json.dumps(sgAssocs[localId]),
                                                 self.sydent.server_name, localId)
 
+                # if this is an association that matches one of our invite_tokens then we should call the onBind callback
+                # at this point, in order to tell the inviting HS that someone out there has just bound the 3PID.
+                sydent.threepidBinder.notifyPendingInvites(assocObj)
+
         d = twisted.internet.defer.succeed(True)
         return d
 

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -69,7 +69,7 @@ class LocalPeer(Peer):
 
                 # if this is an association that matches one of our invite_tokens then we should call the onBind callback
                 # at this point, in order to tell the inviting HS that someone out there has just bound the 3PID.
-                sydent.threepidBinder.notifyPendingInvites(assocObj)
+                self.sydent.threepidBinder.notifyPendingInvites(assocObj)
 
         d = twisted.internet.defer.succeed(True)
         return d

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -62,20 +62,24 @@ class ThreepidBinder:
 
         self.sydent.pusher.doLocalPush()
 
+    def notifyPendingInvites(assoc):
+        # this is called back by the replication code once we see new bindings
+        # (including local ones created by addBinding() above)
+
         joinTokenStore = JoinTokenStore(self.sydent)
-        pendingJoinTokens = joinTokenStore.getTokens(s.medium, s.address)
+        pendingJoinTokens = joinTokenStore.getTokens(assoc.medium, assoc.address)
         invites = []
         for token in pendingJoinTokens:
-            token["mxid"] = mxid
+            token["mxid"] = assoc.mxid
             token["signed"] = {
-                "mxid": mxid,
+                "mxid": assoc.mxid,
                 "token": token["token"],
             }
             token["signed"] = signedjson.sign.sign_json(token["signed"], self.sydent.server_name, self.sydent.keyring.ed25519)
             invites.append(token)
         if invites:
             assoc.extra_fields["invites"] = invites
-            joinTokenStore.markTokensAsSent(s.medium, s.address)
+            joinTokenStore.markTokensAsSent(assoc.medium, assoc.address)
 
         assocSigner = AssociationSigner(self.sydent)
         sgassoc = assocSigner.signedThreePidAssociation(assoc)

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -62,7 +62,7 @@ class ThreepidBinder:
 
         self.sydent.pusher.doLocalPush()
 
-    def notifyPendingInvites(assoc):
+    def notifyPendingInvites(self, assoc):
         # this is called back by the replication code once we see new bindings
         # (including local ones created by addBinding() above)
 


### PR DESCRIPTION
We seem to always have had a bug where:
 * User on HS1+IS1 issues a 3PID invite, and IS1 stores a invite_tokens to track it.
 * User on HS2+IS2 registers an account with that 3PID
 * HS2 adds the 3PID binding to IS2, and IS2 call onBind on HS2.
 * However, IS2 has no way of telling about the pending invite and invite_token in IS1, so in the onBind it doesn't tell HS2 that there are any 3PID invites and so HS2 never calls HS1's exchange_third_party_invite to tell it to fulfil the 3PID invite (turning it into a real invite).

This PR attempts to address this (in a bit of a rush) by having all ISes attempt to callback onBinds whenever they see a new association (local or remote).  Thus IS2 will replicate the new association to IS1, which will then call onBind on HS1, which will then call back itself to fulfil the 3PID invite (turning it into a real invite).

Concerns here are:
 * I'm not sure why exchange_third_party_invite exists.  Why doesn't the IS2 always just call HS1's onBind, rather than going IS2->HS2->HS1?  Is it a trust thing?  If so, does this PR break the trust model?

If IS2 could just call HS1's onBind, then we wouldn't need to go IS2->IS1->HS1->HS1 (which is what this PR does).

@illicitonion I appreciate this is truly oldnews at this point, but if you have any idea how/if this was ever meant to work, thoughts appreciated O:-)