### PR TITLE
Fix support of JSON body in /store-invite requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "attrs>=19.1.0",
         "netaddr>=0.7.0",
         "sortedcontainers>=2.1.0",
+        "six>=1.10",
     ],
     # make sure we package the sql files
     include_package_data=True,

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -18,6 +18,7 @@ import random
 import string
 from email.header import Header
 
+from six import string_types
 from twisted.web.resource import Resource
 from unpaddedbase64 import encode_base64
 
@@ -75,9 +76,9 @@ class StoreInviteServlet(Resource):
         tokenStore.storeToken(medium, address, roomId, sender, token)
 
         substitutions = {}
-        for key, values in request.args.items():
-            if len(values) == 1 and type(values[0]) == str:
-                substitutions[key] = values[0]
+        for k, v in args.items():
+            if isinstance(v, string_types):
+                substitutions[k] = v
         substitutions["token"] = token
 
         required = [


### PR DESCRIPTION
The spec [says](https://matrix.org/docs/spec/identity_service/r0.2.1#api-standards) that `/store-invite` requests should be done using the `application/json` mimetype, but currently Sydent chokes on such requests, because it first extracts its params from the request, doing the right thing if the content-type is JSON, but, when trying to compute the dict of substitutions to apply to the email template, looks for them in `request.args`, which is empty when using `application/json`.

On top of that, `json.dumps()` outputs a dict which keys and string values are of type `unicode`, which Python 2 doesn't consider to be strings (or at least not the same as `str`), so the arguments wouldn't be added to the substitutions dict.

This bug went unnoticed because Synapse isn't compliant with the spec here and sends that data using the `application/x-www-form-urlencoded` mimetype. This is tracked in https://github.com/matrix-org/synapse/issues/5634.

This makes Sydent not try to re-extract the params from the `request.args`, but instead use the ones it has already extracted the right way. It also changes the type comparison on the params' values, comparing them with `six.string_types` instead of only the `str` type.