### PR TITLE
Fix notifyPendingInvites

### DIFF
--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -100,7 +100,8 @@ class ThreepidBinder:
 
             self._notify(sgassoc, 0)
 
-        return sgassoc
+            return sgassoc
+        return None
 
     def removeBinding(self, threepid, mxid):
         localAssocStore = LocalAssociationStore(self.sydent)


### PR DESCRIPTION
Don't return something that's no longer in scope