### PR TITLE
Make it clearer that signedAssocs is separated

### DIFF
--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -61,7 +61,7 @@ class Pusher:
         """
         localPeer = LocalPeer(self.sydent)
 
-        signedAssocs = self.getSignedAssociationsAfterId(localPeer.lastId, None)[0]
+        (signedAssocs, _) = self.getSignedAssociationsAfterId(localPeer.lastId, None)
 
         localPeer.pushUpdates(signedAssocs)
 


### PR DESCRIPTION
Just a small fix, but hopefully one that'll reduce confusion.