### PR TITLE
Use trustRoot instead of verify for request verification

### DIFF
--- a/sydent/http/federation_tls_options.py
+++ b/sydent/http/federation_tls_options.py
@@ -90,7 +90,11 @@ class ClientTLSOptionsFactory(object):
     to remote servers for federation."""
 
     def __init__(self, config):
-        self._options = ssl.CertificateOptions(verify=config.getboolean("http", "federation.verifycerts"))
+        verify_requests = config.getboolean("http", "federation.verifycerts")
+        if verify_requests:
+            self._options = ssl.CertificateOptions(trustRoot=ssl.platformTrust())
+        else:
+            self._options = ssl.CertificateOptions()
 
     def get_options(self, host):
         # Use _makeContext so that we get a fresh OpenSSL CTX each time.


### PR DESCRIPTION
Use `trustRoot` instead of `verify` for specifying `CertificateOptions`, as `verify` has essentially been made deprecated.

This takes the same approach as the implementation in Synapse:

https://github.com/matrix-org/synapse/blob/63b75cf7d70db28924f29bce55b55f567d8053f2/synapse/crypto/context_factory.py#L130-L139

I'm not sure if there's a way to provide a default value to `getboolean`, so I've added a check for it. The setup of the config file is that the default values are supposed to be put at the top, and then overridden later on in the config file, but that all seems pretty flaky. The whole config file needs a refactor which is tracked at #101.