### PR TITLE
Have 'mappings' contain medium as well as address

### DIFF
--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -104,7 +104,8 @@ class LookupV2Servlet(Resource):
             medium_address_mxid_tuples = self.globalAssociationStore.getMxids(medium_address_tuples)
 
             # Return a dictionary of lookup_string: mxid values
-            return {'mappings': {x[1]: x[2] for x in medium_address_mxid_tuples}}
+            return {'mappings': {
+                        "%s %s" % (x[1], x[0]): x[2] for x in medium_address_mxid_tuples}}
 
         elif algorithm == "sha256":
             # Lookup using SHA256 with URL-safe base64 encoding

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -104,8 +104,8 @@ class LookupV2Servlet(Resource):
             medium_address_mxid_tuples = self.globalAssociationStore.getMxids(medium_address_tuples)
 
             # Return a dictionary of lookup_string: mxid values
-            return {'mappings': {
-                        "%s %s" % (x[1], x[0]): x[2] for x in medium_address_mxid_tuples}}
+            return {'mappings': {"%s %s" % (x[1], x[0]): x[2]
+                                 for x in medium_address_mxid_tuples}}
 
         elif algorithm == "sha256":
             # Lookup using SHA256 with URL-safe base64 encoding


### PR DESCRIPTION
[MSC2134](https://github.com/matrix-org/matrix-doc/pull/2134) states that the response when using the `none` algorithm should contain a `mappings` dict with keys that contain `"<address> <medium>"`. PR #184 contained only `"<address>"`. This fixes that.