### PR TITLE
Put default config in the right sections

### DIFF
--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -54,23 +54,23 @@ from replication.pusher import Pusher
 
 logger = logging.getLogger(__name__)
 
-
-class Sydent:
-    CONFIG_SECTIONS = ['general', 'db', 'http', 'email', 'crypto', 'sms']
-    CONFIG_DEFAULTS = {
-        # general
+CONFIG_DEFAULTS = {
+    'general': {
         'server.name': '',
         'log.path': '',
         'pidfile.path': 'sydent.pid',
-        # db
+    },
+    'db': {
         'db.file': 'sydent.db',
-        # http
+    },
+    'http': {
         'clientapi.http.port': '8090',
         'replication.https.certfile': '',
         'replication.https.cacert': '', # This should only be used for testing
         'replication.https.port': '4434',
-        'obey_x_forwarded_for': False,
-        # email
+        'obey_x_forwarded_for': 'False',
+    },
+    'email': {
         'email.template': 'res/email.template',
         'email.from': 'Sydent Validation <noreply@{hostname}>',
         'email.subject': 'Your Validation Token',
@@ -81,14 +81,20 @@ class Sydent:
         'email.smtppassword': '',
         'email.hostname': '',
         'email.tlsmode': '0',
-        # sms
+    },
+    'sms': {
         'bodyTemplate': 'Your code is {token}',
-        # crypto
+    },
+    'crypto': {
         'ed25519.signingkey': '',
-    }
+    },
+}
 
+
+class Sydent:
     def __init__(self):
-        self.parse_config()
+        self.config_file = os.environ.get('SYDENT_CONF', "sydent.conf")
+        self.cfg = parse_config(self.config_file)
 
         log_format = (
             "%(asctime)s - %(name)s - %(lineno)d - %(levelname)s"
@@ -170,17 +176,8 @@ class Sydent:
 
         self.pusher = Pusher(self)
 
-    def parse_config(self):
-        self.cfg = ConfigParser.SafeConfigParser(Sydent.CONFIG_DEFAULTS)
-        for sect in Sydent.CONFIG_SECTIONS:
-            try:
-                self.cfg.add_section(sect)
-            except ConfigParser.DuplicateSectionError:
-                pass
-        self.cfg.read(os.environ.get('SYDENT_CONF', "sydent.conf"))
-
     def save_config(self):
-        fp = open("sydent.conf", 'w')
+        fp = open(self.config_file, 'w')
         self.cfg.write(fp)
         fp.close()
 
@@ -213,6 +210,36 @@ class Servlets:
 class Keyring:
     pass
 
+
+def parse_config(config_file):
+    """Parse the given config file, populating missing items and sections
+
+    Args:
+        config_file (str): the file to be parsed
+    """
+
+    cfg = ConfigParser.SafeConfigParser()
+
+    # if the config file doesn't exist, prepopulate the config object
+    # with the defaults, in the right section.
+    if not os.path.exists(config_file):
+        for sect, entries in CONFIG_DEFAULTS.items():
+            cfg.add_section(sect)
+            for k, v in entries.items():
+                cfg.set(sect, k, v)
+    else:
+        # otherwise, we have to put the defaults in the DEFAULT section,
+        # to ensure that they don't override anyone's settings which are
+        # in their config file in the default section (which is likely,
+        # because sydent used to be braindead).
+        for sect, entries in CONFIG_DEFAULTS.items():
+            cfg.add_section(sect)
+            for k, v in entries.items():
+                cfg.set(ConfigParser.DEFAULTSECT, k, v)
+
+        cfg.read(config_file)
+
+    return cfg
 
 if __name__ == '__main__':
     syd = Sydent()


### PR DESCRIPTION
When we construct a new config file, try to put the default settings in the
right sections.