### PR TITLE
Properly verify replicated data

### DIFF
--- a/scripts/generate-key
+++ b/scripts/generate-key
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Run example
+# ./scripts/show-verify-key ed25519 0 xjKlejLcLyTQg7Fxy/XGopUeF3W/l3/cRgpFe+edi0E
+
 # Use this to generate a signing key and verify key for use in sydent
 # configurations.
 

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import twisted.internet.defer
 
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.threepid import threePidAssocFromDict
@@ -24,7 +23,7 @@ import logging
 import json
 
 import twisted.internet.reactor
-import twisted.internet.defer
+from twisted.internet import defer
 from twisted.web.client import readBody
 
 logger = logging.getLogger(__name__)
@@ -83,16 +82,25 @@ class RemotePeer(Peer):
         if not 'signatures' in jsonMessage:
             raise NoSignaturesException()
 
+        alg = 'ed25519'
+
         key_ids = signedjson.sign.signature_ids(jsonMessage, self.servername)
-        if not key_ids or len(key_ids) == 0 or not key_ids[0].startswith("ed25519:"):
+        if not key_ids or len(key_ids) == 0 or not key_ids[0].startswith(alg + ":"):
             e = NoMatchingSignatureException()
             e.foundSigs = jsonMessage['signatures'].keys()
             e.requiredServername = self.servername
             raise e
-        verify_key = yield self.get_server_verify_key(server_name, key_ids)
-        verifyKey = nacl.signing.VerifyKey(self.pubkeys['ed25519'], encoder=nacl.encoding.HexEncoder)
-        verifyKey.alg = 'ed25519'
-        signedjson.sign.verify_signed_json(jsonMessage, self.servername, verifyKey)
+
+        # Get verify key from signing key
+        signing_key = signedjson.key.decode_signing_key_base64(alg, "0", self.pubkeys[alg])
+        verify_key = signing_key.verify_key
+
+        # Attach metadata
+        verify_key.alg = alg
+        verify_key.version = 0
+
+        # Verify the JSON
+        signedjson.sign.verify_signed_json(jsonMessage, self.servername, verify_key)
 
     def pushUpdates(self, sgAssocs):
         body = {'sgAssocs': sgAssocs}

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -23,7 +23,7 @@ from sydent.util import time_msec
 from sydent.replication.peer import LocalPeer
 from sydent.db.threepid_associations import LocalAssociationStore
 from sydent.db.peers import PeerStore
-from sydent.threepid.assocsigner import AssociationSigner
+from sydent.threepid.signer import Signer
 
 logger = logging.getLogger(__name__)
 
@@ -39,15 +39,15 @@ class Pusher:
         cb.start(10.0)
 
     def getSignedAssociationsAfterId(self, afterId, limit):
-        signedAssocs = {}
+        assocs = {}
 
         localAssocStore = LocalAssociationStore(self.sydent)
         (localAssocs, maxId) = localAssocStore.getAssociationsAfterId(afterId, limit)
 
-        assocSigner = AssociationSigner(self.sydent)
+        signer = Signer(self.sydent)
 
         for localId in localAssocs:
-            sgAssoc = assocSigner.signedThreePidAssociation(localAssocs[localId])
+            sgAssoc = signer.signedThreePidAssociation(localAssocs[localId])
             signedAssocs[localId] = sgAssoc
 
         return (signedAssocs, maxId)

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -25,7 +25,7 @@ from sydent.db.invite_tokens import JoinTokenStore
 from sydent.db.threepid_associations import LocalAssociationStore
 
 from sydent.util import time_msec
-from sydent.threepid.assocsigner import AssociationSigner
+from sydent.threepid.signer import Signer
 
 from sydent.threepid import ThreepidAssociation
 
@@ -84,8 +84,8 @@ class ThreepidBinder:
             assoc.extra_fields["invites"] = invites
             joinTokenStore.markTokensAsSent(medium, address)
 
-        assocSigner = AssociationSigner(self.sydent)
-        sgassoc = assocSigner.signedThreePidAssociation(assoc)
+        signer = Signer(self.sydent)
+        sgassoc = signer.signedThreePidAssociation(assoc)
 
         self._notify(sgassoc, 0)
 

--- a/sydent/threepid/signer.py
+++ b/sydent/threepid/signer.py
@@ -16,7 +16,7 @@
 
 import signedjson.sign
 
-class AssociationSigner:
+class Signer:
     def __init__(self, sydent):
         self.sydent = sydent
 


### PR DESCRIPTION
The original implementation used a call to `yield` (to a function that didn't exist) and since the containing function was just called withing a `try: catch:` it would succeed without fail, meaning replication signatures were never actually checked.

The rename of the class is due to the fact that it could be used for more general applications later down the line (and is in subsequent PRs).