### PR TITLE
allow replication of IS bindings to a shadow server

### DIFF
--- a/sydent/db/peers.sql
+++ b/sydent/db/peers.sql
@@ -14,8 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-CREATE TABLE IF NOT EXISTS peers (id integer primary key, name varchar(255) not null, port integer default null, lastSentVersion integer, lastPokeSucceededAt integer, active integer not null default 0);
+CREATE TABLE IF NOT EXISTS peers (
+	id integer primary key,
+	name varchar(255) not null,
+	port integer default null,
+	lastSentVersion integer,
+	lastPokeSucceededAt integer,
+	active integer not null default 0,
+	shadow integer not null default 0
+);
 CREATE UNIQUE INDEX IF NOT EXISTS name on peers(name);
 
-CREATE TABLE IF NOT EXISTS peer_pubkeys (id integer primary key, peername varchar(255) not null, alg varchar(16) not null, key text not null, foreign key (peername) references peers (peername));
+CREATE TABLE IF NOT EXISTS peer_pubkeys (
+	id integer primary key,
+	peername varchar(255) not null,
+	alg varchar(16) not null,
+	key text not null,
+	foreign key (peername) references peers (peername)
+);
 CREATE UNIQUE INDEX IF NOT EXISTS peername_alg on peer_pubkeys(peername, alg);

--- a/sydent/db/profiles.sql
+++ b/sydent/db/profiles.sql
@@ -14,7 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-CREATE TABLE IF NOT EXISTS profiles (user_id TEXT primary key, display_name TEXT DEFAULT NULL, avatar_url TEXT DEFAULT NULL, origin_server TEXT NOT NULL, batch BIGINT NOT NULL);
+CREATE TABLE IF NOT EXISTS profiles (
+	user_id TEXT primary key,
+	display_name TEXT DEFAULT NULL,
+	avatar_url TEXT DEFAULT NULL,
+	origin_server TEXT NOT NULL,
+	batch BIGINT NOT NULL
+);
 
 CREATE INDEX IF NOT EXISTS profiles_lower_displayname on profiles(LOWER(display_name));
 CREATE INDEX IF NOT EXISTS profiles_origin_server_batch on profiles(origin_server, batch);

--- a/sydent/db/threepid_validation.sql
+++ b/sydent/db/threepid_validation.sql
@@ -14,6 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-CREATE TABLE IF NOT EXISTS threepid_validation_sessions (id integer primary key, medium varchar(16) not null, address varchar(256) not null, clientSecret varchar(32) not null, validated int default 0, mtime bigint not null);
-CREATE TABLE IF NOT EXISTS threepid_token_auths (id integer primary key, validationSession integer not null, token varchar(32) not null, sendAttemptNumber integer not null, foreign key (validationSession) references threepid_validations(id));
+CREATE TABLE IF NOT EXISTS threepid_validation_sessions (
+	id integer primary key,
+	medium varchar(16) not null,
+	address varchar(256) not null,
+	clientSecret varchar(32) not null,
+	validated int default 0,
+	mtime bigint not null
+);
 
+CREATE TABLE IF NOT EXISTS threepid_token_auths (
+	id integer primary key,
+	validationSession integer not null,
+	token varchar(32) not null,
+	sendAttemptNumber integer not null,
+	foreign key (validationSession) references threepid_validations(id)
+);

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -50,11 +50,11 @@ class Pusher:
             sgAssoc = assocSigner.signedThreePidAssociation(localAssocs[localId])
             shadowSgAssoc = None
 
-            if self.sydent.shadow_server_name:
+            if self.sydent.shadow_hs_master and self.sydent.shadow_hs_slave:
                 shadowAssoc = copy.deepcopy(localAssocs[localId])
                 shadowAssoc.mxid = shadowAssoc.mxid.replace(
-                    ":" + self.sydent.server_name,
-                    ":" + self.sydent.shadow_server_name
+                    ":" + self.sydent.shadow_hs_master,
+                    ":" + self.sydent.shadow_hs_slave
                 )
                 shadowSgAssoc = assocSigner.signedThreePidAssociation(shadowAssoc)
 

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -48,7 +48,17 @@ class Pusher:
 
         for localId in localAssocs:
             sgAssoc = assocSigner.signedThreePidAssociation(localAssocs[localId])
-            signedAssocs[localId] = sgAssoc
+            shadowSgAssoc = None
+
+            if self.sydent.shadow_server_name:
+                shadowAssoc = copy.deepcopy(localAssocs[localId])
+                shadowAssoc.mxid = shadowAssoc.mxid.replace(
+                    ":" + self.sydent.server_name,
+                    ":" + self.sydent.shadow_server_name
+                )
+                shadowSgAssoc = assocSigner.signedThreePidAssociation(shadowAssoc)
+
+            signedAssocs[localId] = (sgAssoc, shadowSgAssoc)
 
         return (signedAssocs, maxId)
 

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -70,6 +70,8 @@ class Sydent:
         'server.name': '',
         'log.path': '',
         'pidfile.path': 'sydent.pid',
+        'shadow.hs.master': '',
+        'shadow.hs.slave': '',
         # db
         'db.file': 'sydent.db',
         # http
@@ -95,9 +97,6 @@ class Sydent:
         'ed25519.signingkey': '',
         # user directory
         'userdir.allowed_homeservers': '',
-        # shadowing bindings for one HS to another
-        'shadow.hs.master': '',
-        'shadow.hs.slave': '',
     }
 
     def __init__(self):

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -95,6 +95,8 @@ class Sydent:
         'ed25519.signingkey': '',
         # user directory
         'userdir.allowed_homeservers': '',
+        # shadowing to another IS network
+        'shadow.server.name': '',
     }
 
     def __init__(self):
@@ -141,6 +143,8 @@ class Sydent:
                         + "the config file.") % (self.server_name,))
             self.cfg.set('general', 'server.name', self.server_name)
             self.save_config()
+
+        self.shadow_server_name = self.cfg.get('general', 'shadow.server.name')
 
         self.user_dir_allowed_hses = set(list_from_comma_sep_string(
             self.cfg.get('userdir', 'userdir.allowed_homeservers', '')

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -95,8 +95,9 @@ class Sydent:
         'ed25519.signingkey': '',
         # user directory
         'userdir.allowed_homeservers': '',
-        # shadowing to another IS network
-        'shadow.server.name': '',
+        # shadowing bindings for one HS to another
+        'shadow.hs.master': '',
+        'shadow.hs.slave': '',
     }
 
     def __init__(self):
@@ -144,7 +145,8 @@ class Sydent:
             self.cfg.set('general', 'server.name', self.server_name)
             self.save_config()
 
-        self.shadow_server_name = self.cfg.get('general', 'shadow.server.name')
+        self.shadow_hs_master = self.cfg.get('general', 'shadow.hs.master')
+        self.shadow_hs_slave  = self.cfg.get('general', 'shadow.hs.slave')
 
         self.user_dir_allowed_hses = set(list_from_comma_sep_string(
             self.cfg.get('userdir', 'userdir.allowed_homeservers', '')


### PR DESCRIPTION
Add the concept of shadow servers.  Each HS can have a shadow HS, whose accounts have the same local_part, creds & profile as on the main HS.

This lets us configure an IS to spoof 3PIDs for the main HS on behalf of the shadow IS.  These spoofed bindings are then replicated only to peer ISes which are designated as 'shadow', thus allowing identity mappings in a shadow platform to be puppetted based on the behaviour of the master platform.

To use this:
 * add `shadow.hs.master` to the config to give the name of the IS's designated local master HS (at the moment, we only support one shadow HS setup per IS)
 * add `shadow.hs.slave` to the config to give the name of the IS's designated local shadow HS
 * update sqlite to track shadowness per peer with `alter table peers add column shadow integer not null default 0`
 * add the shadow IS peers, with `shadow` set to 1.