### PR TITLE
Stop debug logging from breaking on peer replication

### DIFF
--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -76,7 +76,10 @@ class Pusher:
             peers = self.peerStore.getAllPeers()
 
             for p in peers:
-                logger.debug("Looking for update after %d to push to %s", p.lastSentVersion, p.servername)
+                if p.lastSentVersion:
+                    logger.debug("Looking for update after %d to push to %s", p.lastSentVersion, p.servername)
+                else:
+                    logger.debug("Looking for update to push to %s", p.servername)
                 (signedAssocTuples, maxId) = self.getSignedAssociationsAfterId(p.lastSentVersion, 100)
                 logger.debug("%d updates to push to %s", len(signedAssocTuples), p.servername)
                 if len(signedAssocTuples) > 0:


### PR DESCRIPTION
If you haven't made a push to this peer before, then lastSentVersion is `null`, which breaks debug logging.

Include a check for this.