### PR TITLE
Pin twisted to not upgrade to 18.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         "signedjson==1.0.0",
         "unpaddedbase64==1.1.0",
-        "Twisted>=14.0.0",
+        "Twisted>=14.0.0,<18.0.0",
         "service_identity>=1.0.0",
         "pyasn1",
         "pynacl",


### PR DESCRIPTION
The code in http/httpclient.py, causes this currently:
```
from sydent.http.httpclient import SimpleHttpClient
File "/opt/sydent/sydent/sydent/http/httpclient.py", line 22, in <module>
from twisted.internet._sslverify import _OpenSSLECCurve, _defaultCurveName, ClientTLSOptions
ImportError: cannot import name _OpenSSLECCurve
```

This is the same problem as synapse had in https://github.com/matrix-org/synapse/issues/3135 , but I do not know if the same fix is required.

Pinning Twisted to <18.0 allows installations to continue, but we should address the underlying problem.