### PR TITLE
Return the user's current server on /info while it's still active

### DIFF
--- a/sydent/http/servlets/infoservlet.py
+++ b/sydent/http/servlets/infoservlet.py
@@ -20,6 +20,7 @@ from netaddr import IPAddress
 import logging
 import json
 
+from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,14 @@ class InfoServlet(Resource):
         if self.sydent.nonshadow_ips and ip not in self.sydent.nonshadow_ips:
             # This user is not whitelisted, present shadow_hs at their only hs
             result['hs'] = result.pop('shadow_hs', None)
+
+        store = GlobalAssociationStore(self.sydent)
+        mxid = store.getMxid(medium, address)
+        if mxid:
+            current_hs = mxid.split(':', 1)[1]
+            if current_hs != result['hs']:
+                result['new_hs'] = result['hs']
+                result['hs'] = current_hs
 
         # Non-internal. Remove 'requires_invite' if found
         result.pop('requires_invite', None)

--- a/sydent/http/servlets/infoservlet.py
+++ b/sydent/http/servlets/infoservlet.py
@@ -67,6 +67,10 @@ class InfoServlet(Resource):
             # This user is not whitelisted, present shadow_hs at their only hs
             result['hs'] = result.pop('shadow_hs', None)
 
+        # Check if there's a MXID associated with this address, if so use its domain as
+        # the value for "hs" (so that the user can still access their account through
+        # Tchap) and move the value "hs" should have had otherwise to "new_hs" if it's a
+        # different one.
         store = GlobalAssociationStore(self.sydent)
         mxid = store.getMxid(medium, address)
         if mxid:


### PR DESCRIPTION
i.e. if there's a binding for the 3PID, use the server name from the MXID instead of the data from `info.yaml` on `/info` responses.

The use case is that the `/info` endpoint is hit by clients to know which HS they should connect to. When an email domain sees the server it should be registered to change, this endpoint would prevent a user under this domain from logging back to their previous account to retrieve some data or logs they might still need.
In this case, we want `/info` to still return the previous HS so that the user can log back into their previous account until they manually deactivate it. Once they've deactivated it, they can register a new account on the new HS.

This PR also adds a `new_hs` to the `/info` response, so that the client can provide a nice UI to tell the user they should deactivate their account and recreate it.

I tested it on a personal deployment, and a `test3pid@brendanabolivier.com` email 3PID, with the following `info.yaml` file:

```yaml
platforms:
    - &education
        hs: education.tchap.gouv.fr
    - &labs
        hs: labs.abolivier.bzh

medium:
    email:
        entries:
            test3pid@brendanabolivier.com: *labs
```

Before doing anything, a curl on `/info` returns:

```json
{"hs": "labs.abolivier.bzh"}
```

After binding the 3PID to my `labs.abolivier.bzh` user, it still returns:

```json
{"hs": "labs.abolivier.bzh"}
```

When changing `*labs` into `*education` for `test3pid@brendanabolivier.com` (and restarting Sydent):

```json
{"hs": "labs.abolivier.bzh", "new_hs": "education.tchap.gouv.fr"}
```

When unbinding the 3PID from my `labs.abolivier.bzh` user:

```json
{"hs": "education.tchap.gouv.fr"}
```

Which seems to be the expected behaviour.