### PR TITLE
Fix config parsing

### DIFF
--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -82,7 +82,7 @@ CONFIG_DEFAULTS = {
         # Timestamp in milliseconds, or string in the form of e.g. "2w" for two weeks,
         # which defines the time during which an invite will be valid on this server
         # from the time it has been received.
-        'invites.validity_period': 'None',
+        'invites.validity_period': '',
     },
     'db': {
         'db.file': 'sydent.db',
@@ -305,7 +305,7 @@ def parse_config(config_file):
 
 
 def parse_duration(value):
-    if value == 'None':
+    if not len(value):
         return None
 
     try:

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -82,7 +82,7 @@ CONFIG_DEFAULTS = {
         # Timestamp in milliseconds, or string in the form of e.g. "2w" for two weeks,
         # which defines the time during which an invite will be valid on this server
         # from the time it has been received.
-        'invites.validity_period': None,
+        'invites.validity_period': 'None',
     },
     'db': {
         'db.file': 'sydent.db',
@@ -305,8 +305,14 @@ def parse_config(config_file):
 
 
 def parse_duration(value):
-    if isinstance(value, int):
-        return value
+    if value == 'None':
+        return None
+
+    try:
+        return int(value)
+    except ValueError:
+        pass
+
     second = 1000
     minute = 60 * second
     hour = 60 * minute


### PR DESCRIPTION
Turns out that ConfigParser expects values to be string and only outputs strings. This causes Sydent to crash on this branch since #166 got merged.