### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased changes
 ==================
 
  * Delete stored invites upon successful delivery to a homeserver
+ * Fix a bug that would prevent requests to the `/store-invite` endpoint with JSON payloads to be correctly processed
  * Filter out delivered invites when delivering invites to a homserver upon successful binding
  * Implement support for authenticating unbind queries by providing a `sid` and a
    `client_secret`, as per [MSC1915](https://github.com/matrix-org/matrix-doc/blob/master/proposals/1915-unbind-identity-server-param.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@ Unreleased changes
 ==================
 
  * Delete stored invites upon successful delivery to a homeserver
- * Fix a bug that would prevent requests to the `/store-invite` endpoint with JSON payloads to be correctly processed
- * Filter out delivered invites when delivering invites to a homserver upon successful binding
+ * Fix a bug that would prevent requests to the `/store-invite` endpoint with
+   JSON payloads to be correctly processed
+ * Filter out delivered invites when delivering invites to a homserver upon
+   successful binding
  * Implement support for authenticating unbind queries by providing a `sid` and a
    `client_secret`, as per [MSC1915](https://github.com/matrix-org/matrix-doc/blob/master/proposals/1915-unbind-identity-server-param.md)
  * Add support for Prometheus and Sentry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Unreleased changes
 
  * Delete stored invites upon successful delivery to a homeserver
  * Fix a bug that would prevent requests to the `/store-invite` endpoint with
-   JSON payloads to be correctly processed
+   JSON payloads from being correctly processed
  * Filter out delivered invites when delivering invites to a homserver upon
    successful binding
  * Implement support for authenticating unbind queries by providing a `sid` and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+Unreleased changes
+==================
+
+ * Delete stored invites upon successful delivery to a homeserver
+ * Filter out delivered invites when delivering invites to a homserver upon successful binding
+ * Implement support for authenticating unbind queries by providing a `sid` and a
+   `client_secret`, as per [MSC1915](https://github.com/matrix-org/matrix-doc/blob/master/proposals/1915-unbind-identity-server-param.md)
+ * Add support for Prometheus and Sentry
+ * Handle .well-known files when talking to homeservers
+
+
 Changes in [1.0.3](https://github.com/matrix-org/sydent/releases/tag/v1.0.3) (2019-05-03)
 =========================================================================================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Unreleased changes
    `client_secret`, as per [MSC1915](https://github.com/matrix-org/matrix-doc/blob/master/proposals/1915-unbind-identity-server-param.md)
  * Add support for Prometheus and Sentry
  * Handle .well-known files when talking to homeservers
+ * Fix a bug where multiple cleanup tasks would be unnecessary spawned
+ * Fix logging so Sydent doesn't log 3PIDs when processing lookup requests
 
 
 Changes in [1.0.3](https://github.com/matrix-org/sydent/releases/tag/v1.0.3) (2019-05-03)


### PR DESCRIPTION
The changelog hasn't been updated since 1.0.3 was released, therefore I'm updating it so we don't omit changes when doing the next release.

I went through the list of commits that happened on master since the previous release and added an entry for each merged PR.

[Rendered](https://github.com/matrix-org/sydent/blob/babolivier/changelog/CHANGELOG.md)