### PR TITLE
Make sid generation non-sequential

### DIFF
--- a/sydent/db/threepid_validation.sql
+++ b/sydent/db/threepid_validation.sql
@@ -17,3 +17,5 @@ limitations under the License.
 CREATE TABLE IF NOT EXISTS threepid_validation_sessions (id integer primary key, medium varchar(16) not null, address varchar(256) not null, clientSecret varchar(32) not null, validated int default 0, mtime bigint not null);
 CREATE TABLE IF NOT EXISTS threepid_token_auths (id integer primary key, validationSession integer not null, token varchar(32) not null, sendAttemptNumber integer not null, foreign key (validationSession) references threepid_validations(id));
 
+-- Used to find and delete expired sessions
+CREATE INDEX IF NOT EXISTS threepid_validation_sessions_mtime ON threepid_validation_sessions(mtime);


### PR DESCRIPTION
Otherwise we leak the number of validations we've started.

Based on #142