### PR TITLE
Use MatrixFederationAgent for binds to Synapse

### DIFF
--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -86,6 +86,12 @@ class HTTPClient(object):
             headers,
             bodyProducer=FileBodyProducer(StringIO(json_str))
         )
+
+        # Ensure the body object is read otherwise we'll leak HTTP connections
+        # as per
+        # https://twistedmatrix.com/documents/current/web/howto/client.html
+        yield readBody(response)
+
         defer.returnValue(response)
 
 class SimpleHttpClient(HTTPClient):

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -184,18 +184,3 @@ class ThreepidBinder:
 
         servers.sort()
         defer.returnValue(servers)
-
-
-class InsecureInterceptableContextFactory(ssl.ContextFactory):
-    """
-    Factory for PyOpenSSL SSL contexts which accepts any certificate for any domain.
-
-    Do not use this since it allows an attacker to intercept your communications.
-    """
-
-    def __init__(self):
-        self._context = SSL.Context(SSL.SSLv23_METHOD)
-        self._context.set_verify(VERIFY_NONE, lambda *_: None)
-
-    def getContext(self, hostname, port):
-        return self._context

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -115,6 +115,7 @@ class ThreepidBinder:
             response = yield http_client.post_json_get_nothing(post_url, assoc, {})
         except Exception as e:
             self._notifyErrback(assoc, attempt, e)
+            return
 
         # If the request failed, try again with exponential backoff
         if response.code != 200:

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -113,15 +113,16 @@ class ThreepidBinder:
         http_client = FederationHttpClient(self.sydent)
         try:
             response = yield http_client.post_json_get_nothing(post_url, assoc, {})
-            # If the request failed, try again with exponential backoff
-            if response.code != 200:
-                self._notifyErrback(
-                    assoc, attempt, "Non-OK error code received (%d)" % response.code
-                )
-            else:
-                logger.info("Successfully notified on bind for %s" % (mxid,))
         except Exception as e:
             self._notifyErrback(assoc, attempt, e)
+
+        # If the request failed, try again with exponential backoff
+        if response.code != 200:
+            self._notifyErrback(
+                assoc, attempt, "Non-OK error code received (%d)" % response.code
+            )
+        else:
+            logger.info("Successfully notified on bind for %s" % (mxid,))
 
     def _notifyErrback(self, assoc, attempt, error):
         logger.warn("Error notifying on bind for %s: %s - rescheduling", assoc["mxid"], error)


### PR DESCRIPTION
Stop using the `InsecureInterceptableContextFactory` and instead use MatrixFederationAgent which can handle .well-known server files.