### PR TITLE
User search: signature verification

### DIFF
--- a/sydent/db/profiles.py
+++ b/sydent/db/profiles.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class ProfileStore:
+    def __init__(self, sydent):
+        self.sydent = sydent
+
+    def getLastBatchForOriginServer(self, host):
+        cur = self.sydent.db.cursor()
+        res = cur.execute(
+            "SELECT MAX(batch) FROM profiles WHERE origin_server = ?", (host,)
+        )
+        return res.fetchone()[0]
+
+    def addBatch(self, host, batchnum, batch):
+        cur = self.sydent.db.cursor()
+
+        vals = [(k, v['display_name'], v['avatar_url'], host, batchnum) for k, v in batch.items()]
+
+        cur.executemany(
+            "INSERT OR REPLACE INTO profiles "
+            "('user_id', 'display_name', 'avatar_url', 'origin_server', 'batch')"
+            " values (?, ?, ?, ?, ?)",
+            vals,
+        )
+        self.sydent.db.commit()

--- a/sydent/db/profiles.py
+++ b/sydent/db/profiles.py
@@ -38,3 +38,22 @@ class ProfileStore:
             vals,
         )
         self.sydent.db.commit()
+
+    def getProfilesMatchingSearchTerm(self, search_term, limit):
+        cur = self.sydent.db.cursor()
+
+        sql = (
+            "SELECT user_id, display_name, avatar_url FROM profiles WHERE "
+            "user_id LIKE LOWER(?) OR "
+            "LOWER(display_name) LIKE LOWER(?) "
+            "LIMIT ?"
+        )
+
+        like_pat = '%' + search_term.replace('%', '%%') + '%'
+
+        res = cur.execute(sql, (like_pat, like_pat, limit))
+        return [{
+            'user_id': r[0],
+            'display_name': r[1],
+            'avatar_url': r[2],
+        } for r in res.fetchall()]

--- a/sydent/db/profiles.sql
+++ b/sydent/db/profiles.sql
@@ -16,6 +16,6 @@ limitations under the License.
 
 CREATE TABLE IF NOT EXISTS profiles (user_id TEXT primary key, display_name TEXT DEFAULT NULL, avatar_url TEXT DEFAULT NULL, origin_server TEXT NOT NULL, batch BIGINT NOT NULL);
 
-CREATE INDEX IF NOT EXISTS profiles_displayname on profiles(display_name);
+CREATE INDEX IF NOT EXISTS profiles_lower_displayname on profiles(LOWER(display_name));
 CREATE INDEX IF NOT EXISTS profiles_origin_server_batch on profiles(origin_server, batch);
 

--- a/sydent/db/profiles.sql
+++ b/sydent/db/profiles.sql
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+CREATE TABLE IF NOT EXISTS profiles (user_id TEXT primary key, display_name TEXT DEFAULT NULL, avatar_url TEXT DEFAULT NULL, origin_server TEXT NOT NULL, batch BIGINT NOT NULL);
+
+CREATE INDEX IF NOT EXISTS profiles_displayname on profiles(display_name);
+CREATE INDEX IF NOT EXISTS profiles_origin_server_batch on profiles(origin_server, batch);
+

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -39,6 +39,8 @@ verifying that the signature on the json blob matches.
 class Verifier(object):
     def __init__(self, sydent):
         self.sydent = sydent
+        # Cache of server keys. These are cached until the 'valid_until_ts' time
+        # in the result.
         self.cache = {
             # server_name: <result from keys query>,
         }

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from twisted.internet import defer
+from twisted.names.error import DNSNameError
+import twisted.names.client
+from unpaddedbase64 import decode_base64
+import signedjson.sign
+import signedjson.key
+from signedjson.sign import SignatureVerifyException
+
+from sydent.http.httpclient import FederationHttpClient
+
+
+logger = logging.getLogger(__name__)
+
+"""
+Verifies signed json blobs from Matrix Homeservers by finding the
+Homeserver's address, contacting it, requesting its keys and
+verifying that the signature on the json blob matches.
+"""
+class Verifier(object):
+    def __init__(self, sydent):
+        self.sydent = sydent
+
+    @defer.inlineCallbacks
+    def _getEndpointForServer(self, server_name):
+        if ':' in server_name:
+            defer.returnValue(tuple(server_name.rsplit(':', 1)))
+
+        service_name = "_%s._%s.%s" % ('_matrix', '_tcp', server_name)
+
+        default = server_name, 8448
+
+        try:
+            answers, _, _ = yield twisted.names.client.lookupService(service_name)
+        except DNSNameError:
+            defer.returnValue(default)
+
+        for answer in answers:
+            if answer.type != dns.SRV or not answer.payload:
+                continue
+
+            # XXX we just use the first
+            defer.returnValue(str(answer.payload.target), answer.payload.port)
+
+        defer.returnValue(default)
+
+    @defer.inlineCallbacks
+    def _getKeysForServer(self, server_name):
+        """Get the signing key data from a home server.
+        """
+        host_port = yield self._getEndpointForServer(server_name)
+        logger.info("Got host/port %s/%s for %s", host_port[0], host_port[1], server_name)
+        client = FederationHttpClient(self.sydent)
+        result = yield client.get_json("https://%s:%s/_matrix/key/v2/server/" % host_port)
+        if 'verify_keys' not in result:
+            raise Exception("No key found in response")
+        defer.returnValue(result['verify_keys'])
+
+    @defer.inlineCallbacks
+    def verifyServerSignedJson(self, signed_json, acceptable_server_names=None):
+        """Given a signed json object, try to verify any one
+        of the signatures on it
+        XXX: This contains a very noddy version of the home server
+        SRV lookup and signature verification. It forms HTTPS URLs
+        from the result of the SRV lookup which will mean the Host:
+        parameter in the request will be wrong. It only looks at
+        the first SRV result. It does no caching (just fetches the
+        signature each time and does not contact any other servers
+        to do perspectives checks.
+
+        :param acceptable_server_names If provided and not None,
+        only signatures from servers in this list will be accepted.
+
+        :return a tuple of the server name and key name that was
+        successfully verified. If the json cannot be verified,
+        raises SignatureVerifyException.
+        """
+        if 'signatures' not in signed_json:
+            raise SignatureVerifyException()
+        for server_name, sigs in signed_json['signatures'].items():
+            if acceptable_server_names is not None:
+                if server_name not in acceptable_server_names:
+                    continue
+
+            server_keys = yield self._getKeysForServer(server_name)
+            for key_name, sig in sigs.items():
+                if key_name in server_keys:
+                    if 'key' not in server_keys[key_name]:
+                        logger.warn("Ignoring key %s with no 'key'")
+                        continue
+                    key_bytes = decode_base64(server_keys[key_name]['key'])
+                    verify_key = signedjson.key.decode_verify_key_bytes(key_name, key_bytes)
+                    signedjson.sign.verify_signed_json(signed_json, server_name, verify_key)
+                    logger.info("Verified signature with key %s from %s", key_name, server_name)
+                    defer.returnValue((server_name, key_name))
+        logger.warn("No matching key found for signature block %r", signed_json['signatures'])
+        raise SignatureVerifyException()

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -18,26 +18,49 @@ import json
 import logging
 
 from StringIO import StringIO
-from twisted.internet import defer, reactor
-from twisted.web.client import FileBodyProducer, Agent
+from twisted.internet import defer, reactor, ssl
+from twisted.internet._sslverify import _OpenSSLECCurve, _defaultCurveName, ClientTLSOptions
+from twisted.web.client import FileBodyProducer, Agent, readBody
 from twisted.web.http_headers import Headers
+from twisted.web.iweb import IPolicyForHTTPS
+from zope.interface import implementer
+from OpenSSL import SSL
 
 logger = logging.getLogger(__name__)
+
 
 class SimpleHttpClient(object):
     """
     A simple, no-frills HTTP client based on the class of the same name
     from synapse
     """
-    def __init__(self, sydent):
+    def __init__(self, sydent, context_factory=None):
         self.sydent = sydent
-        # The default context factory in Twisted 14.0.0 (which we require) is
-        # BrowserLikePolicyForHTTPS which will do regular cert validation
-        # 'like a browser'
-        self.agent = Agent(
-            reactor,
-            connectTimeout=15,
+        if context_factory is None:
+            # The default context factory in Twisted 14.0.0 (which we require) is
+            # BrowserLikePolicyForHTTPS which will do regular cert validation
+            # 'like a browser'
+            self.agent = Agent(
+                reactor,
+                connectTimeout=15,
+            )
+        else:
+            self.agent = Agent(
+                reactor,
+                connectTimeout=15,
+                contextFactory=context_factory
+            )
+
+    @defer.inlineCallbacks
+    def get_json(self, uri):
+        logger.debug("HTTP GET %s", uri)
+
+        response = yield self.agent.request(
+            "GET",
+            uri.encode("ascii"),
         )
+        body = yield readBody(response)
+        defer.returnValue(json.loads(body))
 
     @defer.inlineCallbacks
     def post_json_get_nothing(self, uri, post_json, opts):
@@ -56,4 +79,24 @@ class SimpleHttpClient(object):
             bodyProducer=FileBodyProducer(StringIO(json_str))
         )
         defer.returnValue(response)
+
+
+@implementer(IPolicyForHTTPS)
+class FederationPolicyForHTTPS(object):
+    def creatorForNetloc(self, hostname, port):
+        context = SSL.Context(SSL.SSLv23_METHOD)
+        try:
+            _ecCurve = _OpenSSLECCurve(_defaultCurveName)
+            _ecCurve.addECKeyToContext(context)
+        except Exception:
+            logger.exception("Failed to enable elliptic curve for TLS")
+        context.set_options(SSL.OP_NO_SSLv2 | SSL.OP_NO_SSLv3)
+
+        context.set_cipher_list("!ADH:HIGH+kEDH:!AECDH:HIGH+kEECDH")
+        return ClientTLSOptions(hostname, context)
+
+
+class FederationHttpClient(SimpleHttpClient):
+    def __init__(self, sydent):
+        super(FederationHttpClient, self).__init__(sydent, FederationPolicyForHTTPS())
 

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -91,6 +91,14 @@ class ClientApiHttpServer:
 
         v1.putChild('sign-ed25519', self.sydent.servlets.blindlySignStuffServlet)
 
+        federation = Resource()
+        matrix.putChild('federation', federation)
+
+        federation_v1 = Resource()
+        federation.putChild('v1', federation_v1)
+
+        federation_v1.putChild('replicate_profiles', self.sydent.servlets.profileReplicationServlet)
+
         self.factory = Site(root)
 
     def setup(self):

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -55,6 +55,8 @@ class ClientApiHttpServer:
         pubkey = Resource()
         ephemeralPubkey = Resource()
 
+        userDirectory = Resource()
+
         pk_ed25519 = self.sydent.servlets.pubkey_ed25519
 
         root.putChild('_matrix', matrix)
@@ -90,6 +92,10 @@ class ClientApiHttpServer:
         v1.putChild('store-invite', self.sydent.servlets.storeInviteServlet)
 
         v1.putChild('sign-ed25519', self.sydent.servlets.blindlySignStuffServlet)
+
+        v1.putChild('user_directory', userDirectory)
+
+        userDirectory.putChild('search', self.sydent.servlets.userDirectorySearchServlet)
 
         federation = Resource()
         matrix.putChild('federation', federation)

--- a/sydent/http/servlets/profilereplicationservlet.py
+++ b/sydent/http/servlets/profilereplicationservlet.py
@@ -16,11 +16,20 @@
 from twisted.web.resource import Resource
 from twisted.internet import defer
 from twisted.web import server
+from twisted.web.client import readBody
+import twisted.names.client
+from twisted.names import dns
+from twisted.names.error import DNSNameError
 
+import signedjson.sign
+import signedjson.key
+from signedjson.sign import SignatureVerifyException
+from unpaddedbase64 import decode_base64
 import json
 import logging
 from sydent.http.servlets import get_args, jsonwrap
 from sydent.db.profiles  import ProfileStore
+from sydent.http.httpclient import FederationHttpClient
 
 
 logger = logging.getLogger(__name__)
@@ -45,6 +54,70 @@ class ProfileReplicationServlet(Resource):
         return server.NOT_DONE_YET
 
     @defer.inlineCallbacks
+    def getEndpointForServer(self, server_name):
+        if ':' in server_name:
+            defer.returnValue(tuple(server_name.rsplit(':', 1)))
+
+        service_name = "_%s._%s.%s" % ('_matrix', '_tcp', server_name)
+
+        default = server_name, 8448
+
+        try:
+            answers, _, _ = yield twisted.names.client.lookupService(service_name)
+        except DNSNameError:
+            defer.returnValue(default)
+
+        for answer in answers:
+            if answer.type != dns.SRV or not answer.payload:
+                continue
+
+            # XXX we just use the first
+            defer.returnValue(str(answer.payload.target), answer.payload.port)
+
+        defer.returnValue(default)
+
+    @defer.inlineCallbacks
+    def getKeysForServer(self, server_name):
+        """Get the signing key data from a home server.
+        """
+        host_port = yield self.getEndpointForServer(server_name)
+        logger.info("Got host/port %s/%s for %s", host_port[0], host_port[1], server_name)
+        client = FederationHttpClient(self.sydent)
+        result = yield client.get_json("https://%s:%s/_matrix/key/v2/server/" % host_port)
+        if 'verify_keys' not in result:
+            raise Exception("No key found in response")
+        defer.returnValue(result['verify_keys'])
+
+    @defer.inlineCallbacks
+    def verifyServerSignedJson(self, signed_json):
+        """Given a signed json object, try to verify any one
+        of the signatures on it
+        XXX: This contains a very noddy version of the home server
+        SRV lookup and signature verification. It forms HTTPS URLs
+        from the result of the SRV lookup which will mean the Host:
+        parameter in the request will be wrong. It only looks at
+        the first SRV result. It does no caching (just fetches the
+        signature each time and does not contact any other servers
+        to do perspectives checks.
+        """
+        if 'signatures' not in signed_json:
+            raise SignatureVerifyException()
+        for server_name, sigs in signed_json['signatures'].items():
+            server_keys = yield self.getKeysForServer(server_name)
+            for key_name, sig in sigs.items():
+                if key_name in server_keys:
+                    if 'key' not in server_keys[key_name]:
+                        logger.warn("Ignoring key %s with no 'key'")
+                        continue
+                    key_bytes = decode_base64(server_keys[key_name]['key'])
+                    verify_key = signedjson.key.decode_verify_key_bytes(key_name, key_bytes)
+                    signedjson.sign.verify_signed_json(signed_json, server_name, verify_key)
+                    logger.info("Verified signature with key %s from %s", key_name, server_name)
+                    defer.returnValue(None)
+        logger.warn("No matching key found for signature block %r", signed_json['signatures'])
+        raise SignatureVerifyException()
+
+    @defer.inlineCallbacks
     def _async_render_POST(self, request):
         yield
         try:
@@ -63,7 +136,13 @@ class ProfileReplicationServlet(Resource):
             request.finish()
             defer.returnValue(None)
 
-        # XXX: verify the sig to auth the source HS
+        try:
+            yield self.verifyServerSignedJson(body)
+        except SignatureVerifyException:
+            request.setResponseCode(403)
+            request.write(json.dumps({'errcode': 'M_FORBIDDEN', 'error': 'Signature verification failed'}))
+            request.finish()
+            defer.returnValue(None)
 
         batchnum = body["batchnum"]
         batch = body["batch"]

--- a/sydent/http/servlets/profilereplicationservlet.py
+++ b/sydent/http/servlets/profilereplicationservlet.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from twisted.web.resource import Resource
+
+import json
+import logging
+from sydent.http.servlets import get_args, jsonwrap
+from sydent.db.profiles  import ProfileStore
+
+
+logger = logging.getLogger(__name__)
+
+MAX_BATCH_SIZE = 200
+
+
+class ProfileReplicationServlet(Resource):
+    isLeaf = True
+
+    def __init__(self, syd):
+        self.sydent = syd
+
+    def _getAllowedHomeservers(self):
+        rawstr = self.sydent.cfg.get('userdir', 'userdir.allowed_homeservers', '')
+        if rawstr == '':
+            return []
+        return [x.strip() for x in rawstr.split(',')]
+
+    @jsonwrap
+    def render_POST(self, request):
+        try:
+            body = json.load(request.content)
+        except ValueError:
+            request.setResponseCode(400)
+            return {'errcode': 'M_BAD_JSON', 'error': 'Malformed JSON'}
+
+        missing = [k for k in ("batchnum", "batch", "origin_server") if k not in body]
+        if len(missing) > 0:
+            request.setResponseCode(400)
+            msg = "Missing parameters: "+(",".join(missing))
+            return {'errcode': 'M_MISSING_PARAMS', 'error': msg}
+
+        # XXX: verify the sig to auth the source HS
+
+        batchnum = body["batchnum"]
+        batch = body["batch"]
+        origin_server = body["origin_server"]
+
+        allowed_hses = self._getAllowedHomeservers()
+        if not origin_server in allowed_hses:
+            request.setResponseCode(403)
+            return {'errcode': 'M_FORBIDDEN', 'error': 'origin server not whitelisted'}
+
+        profile_store = ProfileStore(self.sydent)
+
+        latest_batch_on_host = profile_store.getLastBatchForOriginServer(origin_server)
+        if latest_batch_on_host is None:
+            latest_batch_on_host = -1
+        if batchnum <= latest_batch_on_host:
+            logger.info("Ignoring batch %d from %s: we already have %d", batchnum, origin_server, latest_batch_on_host)
+            # we already have this batch, thanks
+            return {}
+        elif batchnum == latest_batch_on_host + 1:
+            # good, this is the next batch
+            if len(batch) > MAX_BATCH_SIZE:
+                logger.warn("Host %s sent batch of %s which exceeds max of %d", origin_server, len(batch), MAX_BATCH_SIZE)
+                request.setResponseCode(400)
+                return {'errcode': 'M_UNKNOWN', 'error': 'batch size exceeds max of %d' % (MAX_BATCH_SIZE,)}
+                
+            bad_uids = []
+            for uid, info in batch.items():
+                if 'display_name' not in info or 'avatar_url' not in info:
+                    bad_uids.append(uid)
+            if len(bad_uids) > 0:
+                logger.warn("Host %s sent batch with missing fields", origin_server)
+                request.setResponseCode(400)
+                msg = "Missing data for user IDs: %s (required: display_name, avatar_url" % (','.join(bad_uids,))
+                return {'errcode': 'M_UNKNOWN', 'error': msg}
+
+            logger.info("Storing %d profiles in batch %d from %s", len(batch), batchnum, origin_server)
+            profile_store.addBatch(origin_server, batchnum, batch)
+            return {}
+        else:
+            # we've missing a batch, so don't accept this one: they need to be in order
+            logger.warn("Rejecting batch %d from %s as we only have %d", batchnum, origin_server, latest_batch_on_host)
+            request.setResponseCode(400)
+            msg = "Expecting batch %d but got %d" % (latest_batch_on_host + 1, batchnum)
+            return {'errcode': 'M_UNKNOWN', 'error': msg}

--- a/sydent/http/servlets/userdirectorysearchservlet.py
+++ b/sydent/http/servlets/userdirectorysearchservlet.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from twisted.web.resource import Resource
+
+import logging
+import json
+
+from sydent.http.servlets import jsonwrap, send_cors
+from sydent.db.profiles import ProfileStore
+
+
+logger = logging.getLogger(__name__)
+
+MAX_SEARCH_LIMIT = 100
+
+
+class UserDirectorySearchServlet(Resource):
+    isLeaf = True
+
+    def __init__(self, syd):
+        self.sydent = syd
+
+    @jsonwrap
+    def render_POST(self, request):
+        send_cors(request)
+        try:
+            body = json.load(request.content)
+        except ValueError:
+            request.setResponseCode(400)
+            return {'errcode': 'M_BAD_JSON', 'error': 'Malformed JSON'}
+
+        if 'search_term' not in body:
+            request.setResponseCode(400)
+            return {'errcode': 'M_MISSING_PARAMS', 'error': 'Missing param: search_term'}
+
+        search_term = body['search_term']
+        limit = min(body.get('limit', 10), MAX_SEARCH_LIMIT)
+
+        profileStore = ProfileStore(self.sydent)
+
+        # search for one more result than the limit: if we get limit + 1, we know there
+        # are more results we could have returned
+        results = profileStore.getProfilesMatchingSearchTerm(search_term, limit + 1)
+
+        return {
+            'results': results[0:limit],
+            'limited': len(results) > limit,
+        }
+
+    @jsonwrap
+    def render_OPTIONS(self, request):
+        send_cors(request)
+        request.setResponseCode(200)
+        return {}

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2014 OpenMarket Ltd
+# Copyright 2018 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,6 +46,7 @@ from http.servlets.getvalidated3pidservlet import GetValidated3pidServlet
 from http.servlets.store_invite_servlet import StoreInviteServlet
 from http.servlets.infoservlet import InfoServlet
 from http.servlets.profilereplicationservlet import ProfileReplicationServlet
+from http.servlets.userdirectorysearchservlet import UserDirectorySearchServlet
 
 from threepid.bind import ThreepidBinder
 
@@ -157,6 +159,7 @@ class Sydent:
         self.servlets.blindlySignStuffServlet = BlindlySignStuffServlet(self)
         self.servlets.profileReplicationServlet = ProfileReplicationServlet(self)
         self.servlets.info = InfoServlet(self)
+        self.servlets.userDirectorySearchServlet = UserDirectorySearchServlet(self)
 
         self.threepidBinder = ThreepidBinder(self)
 

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -44,6 +44,7 @@ from http.servlets.replication import ReplicationPushServlet
 from http.servlets.getvalidated3pidservlet import GetValidated3pidServlet
 from http.servlets.store_invite_servlet import StoreInviteServlet
 from http.servlets.infoservlet import InfoServlet
+from http.servlets.profilereplicationservlet import ProfileReplicationServlet
 
 from threepid.bind import ThreepidBinder
 
@@ -53,7 +54,7 @@ logger = logging.getLogger(__name__)
 
 
 class Sydent:
-    CONFIG_SECTIONS = ['general', 'db', 'http', 'email', 'crypto', 'sms']
+    CONFIG_SECTIONS = ['general', 'db', 'http', 'email', 'crypto', 'sms', 'userdir']
     CONFIG_DEFAULTS = {
         # general
         'server.name': '',
@@ -82,6 +83,8 @@ class Sydent:
         'bodyTemplate': 'Your code is {token}',
         # crypto
         'ed25519.signingkey': '',
+        # user directory
+        'userdir.allowed_homeservers': '',
     }
 
     def __init__(self):
@@ -152,6 +155,7 @@ class Sydent:
         self.servlets.getValidated3pid = GetValidated3pidServlet(self)
         self.servlets.storeInviteServlet = StoreInviteServlet(self)
         self.servlets.blindlySignStuffServlet = BlindlySignStuffServlet(self)
+        self.servlets.profileReplicationServlet = ProfileReplicationServlet(self)
         self.servlets.info = InfoServlet(self)
 
         self.threepidBinder = ThreepidBinder(self)


### PR DESCRIPTION
Verify signatures on profile replication pushes. Comes with all the caveats in the comment.

Also now includes requiring signatures on user profiles as I refactored a lot of this stuff to do signature verification in both places.

Based on https://github.com/matrix-org/sydent/pull/57