### PR TITLE
Keep a year(ish) worth of logs

### DIFF
--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -98,7 +98,7 @@ class Sydent:
         logPath = self.cfg.get('general', "log.path")
         if logPath != '':
             handler = logging.handlers.RotatingFileHandler(
-                logPath, maxBytes=(1000 * 1000 * 100), backupCount=3
+                logPath, maxBytes=(1000 * 1000 * 100), backupCount=365
             )
             handler.setFormatter(formatter)
             def sighup(signum, stack):

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -97,8 +97,8 @@ class Sydent:
 
         logPath = self.cfg.get('general', "log.path")
         if logPath != '':
-            handler = logging.handlers.RotatingFileHandler(
-                logPath, maxBytes=(1000 * 1000 * 100), backupCount=365
+            handler = logging.handlers.TimedRotatingFileHandler(
+                logPath, when='midnight', backupCount=365
             )
             handler.setFormatter(formatter)
             def sighup(signum, stack):


### PR DESCRIPTION
RotatingFileHandler doesn't have a 'keep everything' mode (because
it renames (.1 -> .2, .2 -> .3 etc, so it would be an arbitrarily
large number of reanmes). Onlyt keeping 3 days of logs isn't
sensible though, so keep a year's worth. The sensible thing to do
would be to employ a log archiver to archive the old ones.