### PR TITLE
Return algorithm, lookup_pepper in M_INVALID_PEPPER response

### DIFF
--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -79,7 +79,7 @@ class LookupV2Servlet(Resource):
             request.setResponseCode(400)
             return {
                 'errcode': 'M_INVALID_PEPPER',
-                'error': "pepper does not match '%s'" % self.lookup_pepper,
+                'error': "pepper does not match '%s'" % (self.lookup_pepper,),
                 'algorithm': algorithm,
                 'lookup_pepper': self.lookup_pepper,
             }

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -77,8 +77,12 @@ class LookupV2Servlet(Resource):
         pepper = str(args['pepper'])
         if pepper != self.lookup_pepper:
             request.setResponseCode(400)
-            return {'errcode': 'M_INVALID_PEPPER', 'error': "pepper does not match '%s'" %
-                                                            self.lookup_pepper}
+            return {
+                'errcode': 'M_INVALID_PEPPER',
+                'error': "pepper does not match '%s'" % self.lookup_pepper,
+                'algorithm': algorithm,
+                'lookup_pepper': self.lookup_pepper,
+            }
 
         logger.info("Lookup of %d threepid(s) with algorithm %s", len(addresses), algorithm)
         if algorithm == "none":


### PR DESCRIPTION
MSC2134 [states](https://github.com/matrix-org/matrix-doc/pull/2134/files#diff-307ccba639fd62a74c00c27834c7eca5R168) that the `M_INVALID_PEPPER` response should include the used algorithm and the correct server pepper. The initial implementation did not do this, and just returned an error code and message.

This PR adds in the algorithm and correct pepper.