### PR TITLE
Don't fail the unbind request if the binding doesn't exist

### DIFF
--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -96,7 +96,8 @@ class LocalAssociationStore:
                 "No local assoc found for %s/%s/%s",
                 threepid['medium'], threepid['address'], mxid,
             )
-            raise ValueError("No match found between provided mxid and threepid")
+            # we still consider this successful in the name of idempotency:
+            # the binding to be deleted is not there, so we're in the desired state.
 
 
 class GlobalAssociationStore:

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -144,16 +144,7 @@ class ThreePidUnbindServlet(Resource):
                     request.finish()
                     return
 
-            try:
-                res = self.sydent.threepidBinder.removeBinding(threepid, mxid)
-            except ValueError:
-                # User could have provided correct 3PID/sid/client_secret
-                # details but not the correct mxid, which would cause the
-                # binding removal to fail
-                request.setResponseCode(400)
-                request.write(json.dumps({'errcode': 'M_UNKNOWN', 'error': "Association between provided mxid and 3pid not found"}))
-                request.finish()
-                return
+            res = self.sydent.threepidBinder.removeBinding(threepid, mxid)
 
             request.write(json.dumps({}))
             request.finish()


### PR DESCRIPTION
This makes the request idempotent. Also add a comment saying why
it's not throwing