### PR TITLE
Ability to unbind using sid/client_secret

### DIFF
--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -96,6 +96,7 @@ class LocalAssociationStore:
                 "No local assoc found for %s/%s/%s",
                 threepid['medium'], threepid['address'], mxid,
             )
+            raise ValueError("No match found between provided mxid and threepid")
 
 
 class GlobalAssociationStore:

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -67,6 +67,20 @@ class ThreePidUnbindServlet(Resource):
                 request.finish()
                 return
 
+            # We now check for authentication in two different ways, depending
+            # on the contents of the request. If the user has supplied "sid"
+            # (the Session ID returned by Sydent during the original binding)
+            # and "client_secret" fields, they are trying to provie that they
+            # were the original author of the bind. We then check that what
+            # they supply matches and if it does, allow the unbind.
+            # 
+            # However if these fields are not supplied, we instead check
+            # whether the request originated from a homeserver, and if so the
+            # same homeserver that originally created the bind. We do this by
+            # checking the signature of the request. If it all matches up, we
+            # allow the unbind.
+            #
+            # Only one method of authentication is required.
             if 'sid' in body and 'client_secret' in body:
                 sid = body['sid']
                 client_secret = body['client_secret']

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -130,7 +130,17 @@ class ThreePidUnbindServlet(Resource):
                     request.finish()
                     return
 
-            res = self.sydent.threepidBinder.removeBinding(threepid, mxid)
+            try:
+                res = self.sydent.threepidBinder.removeBinding(threepid, mxid)
+            except ValueError:
+                # User could have provided correct 3PID/sid/client_secret
+                # details but not the correct mxid, which would cause the
+                # binding removal to fail
+                request.setResponseCode(400)
+                request.write(json.dumps({'errcode': 'M_UNKNOWN', 'error': "Association between provided mxid and 3pid not found"}))
+                request.finish()
+                return
+
             request.write(json.dumps({}))
             request.finish()
         except Exception as ex:


### PR DESCRIPTION
Closes https://github.com/matrix-org/sydent/issues/134

Adds the ability to give `sid` and `client_secret` fields to `POST /_matrix/identity/api/v1/3pid/unbind` such that a requester can unbind a bound 3PID without having to be the original HS.

Tested manually.