### PR TITLE
Fix content types & OPTIONS requests

### DIFF
--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -96,6 +96,7 @@ def jsonwrap(f):
     @functools.wraps(f)
     def inner(self, request, *args, **kwargs):
         try:
+            request.setHeader("Content-Type", "application/json")
             return json.dumps(f(self, request, *args, **kwargs)).encode("UTF-8")
         except MatrixRestError as e:
             request.setResponseCode(e.httpStatus)
@@ -138,7 +139,6 @@ def deferjsonwrap(f):
     return inner
 
 def send_cors(request):
-    request.setHeader(b"Content-Type", b"application/json")
     request.setHeader("Access-Control-Allow-Origin", "*")
     request.setHeader("Access-Control-Allow-Methods",
                       "GET, POST, PUT, DELETE, OPTIONS")

--- a/sydent/http/servlets/accountservlet.py
+++ b/sydent/http/servlets/accountservlet.py
@@ -42,9 +42,8 @@ class AccountServlet(Resource):
             "user_id": account.userId,
         }
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''
 

--- a/sydent/http/servlets/accountservlet.py
+++ b/sydent/http/servlets/accountservlet.py
@@ -45,5 +45,5 @@ class AccountServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''
 

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -40,4 +40,4 @@ class AuthenticatedBindThreePidServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -37,8 +37,7 @@ class AuthenticatedBindThreePidServlet(Resource):
             args['medium'], args['address'], args['mxid'],
         )
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -72,4 +72,4 @@ class BlindlySignStuffServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -69,8 +69,7 @@ class BlindlySignStuffServlet(Resource):
 
         return signed
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -62,8 +62,7 @@ class BulkLookupServlet(Resource):
         return { 'threepids': results }
 
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -65,4 +65,4 @@ class BulkLookupServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -66,11 +66,10 @@ class EmailRequestCodeServlet(Resource):
 
         return resp
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''
 
 
 class EmailValidateCodeServlet(Resource):
@@ -129,8 +128,7 @@ class EmailValidateCodeServlet(Resource):
 
         return resp
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -69,7 +69,7 @@ class EmailRequestCodeServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''
 
 
 class EmailValidateCodeServlet(Resource):
@@ -131,4 +131,4 @@ class EmailValidateCodeServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/hashdetailsservlet.py
+++ b/sydent/http/servlets/hashdetailsservlet.py
@@ -62,4 +62,4 @@ class HashDetailsServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/hashdetailsservlet.py
+++ b/sydent/http/servlets/hashdetailsservlet.py
@@ -59,8 +59,7 @@ class HashDetailsServlet(Resource):
             "lookup_pepper": self.lookup_pepper,
         }
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -50,5 +50,5 @@ class LogoutServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''
 

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -47,9 +47,8 @@ class LogoutServlet(Resource):
         accountStore.delToken(token)
         return {}
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''
 

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -117,8 +117,7 @@ class LookupServlet(Resource):
         return json.dumps(results)
          
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -120,4 +120,4 @@ class LookupServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -128,4 +128,4 @@ class LookupV2Servlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -125,8 +125,7 @@ class LookupV2Servlet(Resource):
         request.setResponseCode(400)
         return {'errcode': 'M_INVALID_PARAM', 'error': 'algorithm is not supported'}
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -92,7 +92,7 @@ class MsisdnRequestCodeServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''
 
 
 class MsisdnValidateCodeServlet(Resource):
@@ -155,4 +155,4 @@ class MsisdnValidateCodeServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -89,11 +89,10 @@ class MsisdnRequestCodeServlet(Resource):
 
         return resp
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''
 
 
 class MsisdnValidateCodeServlet(Resource):
@@ -153,8 +152,7 @@ class MsisdnValidateCodeServlet(Resource):
 
         return resp
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -61,9 +61,7 @@ class RegisterServlet(Resource):
             "access_token": tok,
         })
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
-
+        return ''

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -64,4 +64,4 @@ class RegisterServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -79,9 +79,8 @@ class TermsServlet(Resource):
 
         return {}
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''
 

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -82,5 +82,5 @@ class TermsServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''
 

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -66,8 +66,7 @@ class ThreePidBindServlet(Resource):
         res = self.sydent.threepidBinder.addBinding(s.medium, s.address, mxid)
         return res
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -69,4 +69,4 @@ class ThreePidBindServlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/v1_servlet.py
+++ b/sydent/http/servlets/v1_servlet.py
@@ -33,8 +33,7 @@ class V1Servlet(Resource):
         request.setResponseCode(200)
         return {}
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''

--- a/sydent/http/servlets/v1_servlet.py
+++ b/sydent/http/servlets/v1_servlet.py
@@ -36,4 +36,4 @@ class V1Servlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/v2_servlet.py
+++ b/sydent/http/servlets/v2_servlet.py
@@ -35,4 +35,4 @@ class V2Servlet(Resource):
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return ''
+        return b''

--- a/sydent/http/servlets/v2_servlet.py
+++ b/sydent/http/servlets/v2_servlet.py
@@ -32,8 +32,7 @@ class V2Servlet(Resource):
         request.setResponseCode(200)
         return {}
 
-    @jsonwrap
     def render_OPTIONS(self, request):
         send_cors(request)
         request.setResponseCode(200)
-        return {}
+        return ''


### PR DESCRIPTION
Don't set content type in send_cors, that is not a sensible place.
Set it in jsonwrap instead which everything now uses.

Also don't jsonwrap OPTIONS requests or return empty json dicts
because there's no need to return content from an OPTIONS (although
we can do so return the empty string)