### PR TITLE
Filter out sent invite when processing pending invites

### DIFF
--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -34,7 +34,7 @@ class JoinTokenStore(object):
 
         res = cur.execute(
             "SELECT medium, address, room_id, sender, token FROM invite_tokens"
-            " WHERE medium = ? AND address = ?",
+            " WHERE medium = ? AND address = ? AND sent_ts IS NULL",
             (medium, address,)
         )
         rows = res.fetchall()


### PR DESCRIPTION
We don't currently delete pending invites after they've been sent to the homeserver. While it's probably something we'd want to do, I don't know if there's a good reason for keeping them in the DB. What I'm fairly sure about, however, is that we shouldn't list them as pending invites anymore, otherwise someone binding an old 3PID of ours could get all of the 3PID invites that were ever sent to us in the past.