### PR TITLE
Revert "Allow for custom urls in email templates"

### DIFF
--- a/res/invite_template.eml
+++ b/res/invite_template.eml
@@ -18,7 +18,7 @@ Matrix. To join the conversation, either pick a Matrix client from
 https://matrix.org/docs/projects/try-matrix-now.html or use the single-click
 link below to join via Riot (requires Chrome, Firefox, Safari, iOS or Android)
 
-%(client_base_url)s/#/room/%(room_id_forurl)s?email=%(to_forurl)s&signurl=https%%3A%%2F%%2Fmatrix.org%%2F_matrix%%2Fidentity%%2Fapi%%2Fv1%%2Fsign-ed25519%%3Ftoken%%3D%(token)s%%26private_key%%3D%(ephemeral_private_key)s&room_name=%(room_name_forurl)s&room_avatar_url=%(room_avatar_url_forurl)s&inviter_name=%(sender_display_name_forurl)s&guest_access_token=%(guest_access_token_forurl)s&guest_user_id=%(guest_user_id_forurl)s
+https://riot.im/app/#/room/%(room_id_forurl)s?email=%(to_forurl)s&signurl=https%%3A%%2F%%2Fmatrix.org%%2F_matrix%%2Fidentity%%2Fapi%%2Fv1%%2Fsign-ed25519%%3Ftoken%%3D%(token)s%%26private_key%%3D%(ephemeral_private_key)s&room_name=%(room_name_forurl)s&room_avatar_url=%(room_avatar_url_forurl)s&inviter_name=%(sender_display_name_forurl)s&guest_access_token=%(guest_access_token_forurl)s&guest_user_id=%(guest_user_id_forurl)s
 
 
 About Matrix:
@@ -113,7 +113,7 @@ or iOS or Android on mobile.)</p>
 
 <p>
     <a
-    href="%(client_base_url)s/#/room/%(room_id_forurl)s?email=%(to_forurl)s&signurl=https%%3A%%2F%%2Fmatrix.org%%2F_matrix%%2Fidentity%%2Fapi%%2Fv1%%2Fsign-ed25519%%3Ftoken%%3D%(token)s%%26private_key%%3D%(ephemeral_private_key)s&room_name=%(room_name_forurl)s&room_avatar_url=%(room_avatar_url_forurl)s&inviter_name=%(sender_display_name_forurl)s&guest_access_token=%(guest_access_token_forurl)s&guest_user_id=%(guest_user_id_forurl)s">Join the conversation.</a>
+    href="https://riot.im/app/#/room/%(room_id_forurl)s?email=%(to_forurl)s&signurl=https%%3A%%2F%%2Fmatrix.org%%2F_matrix%%2Fidentity%%2Fapi%%2Fv1%%2Fsign-ed25519%%3Ftoken%%3D%(token)s%%26private_key%%3D%(ephemeral_private_key)s&room_name=%(room_name_forurl)s&room_avatar_url=%(room_avatar_url_forurl)s&inviter_name=%(sender_display_name_forurl)s&guest_access_token=%(guest_access_token_forurl)s&guest_user_id=%(guest_user_id_forurl)s">Join the conversation.</a>
 </p>
 
 <br>

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -108,7 +108,6 @@ CONFIG_DEFAULTS = {
         'email.template': 'res/email.template',
         'email.from': 'Sydent Validation <noreply@{hostname}>',
         'email.subject': 'Your Validation Token',
-        'email.client_base_url': 'https://riot.im/app',
         'email.invite.subject': '%(sender_display_name)s has invited you to chat',
         'email.smtphost': 'localhost',
         'email.smtpport': '25',

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -36,7 +36,6 @@ def sendEmail(sydent, templateName, mailTo, substitutions):
         mailTemplateFile = sydent.cfg.get('email', templateName)
 
         myHostname = sydent.cfg.get('email', 'email.hostname')
-        clientBaseUrl = sydent.cfg.get('email', 'email.client_base_url', fallback='https://riot.im/app')
         if myHostname == '':
             myHostname = socket.getfqdn()
         midRandom = "".join([random.choice(string.ascii_letters) for _ in range(16)])
@@ -49,7 +48,6 @@ def sendEmail(sydent, templateName, mailTo, substitutions):
             'date': email.utils.formatdate(localtime=False),
             'to': mailTo,
             'from': mailFrom,
-            'client_base_url': clientBaseUrl
         })
 
         for k,v in allSubstitutions.items():


### PR DESCRIPTION
Reverts matrix-org/sydent#210

Turns out the email templates are designed to be replaced for one's own needs rather than customizing the default one with more variables. Simply replace the template with one that contains your desired client base URL.

We're aware that how to handle email templates are currently not documented (which confused even myself), and plan to rectify that.

The PR also made use of some Python 3-isms while Sydent is currently Python 2-only.