### PR TITLE
Fix missing copy import

### DIFF
--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import logging
+import copy
 
 import twisted.internet.reactor
 import twisted.internet.task


### PR DESCRIPTION
Deprecates https://github.com/matrix-org/sydent/pull/99 which included other fixes which have already been merged.