### PR TITLE
Fix incorrect list name

### DIFF
--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -48,9 +48,9 @@ class Pusher:
 
         for localId in localAssocs:
             sgAssoc = signer.signedThreePidAssociation(localAssocs[localId])
-            signedAssocs[localId] = sgAssoc
+            assocs[localId] = sgAssoc
 
-        return (signedAssocs, maxId)
+        return (assocs, maxId)
 
     def doLocalPush(self):
         """


### PR DESCRIPTION
After pulling out a commit from #108 that changed a variable name, part of it was changed back but not all instances of it.

This PR fixes that inconsistency.