### PR TITLE
Use verification key for peer instead of their signing key for verification

### DIFF
--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -68,7 +68,7 @@ class ReplicationPushServlet(Resource):
 
         for originId,sgAssoc in inJson['sgAssocs'].items():
             try:
-                peer.verifyMessage(sgAssoc)
+                peer.verifySignedAssociation(sgAssoc)
                 logger.debug("Signed association from %s with origin ID %s verified", peer.servername, originId)
 
                 # Don't bother adding if one has already failed: we add all of them or none so we're only going to

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -87,21 +87,26 @@ class RemotePeer(Peer):
         self.verify_key.alg = alg
         self.verify_key.version = 0
 
-    def verifyMessage(self, jsonMessage):
-        if not 'signatures' in jsonMessage:
+    def verifySignedAssociation(self, assoc):
+        """Verifies a signature on a signed association.
+
+        :param assoc: A signed association.
+        :type assoc: Dict
+        """
+        if not 'signatures' in assoc:
             raise NoSignaturesException()
 
         alg = 'ed25519'
 
-        key_ids = signedjson.sign.signature_ids(jsonMessage, self.servername)
+        key_ids = signedjson.sign.signature_ids(assoc, self.servername)
         if not key_ids or len(key_ids) == 0 or not key_ids[0].startswith(alg + ":"):
             e = NoMatchingSignatureException()
-            e.foundSigs = jsonMessage['signatures'].keys()
+            e.foundSigs = assoc['signatures'].keys()
             e.requiredServername = self.servername
             raise e
 
         # Verify the JSON
-        signedjson.sign.verify_signed_json(jsonMessage, self.servername, self.verify_key)
+        signedjson.sign.verify_signed_json(assoc, self.servername, self.verify_key)
 
     def pushUpdates(self, sgAssocs):
         body = {'sgAssocs': sgAssocs}

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -29,6 +29,8 @@ from twisted.web.client import readBody
 
 logger = logging.getLogger(__name__)
 
+SIGNING_KEY_ALGORITHM = "ed25519"
+
 
 class Peer(object):
     def __init__(self, servername, pubkeys):
@@ -78,13 +80,12 @@ class RemotePeer(Peer):
         super(RemotePeer, self).__init__(server_name, pubkeys)
         self.sydent = sydent
         self.port = 1001
-        self.alg = "ed25519"
 
         # Get verify key for this peer
-        self.verify_key = self.pubkeys[self.alg]
+        self.verify_key = self.pubkeys[SIGNING_KEY_ALGORITHM]
 
         # Attach metadata
-        self.verify_key.alg = self.alg
+        self.verify_key.alg = SIGNING_KEY_ALGORITHM
         self.verify_key.version = 0
 
     def verifySignedAssociation(self, assoc):
@@ -97,7 +98,7 @@ class RemotePeer(Peer):
             raise NoSignaturesException()
 
         key_ids = signedjson.sign.signature_ids(assoc, self.servername)
-        if not key_ids or len(key_ids) == 0 or not key_ids[0].startswith(self.alg + ":"):
+        if not key_ids or len(key_ids) == 0 or not key_ids[0].startswith(SIGNING_KEY_ALGORITHM + ":"):
             e = NoMatchingSignatureException()
             e.foundSigs = assoc['signatures'].keys()
             e.requiredServername = self.servername

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -78,13 +78,13 @@ class RemotePeer(Peer):
         super(RemotePeer, self).__init__(server_name, pubkeys)
         self.sydent = sydent
         self.port = 1001
+        self.alg = "ed25519"
 
-        # Get verify key from signing key
-        signing_key = signedjson.key.decode_signing_key_base64(alg, "0", self.pubkeys[alg])
-        self.verify_key = signing_key.verify_key
+        # Get verify key for this peer
+        self.verify_key = self.pubkeys[self.alg]
 
         # Attach metadata
-        self.verify_key.alg = alg
+        self.verify_key.alg = self.alg
         self.verify_key.version = 0
 
     def verifySignedAssociation(self, assoc):
@@ -96,10 +96,8 @@ class RemotePeer(Peer):
         if not 'signatures' in assoc:
             raise NoSignaturesException()
 
-        alg = 'ed25519'
-
         key_ids = signedjson.sign.signature_ids(assoc, self.servername)
-        if not key_ids or len(key_ids) == 0 or not key_ids[0].startswith(alg + ":"):
+        if not key_ids or len(key_ids) == 0 or not key_ids[0].startswith(self.alg + ":"):
             e = NoMatchingSignatureException()
             e.foundSigs = assoc['signatures'].keys()
             e.requiredServername = self.servername


### PR DESCRIPTION
Now that I know verifyKey == public key and signingKey == private key, it was quickly apparent that the implementation of #110 was slightly broken.

This PR aims to correct things so that we don't need a peer's private key to verify their message signatures.

(Specifically, before we needed their private key, generated the public key, and then checked signatures. But we obviously should just be storing the public key in the first place).