### PR TITLE
Delete 3PID invite medatata upon successful delivery to a homeserver 

### DIFF
--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -93,3 +93,13 @@ class JoinTokenStore(object):
         if rows:
             return rows[0][0]
         return None
+
+    def deleteTokens(self, medium, address):
+        cur = self.sydent.db.cursor()
+
+        cur.execute(
+            "DELETE FROM invite_tokens WHERE medium = ? AND address = ?",
+            (int(time.time()), medium, address,)
+        )
+
+        self.sydent.db.commit()

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -99,7 +99,7 @@ class JoinTokenStore(object):
 
         cur.execute(
             "DELETE FROM invite_tokens WHERE medium = ? AND address = ?",
-            (int(time.time()), medium, address,)
+            (medium, address,)
         )
 
         self.sydent.db.commit()

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -126,19 +126,18 @@ class ThreepidBinder:
             logger.info("Successfully notified on bind for %s" % (mxid,))
 
             # Only remove sent tokens when they've been successfully sent.
-            if assoc.get("invites"):
-                try:
-                    joinTokenStore = JoinTokenStore(self.sydent)
-                    joinTokenStore.deleteTokens(assoc["medium"], assoc["address"])
-                    logger.info(
-                        "Successfully deleted invite for %s from the store",
-                        assoc["address"],
-                    )
-                except Exception as e:
-                    logger.exception(
-                        "Couldn't remove invite for %s from the store",
-                        assoc["address"],
-                    )
+            try:
+                joinTokenStore = JoinTokenStore(self.sydent)
+                joinTokenStore.deleteTokens(assoc["medium"], assoc["address"])
+                logger.info(
+                    "Successfully deleted invite for %s from the store",
+                    assoc["address"],
+                )
+            except Exception as e:
+                logger.exception(
+                    "Couldn't remove invite for %s from the store",
+                    assoc["address"],
+                )
 
     def _notifyErrback(self, assoc, attempt, error):
         logger.warn("Error notifying on bind for %s: %s - rescheduling", assoc["mxid"], error)

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -130,9 +130,15 @@ class ThreepidBinder:
                 try:
                     joinTokenStore = JoinTokenStore(self.sydent)
                     joinTokenStore.deleteTokens(assoc["medium"], assoc["address"])
+                    logger.info(
+                        "Successfully deleted invite for %s from the store",
+                        assoc["address"],
+                    )
                 except Exception as e:
                     logger.error(
-                        "Couldn't remove invite for % from the store: %s", mxid, e,
+                        "Couldn't remove invite for % from the store: %s",
+                        assoc["address"],
+                        e,
                     )
 
     def _notifyErrback(self, assoc, attempt, error):

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -126,15 +126,14 @@ class ThreepidBinder:
             logger.info("Successfully notified on bind for %s" % (mxid,))
 
             # Only remove sent tokens when they've been successfully sent.
-            if assoc.extra_fields["invite"]:
+            if assoc.get("invites"):
                 try:
                     joinTokenStore = JoinTokenStore(self.sydent)
-                    joinTokenStore.deleteTokens(assoc.medium, assoc.address)
+                    joinTokenStore.deleteTokens(assoc["medium"], assoc["address"])
                 except Exception as e:
                     logger.error(
                         "Couldn't remove invite for % from the store: %s", mxid, e,
                     )
-
 
     def _notifyErrback(self, assoc, attempt, error):
         logger.warn("Error notifying on bind for %s: %s - rescheduling", assoc["mxid"], error)

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -125,6 +125,17 @@ class ThreepidBinder:
         else:
             logger.info("Successfully notified on bind for %s" % (mxid,))
 
+            # Only remove sent tokens when they've been successfully sent.
+            if assoc.extra_fields["invite"]:
+                try:
+                    joinTokenStore = JoinTokenStore(self.sydent)
+                    joinTokenStore.deleteTokens(assoc.medium, assoc.address)
+                except Exception as e:
+                    logger.error(
+                        "Couldn't remove invite for % from the store: %s", mxid, e,
+                    )
+
+
     def _notifyErrback(self, assoc, attempt, error):
         logger.warn("Error notifying on bind for %s: %s - rescheduling", assoc["mxid"], error)
         reactor.callLater(math.pow(2, attempt), self._notify, assoc, attempt + 1)

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -135,10 +135,9 @@ class ThreepidBinder:
                         assoc["address"],
                     )
                 except Exception as e:
-                    logger.error(
-                        "Couldn't remove invite for % from the store: %s",
+                    logger.exception(
+                        "Couldn't remove invite for %s from the store",
                         assoc["address"],
-                        e,
                     )
 
     def _notifyErrback(self, assoc, attempt, error):


### PR DESCRIPTION
When a 3PID invite is sent to a homeserver, it's not deleted (instead it's filtered out from subsequent deliveries for the same address, at least since https://github.com/matrix-org/sydent/pull/165 got merged).
We shouldn't keep data in the database that we don't need anymore, therefore this PR removes it once the invite has been successfully delivered to the homeserver through a call to [`/onbind`](https://matrix.org/docs/spec/server_server/unstable#put-matrix-federation-v1-3pid-onbind).

If the delivery failed, Sydent will retry it periodically (until it's shutdown or restarted). In such a case, the invite metadata is not deleted in case we want to retry it (retry schedules currently don't persist after a restart, but that sounds like something we might want to implement in the future). It is, however, updated so that someone else managing to bind the same 3PID can't be delivered this invite (as per https://github.com/matrix-org/sydent/pull/165). Let me know if we'd prefer this data removed entirely until we implement persistence on retry schedules.

Once this patch is applied, previously delivered invites can be purged from the database using the following query:

```sql
DELETE FROM invite_tokens WHERE sent_ts IS NOT NULL;
```

One may want to filter on the value of `sent_ts` (which is a timestamp in milliseconds since epoch) so that the query is less likely to target invites that are currently being retried due to e.g. the HS being down (which is unlikely since the delivery is supposed to directly follow a request from the said HS, though).

Binging @lampholder since this is related to matters of privacy and personal data.