### PR TITLE
Deny 3pid bindings not in info.yaml

### DIFF
--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -20,6 +20,7 @@ from sydent.db.valsession import ThreePidValSessionStore
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.validators import SessionExpiredException, IncorrectClientSecretException, InvalidSessionIdException,\
     SessionNotValidatedException
+from sydent.threepid.bind import BindingNotPermittedException
 
 class ThreePidBindServlet(Resource):
     def __init__(self, sydent):
@@ -55,7 +56,13 @@ class ThreePidBindServlet(Resource):
             return {'errcode': 'M_SESSION_NOT_VALIDATED',
                     'error': "This validation session has not yet been completed"}
 
-        res = self.sydent.threepidBinder.addBinding(s.medium, s.address, mxid)
+        try:
+            res = self.sydent.threepidBinder.addBinding(s.medium, s.address, mxid)
+        except BindingNotPermittedException:
+            return {
+                'errcode': 'M_BINDING_NOT_PERMITTED',
+                'error': "This threepid may not be bound to this mxid",
+            }
         return res
 
     @jsonwrap

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -210,7 +210,7 @@ class Sydent:
         self.servlets.info = InfoServlet(self, info)
         self.servlets.internalInfo = InternalInfoServlet(self, info)
 
-        self.threepidBinder = ThreepidBinder(self)
+        self.threepidBinder = ThreepidBinder(self, info)
 
         self.sslComponents = SslComponents(self)
 

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -53,7 +53,7 @@ def parseMxid(mxid):
 
     return parts
 
-class BindingNotPermittedExceotion(Exception):
+class BindingNotPermittedException(Exception):
     pass
 
 class ThreepidBinder:
@@ -87,7 +87,7 @@ class ThreepidBinder:
 
         if mxidParts[1] not in possible_hses:
             logger.info("Denying bind of %r/%r -> %r (info result: %r)", medium, address, mxid, result)
-            raise BindingNotPermittedExceotion()
+            raise BindingNotPermittedException()
 
         localAssocStore = LocalAssociationStore(self.sydent)
 

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -75,6 +75,7 @@ class ThreepidBinder:
             medium (str): the type of 3pid
             address (str): the 3pid
             mxid (str): the mxid to bind it to
+        Returns: The resulting signed association
         """
         mxidParts = parseMxid(mxid)
         result = self._info.match_user_id(medium, address)


### PR DESCRIPTION
Dinsic specific: deny any 3pid bindings if the HS the threepid
doesn't have the coresponding HS listed in the info.yaml