### PR TITLE
support returning shadow HS from /info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "pyyaml",
         "daemonize",
         "phonenumbers",
+        "netaddr",
     ],
     setup_requires=[
         "setuptools_trial",

--- a/sydent/http/servlets/infoservlet.py
+++ b/sydent/http/servlets/infoservlet.py
@@ -43,9 +43,9 @@ class InfoServlet(Resource):
             # medium:
             #   email:
             #     entries:
-            #       matthew@matrix.org: { hs: 'matrix.org' }
+            #       matthew@matrix.org: { hs: 'matrix.org', shadow_hs: 'shadow-matrix.org' }
             #     patterns:
-            #       - .*@matrix.org: { hs: 'matrix.org' }
+            #       - .*@matrix.org: { hs: 'matrix.org', shadow_hs: 'shadow-matrix.org' }
 
         except Exception as e:
             logger.error(e)
@@ -85,6 +85,14 @@ class InfoServlet(Resource):
                     break
 
         result = copy.deepcopy(result)
+
+        if self.sydent.nonshadow_ips:
+            ip = IPAddress(self.sydent.ip_from_request(request))
+            if (ip not in self.sydent.nonshadow_ips):
+                result['hs'] = result['shadow_hs']
+
+        result.pop('shadow_hs', None)
+
         result['invited'] = True if pendingJoinTokens else False
         return json.dumps(result)
 

--- a/sydent/http/servlets/infoservlet.py
+++ b/sydent/http/servlets/infoservlet.py
@@ -90,8 +90,7 @@ class InfoServlet(Resource):
             ip = IPAddress(self.sydent.ip_from_request(request))
             if (ip not in self.sydent.nonshadow_ips):
                 result['hs'] = result['shadow_hs']
-
-        result.pop('shadow_hs', None)
+                result.pop('shadow_hs', None)
 
         result['invited'] = True if pendingJoinTokens else False
         return json.dumps(result)

--- a/sydent/http/servlets/infoservlet.py
+++ b/sydent/http/servlets/infoservlet.py
@@ -91,6 +91,8 @@ class InfoServlet(Resource):
             if (ip not in self.sydent.nonshadow_ips):
                 result['hs'] = result['shadow_hs']
                 result.pop('shadow_hs', None)
+            else:
+                result.setdefault('shadow_hs', '')
 
         result['invited'] = True if pendingJoinTokens else False
         return json.dumps(result)

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -25,6 +25,8 @@ from twisted.python import log
 
 from db.sqlitedb import SqliteDatabase
 
+from netaddr import IPSet, IPNetwork
+
 from http.httpcommon import SslComponents
 from http.httpserver import ClientApiHttpServer, ReplicationHttpsServer
 from http.httpsclient import ReplicationHttpsClient
@@ -70,6 +72,7 @@ class Sydent:
         'server.name': '',
         'log.path': '',
         'pidfile.path': 'sydent.pid',
+        'ips.nonshadow': '',  # \n separated list of CIDR ranges which /info will return non-shadow HS to.
         # db
         'db.file': 'sydent.db',
         # http
@@ -127,6 +130,14 @@ class Sydent:
         logger.info("Starting Sydent server")
 
         self.pidfile = self.cfg.get('general', "pidfile.path");
+
+        self.nonshadow_ips = None
+        ips = self.cfg.get('general', "ips.nonshadow");
+        if ips:
+            self.nonshadow_ips = IPSet()
+            ips = ips.splitlines()
+            for ip in ips:
+                self.nonshadow_ips.add(IPNetwork(ip))
 
         observer = log.PythonLoggingObserver()
         observer.start()


### PR DESCRIPTION
Adds a `ips.nonshadow` config parameter which lists the non-shadow IPs which clients are allowed to connect from which will make /info return the HS rather than shadow-HS URL.  info.yaml is extended to track both HS & shadow_hs URLs.