### PR TITLE
Silently ignore non-whitelisted domains

### DIFF
--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -127,9 +127,11 @@ class ThreePidBindServlet(Resource):
             res = self.sydent.threepidBinder.addBinding(s.medium, s.address, mxid)
             request.write(json.dumps(res))
         else:
+            # ignore and return fake response, otherwise synapse gets confused
             request.write(json.dumps({
-                'errcode': 'M_INVALID_PARAM',
-                'error': "Invalid mxid",
+                'medium': s.medium,
+                'address': s.address,
+                'mxid': mxid,
             }))
 
         request.finish()


### PR DESCRIPTION
Instead of 4xxing, as it does indeed make synapse fail the register
request (riot subsequently polled again and got a 200)