### PR TITLE
Throw exception on bad args & catch in wrapper

### DIFF
--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -72,8 +72,7 @@ def get_args(request, required_args):
         if a not in args:
             missing.append(a)
 
-    @functools.wraps(f)
-    def inner(*args, **kwargs):
+    if len(missing) > 0:
         request.setResponseCode(400)
         msg = "Missing parameters: "+(",".join(missing))
         raise MatrixRestError(400, 'M_MISSING_PARAMS', msg)
@@ -81,6 +80,7 @@ def get_args(request, required_args):
     return args
 
 def jsonwrap(f):
+    @functools.wraps(f)
     def inner(*args, **kwargs):
         try:
             return json.dumps(f(*args, **kwargs)).encode("UTF-8")

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -17,6 +17,7 @@
 import logging
 import json
 import copy
+import functools
 
 
 logger = logging.getLogger(__name__)
@@ -81,11 +82,10 @@ def get_args(request, required_args):
 
 def jsonwrap(f):
     @functools.wraps(f)
-    def inner(*args, **kwargs):
+    def inner(self, request, *args, **kwargs):
         try:
-            return json.dumps(f(*args, **kwargs)).encode("UTF-8")
+            return json.dumps(f(self, request, *args, **kwargs)).encode("UTF-8")
         except MatrixRestError as e:
-            request = args[1]
             request.setResponseCode(e.httpStatus)
             return json.dumps({
                 "errcode": e.errcode,
@@ -93,7 +93,6 @@ def jsonwrap(f):
             })
         except Exception:
             logger.exception("Exception processing request");
-            request = args[1]
             request.setResponseCode(500)
             return json.dumps({
                 "errcode": "M_UNKNOWN",

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -14,11 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import json
 import copy
 
 
+logger = logging.getLogger(__name__)
+
+
 class MatrixRestError(Exception):
+    """
+    Handled by the jsonwrap wrapper. Any servlets that don't use this
+    wrapper should catch this exception themselves.
+    """
     def __init__(self, httpStatus, errcode, error):
         super(Exception, self).__init__(error)
         self.httpStatus = httpStatus
@@ -81,6 +89,14 @@ def jsonwrap(f):
             return json.dumps({
                 "errcode": e.errcode,
                 "error": e.error,
+            })
+        except Exception:
+            logger.exception("Exception processing request");
+            request = args[1]
+            request.setResponseCode(500)
+            return json.dumps({
+                "errcode": "M_UNKNOWN",
+                "error": "Internal Server Error",
             })
     return inner
 

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -72,7 +72,8 @@ def get_args(request, required_args):
         if a not in args:
             missing.append(a)
 
-    if len(missing) > 0:
+    @functools.wraps(f)
+    def inner(*args, **kwargs):
         request.setResponseCode(400)
         msg = "Missing parameters: "+(",".join(missing))
         raise MatrixRestError(400, 'M_MISSING_PARAMS', msg)

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -16,7 +16,7 @@
 
 from twisted.web.resource import Resource
 
-from sydent.http.servlets import get_args, jsonwrap, send_cors
+from sydent.http.servlets import get_args, jsonwrap, send_cors, MatrixRestError
 
 
 class AuthenticatedBindThreePidServlet(Resource):
@@ -31,9 +31,8 @@ class AuthenticatedBindThreePidServlet(Resource):
     @jsonwrap
     def render_POST(self, request):
         send_cors(request)
-        err, args = get_args(request, ('medium', 'address', 'mxid'))
-        if err:
-            return err
+        args = get_args(request, ('medium', 'address', 'mxid'))
+
         return self.sydent.threepidBinder.addBinding(
             args['medium'], args['address'], args['mxid'],
         )

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -19,7 +19,7 @@ import json
 import signedjson.key
 import signedjson.sign
 from sydent.db.invite_tokens import JoinTokenStore
-from sydent.http.servlets import get_args, jsonwrap, send_cors
+from sydent.http.servlets import get_args, jsonwrap, send_cors, MatrixRestError
 
 
 class BlindlySignStuffServlet(Resource):
@@ -29,11 +29,11 @@ class BlindlySignStuffServlet(Resource):
         self.server_name = syd.server_name
         self.tokenStore = JoinTokenStore(syd)
 
+    @jsonwrap
     def render_POST(self, request):
         send_cors(request)
-        err, args = get_args(request, ("private_key", "token", "mxid"))
-        if err:
-            return json.dumps(err)
+
+        args = get_args(request, ("private_key", "token", "mxid"))
 
         private_key_base64 = args['private_key']
         token = args['token']
@@ -41,11 +41,7 @@ class BlindlySignStuffServlet(Resource):
 
         sender = self.tokenStore.getSenderForToken(token)
         if sender is None:
-            request.setResponseCode(404)
-            return json.dumps({
-                "errcode": "M_UNRECOGNIZED",
-                "error": "Didn't recognize token",
-            })
+            raise MatrixRestError(404, "M_UNRECOGNIZED", "Didn't recognize token")
 
         to_sign = {
             "mxid": mxid,
@@ -64,11 +60,10 @@ class BlindlySignStuffServlet(Resource):
                 private_key
             )
         except:
-            return json.dumps({
-                "errcode": "M_UNKNOWN",
-            })
+            logger.exception("signing failed")
+            raise MatrixRestError(500, "M_UNKNOWN", "Internal Server Error")
 
-        return json.dumps(signed)
+        return signed
 
     @jsonwrap
     def render_OPTIONS(self, request):

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -33,10 +33,7 @@ class EmailRequestCodeServlet(Resource):
     def render_POST(self, request):
         send_cors(request)
 
-        error, args = get_args(request, ('email', 'client_secret', 'send_attempt'))
-        if error:
-            request.setResponseCode(400)
-            return error
+        args = get_args(request, ('email', 'client_secret', 'send_attempt'))
 
         email = args['email']
         clientSecret = args['client_secret']
@@ -80,8 +77,12 @@ class EmailValidateCodeServlet(Resource):
         self.sydent = syd
 
     def render_GET(self, request):
-        resp = self.do_validate_request(request)
-        if 'success' in resp and resp['success']:
+        resp = None
+        try:
+            resp = self.do_validate_request(request)
+        except:
+            pass
+        if resp and 'success' in resp and resp['success']:
             msg = "Verification successful! Please return to your Matrix client to continue."
             if 'nextLink' in request.args:
                 next_link = request.args['nextLink'][0]
@@ -103,9 +104,7 @@ class EmailValidateCodeServlet(Resource):
     def do_validate_request(self, request):
         send_cors(request)
 
-        err, args = get_args(request, ('token', 'sid', 'client_secret'))
-        if err:
-            return err
+        args = get_args(request, ('token', 'sid', 'client_secret'))
 
         sid = args['sid']
         tokenString = args['token']

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -31,9 +31,7 @@ class GetValidated3pidServlet(Resource):
 
     @jsonwrap
     def render_GET(self, request):
-        err, args = get_args(request, ('sid', 'client_secret'))
-        if err:
-            return err
+        args = get_args(request, ('sid', 'client_secret'))
 
         sid = args['sid']
         clientSecret = args['client_secret']

--- a/sydent/http/servlets/hashdetailsservlet.py
+++ b/sydent/http/servlets/hashdetailsservlet.py
@@ -36,6 +36,7 @@ class HashDetailsServlet(Resource):
         self.sydent = syd
         self.lookup_pepper = lookup_pepper
 
+    @jsonwrap
     def render_GET(self, request):
         """
         Return the hashing algorithms and pepper that this IS supports. The
@@ -48,12 +49,12 @@ class HashDetailsServlet(Resource):
                  information before hashing.
         """
         send_cors(request)
-        
+
         request.setResponseCode(200)
-        return json.dumps({
+        return {
             "algorithms": self.known_algorithms,
             "lookup_pepper": self.lookup_pepper,
-        })
+        }
 
     @jsonwrap
     def render_OPTIONS(self, request):

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2014,2017 OpenMarket Ltd
+# Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +22,7 @@ import logging
 import json
 import signedjson.sign
 
-from sydent.http.servlets import get_args, jsonwrap, send_cors
+from sydent.http.servlets import get_args, jsonwrap, send_cors, MatrixRestError
 
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,7 @@ class LookupServlet(Resource):
     def __init__(self, syd):
         self.sydent = syd
 
+    @jsonwrap
     def render_GET(self, request):
         """
         Look up an individual threepid.
@@ -44,9 +46,8 @@ class LookupServlet(Resource):
         Returns: A signed association if the threepid has a corresponding mxid, otherwise the empty object.
         """
         send_cors(request)
-        err, args = get_args(request, ('medium', 'address'))
-        if err:
-            return json.dumps(err)
+
+        args = get_args(request, ('medium', 'address'))
 
         medium = args['medium']
         address = args['address']
@@ -56,7 +57,7 @@ class LookupServlet(Resource):
         sgassoc = globalAssocStore.signedAssociationStringForThreepid(medium, address)
 
         if not sgassoc:
-            return json.dumps({})
+            return {}
 
         sgassoc = json.loads(sgassoc.encode('utf8'))
         if not self.sydent.server_name in sgassoc['signatures']:
@@ -82,8 +83,9 @@ class LookupServlet(Resource):
                 self.sydent.server_name,
                 self.sydent.keyring.ed25519
             )
-        return json.dumps(sgassoc)
+        return sgassoc
 
+    @jsonwrap
     def render_POST(self, request):
         """
         Bulk-lookup for threepids.
@@ -94,9 +96,8 @@ class LookupServlet(Resource):
         Threepids for which no mapping is found are omitted.
         """
         send_cors(request)
-        err, args = get_args(request, ('threepids',))
-        if err:
-            return json.dumps(err)
+
+        args = get_args(request, ('threepids',))
 
         threepids = args['threepids']
         if not isinstance(threepids, list):

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -60,9 +60,7 @@ class LookupV2Servlet(Resource):
         """
         send_cors(request)
 
-        err, args = get_args(request, ('addresses', 'algorithm', 'pepper'))
-        if err:
-            return err
+        args = get_args(request, ('addresses', 'algorithm', 'pepper'))
 
         addresses = args['addresses']
         if not isinstance(addresses, list):

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -39,10 +39,7 @@ class MsisdnRequestCodeServlet(Resource):
     def render_POST(self, request):
         send_cors(request)
 
-        error, args = get_args(request, ('phone_number', 'country', 'client_secret', 'send_attempt'))
-        if error:
-            request.setResponseCode(400)
-            return error
+        args = get_args(request, ('phone_number', 'country', 'client_secret', 'send_attempt'))
 
         raw_phone_number = args['phone_number']
         country = args['country']
@@ -128,9 +125,7 @@ class MsisdnValidateCodeServlet(Resource):
     def render_POST(self, request):
         send_cors(request)
 
-        err, args = get_args(request, ('token', 'sid', 'client_secret'))
-        if err:
-            return err
+        args = get_args(request, ('token', 'sid', 'client_secret'))
 
         return self.do_validate_request(args)
 

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -18,7 +18,7 @@ from unpaddedbase64 import encode_base64
 
 import json
 from sydent.db.invite_tokens import JoinTokenStore
-from sydent.http.servlets import get_args
+from sydent.http.servlets import get_args, jsonwrap
 
 
 class Ed25519Servlet(Resource):
@@ -39,15 +39,14 @@ class PubkeyIsValidServlet(Resource):
     def __init__(self, syd):
         self.sydent = syd
 
+    @jsonwrap
     def render_GET(self, request):
-        err, args = get_args(request, ("public_key",))
-        if err:
-            return json.dumps(err)
+        args = get_args(request, ("public_key",))
 
         pubKey = self.sydent.keyring.ed25519.verify_key
         pubKeyBase64 = encode_base64(pubKey.encode())
 
-        return json.dumps({'valid': args["public_key"] == pubKeyBase64})
+        return {'valid': args["public_key"] == pubKeyBase64}
 
 
 class EphemeralPubkeyIsValidServlet(Resource):
@@ -56,12 +55,11 @@ class EphemeralPubkeyIsValidServlet(Resource):
     def __init__(self, syd):
         self.joinTokenStore = JoinTokenStore(syd)
 
+    @jsonwrap
     def render_GET(self, request):
-        err, args = get_args(request, ("public_key",))
-        if err:
-            return json.dumps(err)
+        args = get_args(request, ("public_key",))
         publicKey = args["public_key"]
 
-        return json.dumps({
+        return {
             'valid': self.joinTokenStore.validateEphemeralPublicKey(publicKey),
-        })
+        }

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -26,7 +26,7 @@ import json
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.db.threepid_associations import GlobalAssociationStore
 
-from sydent.http.servlets import get_args, send_cors
+from sydent.http.servlets import get_args, send_cors, jsonwrap
 from sydent.util.emailutils import sendEmail
 
 
@@ -35,11 +35,11 @@ class StoreInviteServlet(Resource):
         self.sydent = syd
         self.random = random.SystemRandom()
 
+    @jsonwrap
     def render_POST(self, request):
         send_cors(request)
-        err, args = get_args(request, ("medium", "address", "room_id", "sender",))
-        if err:
-            return json.dumps(err)
+
+        args = get_args(request, ("medium", "address", "room_id", "sender",))
         medium = args["medium"]
         address = args["address"]
         roomId = args["room_id"]
@@ -49,18 +49,18 @@ class StoreInviteServlet(Resource):
         mxid = globalAssocStore.getMxid(medium, address)
         if mxid:
             request.setResponseCode(400)
-            return json.dumps({
+            return {
                 "errcode": "THREEPID_IN_USE",
                 "error": "Binding already known",
                 "mxid": mxid,
-            })
+            }
 
         if medium != "email":
             request.setResponseCode(400)
-            return json.dumps({
+            return {
                 "errcode": "M_UNRECOGNIZED",
                 "error": "Didn't understand medium '%s'" % (medium,),
-            })
+            }
 
         token = self._randomString(128)
 
@@ -125,7 +125,7 @@ class StoreInviteServlet(Resource):
             "display_name": self.redact(address),
         }
 
-        return json.dumps(resp)
+        return resp
 
     def redact(self, address):
         return "@".join(map(self._redact, address.split("@", 1)))

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -28,9 +28,8 @@ class ThreePidBindServlet(Resource):
     @jsonwrap
     def render_POST(self, request):
         send_cors(request)
-        err, args = get_args(request, ('sid', 'client_secret', 'mxid'))
-        if err:
-            return err
+
+        args = get_args(request, ('sid', 'client_secret', 'mxid'))
 
         sid = args['sid']
         mxid = args['mxid']


### PR DESCRIPTION
Extends the jsonwrap wrapper so it catches errors and returns
approrpiate responses. Have get_args throw an suitable error that
the wrapper can catch.