### PR TITLE
Add a manifest to fix missing files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+graft res
+include scripts/generate-key
+include scripts/sydent-bind
+recursive-include sydent *.sql


### PR DESCRIPTION
Previously, installing via the documented commands would give us a deployment
with no schema files.