### PR TITLE
Add OpenSSL module to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Twisted>=16.0.0",
         "service_identity>=1.0.0",
         "pyasn1",
+        "pyopenssl"
         "pynacl",
         "pyyaml",
         "daemonize",


### PR DESCRIPTION
`pyopenssl` is a required dependency as evidenced by me trying to set up Sydent and failing on not being able to import `OpenSSL`.