### PR TITLE
Fix sqlite syntax IS != =

### DIFF
--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -108,7 +108,7 @@ class JoinTokenStore(object):
         cur = self.sydent.db.cursor()
         res = cur.execute(
             "SELECT id, medium, address, room_id, sender, token FROM invite_tokens"
-            " WHERE id > ? AND origin_id = NULL LIMIT ?",
+            " WHERE id > ? AND origin_id IS NULL LIMIT ?",
             (afterId, limit,)
         )
         rows = res.fetchall()
@@ -240,7 +240,7 @@ class JoinTokenStore(object):
         cur = self.sydent.db.cursor()
         res = cur.execute(
             "SELECT id, public_key, verify_count, persistence_ts FROM ephemeral_public_keys"
-            " WHERE id > ? AND origin_id = NULL LIMIT ?",
+            " WHERE id > ? AND origin_id IS NULL LIMIT ?",
             (afterId, limit,)
         )
         rows = res.fetchall()


### PR DESCRIPTION
We had a bug where using `origin_id = NULL` would actually to produce any rows where `origin_id IS NULL` produces rows.

SQL is weird.