### PR TITLE
Don't accumulate cleanup tasks

### DIFF
--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.internet import task
-
 import sydent.util.tokenutils
 
 from sydent.validators import ValidationSession, IncorrectClientSecretException, InvalidSessionIdException, \
@@ -29,10 +27,6 @@ class ThreePidValSessionStore:
     def __init__(self, syd):
         self.sydent = syd
         self.random = SystemRandom()
-
-        # Clean up old sessions every N minutes
-        cb = task.LoopingCall(self.deleteOldSessions)
-        cb.start(10 * 60.0)
 
     def getOrCreateTokenSession(self, medium, address, clientSecret):
         cur = self.sydent.db.cursor()


### PR DESCRIPTION
The validation session isn't a singleton - one of these gets created
any time something wants to do something with a 3pid validation, so
shceduling this cleanup task in the constructor was adding a new
scheduled task each time.

Just add one in the main sydent object.

Fixes https://github.com/vector-im/riot-web/issues/9644