### PR TITLE
Fix optional 3PID invite expiration feature

### DIFF
--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -43,9 +43,6 @@ class JoinTokenStore(object):
         :param originId: The id of the token in the DB of originServer. Used
         for determining if we've already received a token or not.
         :type originId: int, None
-        :param valid_until_ts: The expiration date to set to this invite on this server.
-            This value is not replicated. None if invites are always valid.
-        :type valid_until_ts: int
         :param commit: Whether DB changes should be committed by this
             function (or an external one).
         :type commit: bool

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -90,8 +90,7 @@ class JoinTokenStore(object):
 
         validity_period = self.sydent.invites_validity_period
         if validity_period is not None:
-            now_ms = int(time.time() * 1000)
-            min_valid_ts_ms = now_ms - validity_period
+            min_valid_ts_ms = int(time.time() - validity_period/1000)
 
         for row in rows:
             medium, address, roomId, sender, token, origin_server, received_ts = row

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -165,17 +165,11 @@ class ReplicationPushServlet(Resource):
             request.finish()
             return
 
-        now_ms = int(time.time() * 1000)
-        if self.sydent.invites_validity_period is not None:
-            valid_until_ts = now_ms + self.sydent.invites_validity_period
-        else:
-            valid_until_ts = None
-
         for originId, inviteToken in invite_tokens.items():
             tokensStore.storeToken(inviteToken['medium'], inviteToken['address'], inviteToken['room_id'],
                                 inviteToken['sender'], inviteToken['token'],
                                 originServer=peer.servername, originId=originId,
-                                valid_until_ts=valid_until_ts, commit=False)
+                                commit=False)
             logger.info("Stored invite token with origin ID %s from %s", originId, peer.servername)
 
         # Process any ephemeral public keys

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -72,17 +72,8 @@ class StoreInviteServlet(Resource):
         ephemeralPrivateKeyBase64 = encode_base64(ephemeralPrivateKey.encode(), True)
         ephemeralPublicKeyBase64 = encode_base64(ephemeralPublicKey.encode(), True)
 
-        now_ms = int(time.time() * 1000)
-        if self.sydent.invites_validity_period is not None:
-            valid_until_ts = now_ms + self.sydent.invites_validity_period
-        else:
-            valid_until_ts = None
-
         tokenStore.storeEphemeralPublicKey(ephemeralPublicKeyBase64)
-        tokenStore.storeToken(
-            medium, address, roomId, sender, token,
-            valid_until_ts=valid_until_ts,
-        )
+        tokenStore.storeToken(medium, address, roomId, sender, token)
 
         substitutions = {}
         for key, values in request.args.items():


### PR DESCRIPTION
The current feature, as implemented in #166, is unnecessarily complicated and lacks backward compatibility, as it uses a new database column which isn't filled for previous entries.

Instead, this PR changes it to use the existing `received_ts` column which should always contain the timestamp at which the invite was received on the server.

Notes to reviewer:

* this leaves us with an unused column `valid_until_ts` that we might want to get rid of. As far as I'm aware, the only way to do this is to create a new table without the column, migrate all of the data to it, then drop the previous table and rename the new one. Although this is something we can technically do in the schema upgrade code, I don't know if that's something we _want_ to do given it can get quite expensive and take quite a long time if the table has a lot of pending invites, and I'm not sure how much we would value the removal of the unused column.
* the CI is failing because the DINSIC Sydent is based on a version of Sydent that predates the sprint that happened around it in the past months. The fix would be to merge mainline back into the `dinsic` branch, but I'd prefer we do that later, once we have a better idea of how we want to handle the new privacy changes in the Tchap infra. Therefore I'd suggest ignoring the `matrix_is_tester` failure on this PR.