### PR TITLE
Add optional, time-based expiration for 3PID invites

### DIFF
--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -48,6 +48,9 @@ class JoinTokenStore(object):
         :param commit: Whether DB changes should be committed by this
             function (or an external one).
         :type commit: bool
+        :param expire_ts_ms: The expiration date to set to this invite on this server. Not
+            replicated. 0 if no expiration date.
+        :type expire_ts_ms: int
         """
         if originId and originServer:
             # Check if we've already seen this association from this server

--- a/sydent/db/invite_tokens.sql
+++ b/sydent/db/invite_tokens.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS invite_tokens (
     sent_ts bigint, -- When the token was sent by us to the user
     origin_id integer, -- original id in homeserver's DB that this was replicated from (if applicable)
     origin_server text, -- homeserver this was replicated from (if applicable)
-    valid_until_ms integer not null default 0 -- When the invite is due to expire
+    valid_until_ts integer -- Timestamp after which the invite isn't valid anymore
 );
 CREATE INDEX IF NOT EXISTS invite_token_medium_address on invite_tokens(medium, address);
 CREATE INDEX IF NOT EXISTS invite_token_token on invite_tokens(token);

--- a/sydent/db/invite_tokens.sql
+++ b/sydent/db/invite_tokens.sql
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 OpenMarket Ltd
+Copyright 2019 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,7 +25,8 @@ CREATE TABLE IF NOT EXISTS invite_tokens (
     received_ts bigint, -- When the invite was received by us from the homeserver
     sent_ts bigint, -- When the token was sent by us to the user
     origin_id integer, -- original id in homeserver's DB that this was replicated from (if applicable)
-    origin_server text -- homeserver this was replicated from (if applicable)
+    origin_server text, -- homeserver this was replicated from (if applicable)
+    valid_until_ms integer not null default 0 -- When the invite is due to expire
 );
 CREATE INDEX IF NOT EXISTS invite_token_medium_address on invite_tokens(medium, address);
 CREATE INDEX IF NOT EXISTS invite_token_token on invite_tokens(token);

--- a/sydent/db/invite_tokens.sql
+++ b/sydent/db/invite_tokens.sql
@@ -25,8 +25,7 @@ CREATE TABLE IF NOT EXISTS invite_tokens (
     received_ts bigint, -- When the invite was received by us from the homeserver
     sent_ts bigint, -- When the token was sent by us to the user
     origin_id integer, -- original id in homeserver's DB that this was replicated from (if applicable)
-    origin_server text, -- homeserver this was replicated from (if applicable)
-    valid_until_ts integer -- Timestamp after which the invite isn't valid anymore
+    origin_server text -- homeserver this was replicated from (if applicable)
 );
 CREATE INDEX IF NOT EXISTS invite_token_medium_address on invite_tokens(medium, address);
 CREATE INDEX IF NOT EXISTS invite_token_token on invite_tokens(token);

--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -146,6 +146,12 @@ class SqliteDatabase:
             self.db.commit()
             logger.info("v2 -> v3 schema migration complete")
             self._setSchemaVersion(3)
+        if curVer < 4:
+            cur = self.db.cursor()
+            cur.execute("ALTER TABLE invite_tokens ADD COLUMN valid_until_ms INTEGER NOT NULL DEFAULT 0")
+            self.db.commit()
+            logger.info("v3 -> v4 schema migration complete")
+            self._setSchemaVersion(4)
 
     def _getSchemaVersion(self):
         cur = self.db.cursor()

--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -148,7 +148,9 @@ class SqliteDatabase:
             self._setSchemaVersion(3)
         if curVer < 4:
             cur = self.db.cursor()
-            cur.execute("ALTER TABLE invite_tokens ADD COLUMN valid_until_ms INTEGER NOT NULL DEFAULT 0")
+            # Timestamp after which the invite isn't considered valid anymore. Is NULL if
+            # invites are always valid.
+            cur.execute("ALTER TABLE invite_tokens ADD COLUMN valid_until_ts INTEGER")
             self.db.commit()
             logger.info("v3 -> v4 schema migration complete")
             self._setSchemaVersion(4)

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -166,13 +166,16 @@ class ReplicationPushServlet(Resource):
             return
 
         now_ms = int(time.time() * 1000)
+        if self.sydent.invites_validity_period is not None:
+            valid_until_ts = now_ms + self.sydent.invites_validity_period
+        else:
+            valid_until_ts = None
 
         for originId, inviteToken in invite_tokens.items():
             tokensStore.storeToken(inviteToken['medium'], inviteToken['address'], inviteToken['room_id'],
                                 inviteToken['sender'], inviteToken['token'],
                                 originServer=peer.servername, originId=originId,
-                                valid_until_ts=now_ms + self.sydent.invites_validity_period if self.sydent.invites_validity_period else None,
-                                commit=False)
+                                valid_until_ts=valid_until_ts, commit=False)
             logger.info("Stored invite token with origin ID %s from %s", originId, peer.servername)
 
         # Process any ephemeral public keys

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2014 OpenMarket Ltd
+# Copyright 2019 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +29,7 @@ from signedjson.sign import SignatureVerifyException
 
 import logging
 import json
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -163,10 +165,13 @@ class ReplicationPushServlet(Resource):
             request.finish()
             return
 
+        now_ms = int(time.time() * 1000)
+
         for originId, inviteToken in invite_tokens.items():
             tokensStore.storeToken(inviteToken['medium'], inviteToken['address'], inviteToken['room_id'],
                                 inviteToken['sender'], inviteToken['token'],
-                                originServer=peer.servername, originId=originId, commit=False)
+                                originServer=peer.servername, originId=originId, commit=False,
+                                expire_ts_ms=now_ms + self.sydent.invites_validity_period if self.sydent.invites_validity_period else 0)
             logger.info("Stored invite token with origin ID %s from %s", originId, peer.servername)
 
         # Process any ephemeral public keys

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -170,8 +170,9 @@ class ReplicationPushServlet(Resource):
         for originId, inviteToken in invite_tokens.items():
             tokensStore.storeToken(inviteToken['medium'], inviteToken['address'], inviteToken['room_id'],
                                 inviteToken['sender'], inviteToken['token'],
-                                originServer=peer.servername, originId=originId, commit=False,
-                                expire_ts_ms=now_ms + self.sydent.invites_validity_period if self.sydent.invites_validity_period else 0)
+                                originServer=peer.servername, originId=originId,
+                                valid_until_ts=now_ms + self.sydent.invites_validity_period if self.sydent.invites_validity_period else None,
+                                commit=False)
             logger.info("Stored invite token with origin ID %s from %s", originId, peer.servername)
 
         # Process any ephemeral public keys

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -73,11 +73,15 @@ class StoreInviteServlet(Resource):
         ephemeralPublicKeyBase64 = encode_base64(ephemeralPublicKey.encode(), True)
 
         now_ms = int(time.time() * 1000)
+        if self.sydent.invites_validity_period is not None:
+            valid_until_ts = now_ms + self.sydent.invites_validity_period
+        else:
+            valid_until_ts = None
 
         tokenStore.storeEphemeralPublicKey(ephemeralPublicKeyBase64)
         tokenStore.storeToken(
             medium, address, roomId, sender, token,
-            valid_until_ts=now_ms + self.sydent.invites_validity_period if self.sydent.invites_validity_period else None,
+            valid_until_ts=valid_until_ts,
         )
 
         substitutions = {}

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2015 OpenMarket Ltd
+# Copyright 2019 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +17,7 @@
 import nacl.signing
 import random
 import string
+import time
 from email.header import Header
 
 from twisted.web.resource import Resource
@@ -70,8 +72,13 @@ class StoreInviteServlet(Resource):
         ephemeralPrivateKeyBase64 = encode_base64(ephemeralPrivateKey.encode(), True)
         ephemeralPublicKeyBase64 = encode_base64(ephemeralPublicKey.encode(), True)
 
+        now_ms = int(time.time() * 1000)
+
         tokenStore.storeEphemeralPublicKey(ephemeralPublicKeyBase64)
-        tokenStore.storeToken(medium, address, roomId, sender, token)
+        tokenStore.storeToken(
+            medium, address, roomId, sender, token,
+            expire_ts_ms=now_ms + self.sydent.invites_validity_period if self.sydent.invites_validity_period else 0,
+        )
 
         substitutions = {}
         for key, values in request.args.items():

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -77,7 +77,7 @@ class StoreInviteServlet(Resource):
         tokenStore.storeEphemeralPublicKey(ephemeralPublicKeyBase64)
         tokenStore.storeToken(
             medium, address, roomId, sender, token,
-            expire_ts_ms=now_ms + self.sydent.invites_validity_period if self.sydent.invites_validity_period else 0,
+            valid_until_ts=now_ms + self.sydent.invites_validity_period if self.sydent.invites_validity_period else None,
         )
 
         substitutions = {}

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -78,6 +78,7 @@ CONFIG_DEFAULTS = {
         'shadow.hs.master': '',
         'shadow.hs.slave': '',
         'ips.nonshadow': '',  # comma separated list of CIDR ranges which /info will return non-shadow HS to.
+        'invites.validity_period': 0,
     },
     'db': {
         'db.file': 'sydent.db',
@@ -175,6 +176,8 @@ class Sydent:
         self.user_dir_allowed_hses = set(list_from_comma_sep_string(
             self.cfg.get('userdir', 'userdir.allowed_homeservers', '')
         ))
+
+        self.invites_validity_period = self.cfg.get("invites.validity_period", 0)
 
         self.validators = Validators()
         self.validators.email = EmailValidator(self)

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -179,7 +179,7 @@ class Sydent:
         ))
 
         self.invites_validity_period = parse_duration(
-            self.cfg.get("invites.validity_period", 0),
+            self.cfg.get('general', 'invites.validity_period', 0),
         )
 
         self.validators = Validators()

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -178,7 +178,9 @@ class Sydent:
             self.cfg.get('userdir', 'userdir.allowed_homeservers', '')
         ))
 
-        self.invites_validity_period = self.cfg.get("invites.validity_period", 0)
+        self.invites_validity_period = parse_duration(
+            self.cfg.get("invites.validity_period", 0),
+        )
 
         self.validators = Validators()
         self.validators.email = EmailValidator(self)
@@ -297,6 +299,25 @@ def parse_config(config_file):
         cfg.read(config_file)
 
     return cfg
+
+
+def parse_duration(value):
+    if isinstance(value, int):
+        return value
+    second = 1000
+    minute = 60 * second
+    hour = 60 * minute
+    day = 24 * hour
+    week = 7 * day
+    year = 365 * day
+    sizes = {"s": second, "m": minute, "h": hour, "d": day, "w": week, "y": year}
+    size = 1
+    suffix = value[-1]
+    if suffix in sizes:
+        value = value[:-1]
+        size = sizes[suffix]
+    return int(value) * size
+
 
 if __name__ == '__main__':
     syd = Sydent()

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -79,7 +79,10 @@ CONFIG_DEFAULTS = {
         'shadow.hs.master': '',
         'shadow.hs.slave': '',
         'ips.nonshadow': '',  # comma separated list of CIDR ranges which /info will return non-shadow HS to.
-        'invites.validity_period': 0,
+        # Timestamp in milliseconds, or string in the form of e.g. "2w" for two weeks,
+        # which defines the time during which an invite will be valid on this server
+        # from the time it has been received.
+        'invites.validity_period': None,
     },
     'db': {
         'db.file': 'sydent.db',
@@ -179,7 +182,7 @@ class Sydent:
         ))
 
         self.invites_validity_period = parse_duration(
-            self.cfg.get('general', 'invites.validity_period', 0),
+            self.cfg.get('general', 'invites.validity_period'),
         )
 
         self.validators = Validators()

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -2,6 +2,7 @@
 
 # Copyright 2014 OpenMarket Ltd
 # Copyright 2018 New Vector Ltd
+# Copyright 2019 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds a new optional config option under `[general]`, named `invites.validity_period` which is either an integer (number of milliseconds) or a string (in the form `2w` for e.g. two weeks) that sets a time limit for 3PID invites received over federation.

An upcoming iteration could be adding a background job to remove tokens for expired invites, but as per #165 I'm not sure about our policy for removing 3PID invite tokens from Sydent's database.