### PR TITLE
Fix typo in column name

### DIFF
--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -80,7 +80,7 @@ class JoinTokenStore(object):
         cur = self.sydent.db.cursor()
 
         res = cur.execute(
-            "SELECT medium, address, room_id, sender, token, origin_server, valid_until_ms FROM invite_tokens"
+            "SELECT medium, address, room_id, sender, token, origin_server, valid_until_ts FROM invite_tokens"
             " WHERE medium = ? AND address = ?",
             (medium, address,)
         )


### PR DESCRIPTION
Introduced in #166, apparently I forgot one occurrence when I renamed the db column `valid_until_ms` into `valid_until_ts`.