### PR TITLE
Update peers.sql

### DIFF
--- a/sydent/db/peers.sql
+++ b/sydent/db/peers.sql
@@ -18,9 +18,9 @@ CREATE TABLE IF NOT EXISTS peers (
 	id integer primary key,
 	name varchar(255) not null,
 	port integer default null,
-	lastSentAssocsId integer,
-	lastSentInviteTokensId integer,
-	lastSentEphemeralKeysId integer,
+	lastSentAssocsId integer default 0,
+	lastSentInviteTokensId integer default 0,
+	lastSentEphemeralKeysId integer default 0,
 	lastPokeSucceededAt integer,
 	active integer not null default 0,
 	shadow integer not null default 0


### PR DESCRIPTION
We should default these values to zero, as null is not greater than or less than the current index, so replication never occurs, as there's never any work to do.