### PR TITLE
Change lookup_hash index from medium to mxid

### DIFF
--- a/sydent/db/invite_tokens.sql
+++ b/sydent/db/invite_tokens.sql
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+-- Note that this SQL file is not up to date, and migrations can be found in sydent/db/sqlitedb.py
+
 CREATE TABLE IF NOT EXISTS invite_tokens (
     id integer primary key,
     medium varchar(16) not null,

--- a/sydent/db/peers.sql
+++ b/sydent/db/peers.sql
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+-- Note that this SQL file is not up to date, and migrations can be found in sydent/db/sqlitedb.py
+
 CREATE TABLE IF NOT EXISTS peers (id integer primary key, name varchar(255) not null, port integer default null, lastSentVersion integer, lastPokeSucceededAt integer, active integer not null default 0);
 CREATE UNIQUE INDEX IF NOT EXISTS name on peers(name);
 

--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -186,6 +186,15 @@ class SqliteDatabase:
             logger.info("v3 -> v4 schema migration complete")
             self._setSchemaVersion(4)
 
+        if curVer < 5:
+            # Fix lookup_hash index for selecting on mxid instead of medium
+            cur = self.db.cursor()
+            cur.execute("DROP INDEX lookup_hash_medium")
+            cur.execute("CREATE UNIQUE INDEX lookup_hash_mxid ON global_threepid_associations(lookup_hash, mxid)")
+            self.db.commit()
+            logger.info("v4 -> v5 schema migration complete")
+            self._setSchemaVersion(5)
+
     def _getSchemaVersion(self):
         cur = self.db.cursor()
         res = cur.execute("PRAGMA user_version");

--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -150,11 +150,6 @@ class SqliteDatabase:
                 "ADD COLUMN lookup_hash VARCHAR(256)"
             )
             cur.execute(
-                "CREATE INDEX IF NOT EXISTS lookup_hash_medium "
-                "on local_threepid_associations "
-                "(lookup_hash, medium)"
-            )
-            cur.execute(
                 "ALTER TABLE global_threepid_associations "
                 "ADD COLUMN lookup_hash VARCHAR(256)"
             )
@@ -189,7 +184,7 @@ class SqliteDatabase:
         if curVer < 5:
             # Fix lookup_hash index for selecting on mxid instead of medium
             cur = self.db.cursor()
-            cur.execute("DROP INDEX lookup_hash_medium")
+            cur.execute("DROP INDEX IF EXITS lookup_hash_medium")
             cur.execute("CREATE INDEX global_threepid_lookup_hash ON global_threepid_associations(lookup_hash)")
             self.db.commit()
             logger.info("v4 -> v5 schema migration complete")

--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -190,7 +190,7 @@ class SqliteDatabase:
             # Fix lookup_hash index for selecting on mxid instead of medium
             cur = self.db.cursor()
             cur.execute("DROP INDEX lookup_hash_medium")
-            cur.execute("CREATE UNIQUE INDEX lookup_hash_mxid ON global_threepid_associations(lookup_hash, mxid)")
+            cur.execute("CREATE INDEX global_threepid_lookup_hash ON global_threepid_associations(lookup_hash)")
             self.db.commit()
             logger.info("v4 -> v5 schema migration complete")
             self._setSchemaVersion(5)

--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -184,7 +184,7 @@ class SqliteDatabase:
         if curVer < 5:
             # Fix lookup_hash index for selecting on mxid instead of medium
             cur = self.db.cursor()
-            cur.execute("DROP INDEX IF EXITS lookup_hash_medium")
+            cur.execute("DROP INDEX IF EXISTS lookup_hash_medium")
             cur.execute("CREATE INDEX global_threepid_lookup_hash ON global_threepid_associations(lookup_hash)")
             self.db.commit()
             logger.info("v4 -> v5 schema migration complete")

--- a/sydent/db/threepid_associations.sql
+++ b/sydent/db/threepid_associations.sql
@@ -14,24 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+-- Note that this SQL file is not up to date, and migrations can be found in sydent/db/sqlitedb.py
+
 CREATE TABLE IF NOT EXISTS local_threepid_associations (
     id integer primary key,
     medium varchar(16) not null,
     address varchar(256) not null,
-    lookup_hash varchar,
     mxid varchar(256) not null,
     ts integer not null,
     notBefore bigint not null,
     notAfter bigint not null
 );
-CREATE INDEX IF NOT EXISTS lookup_hash_medium on local_threepid_associations (lookup_hash, medium);
 CREATE UNIQUE INDEX IF NOT EXISTS medium_address on local_threepid_associations(medium, address);
 
 CREATE TABLE IF NOT EXISTS global_threepid_associations (
     id integer primary key,
     medium varchar(16) not null,
     address varchar(256) not null,
-    lookup_hash varchar,
     mxid varchar(256) not null,
     ts integer not null,
     notBefore bigint not null,
@@ -40,7 +39,6 @@ CREATE TABLE IF NOT EXISTS global_threepid_associations (
     originId integer not null,
     sgAssoc text not null
 );
-CREATE INDEX IF NOT EXISTS lookup_hash_medium on global_threepid_associations (lookup_hash, medium);
 CREATE INDEX IF NOT EXISTS medium_address on global_threepid_associations (medium, address);
 CREATE INDEX IF NOT EXISTS medium_lower_address on global_threepid_associations (medium, lower(address));
 CREATE UNIQUE INDEX IF NOT EXISTS originServer_originId on global_threepid_associations (originServer, originId);

--- a/sydent/db/threepid_associations.sql
+++ b/sydent/db/threepid_associations.sql
@@ -25,7 +25,6 @@ CREATE TABLE IF NOT EXISTS local_threepid_associations (
     notBefore bigint not null,
     notAfter bigint not null
 );
-CREATE UNIQUE INDEX IF NOT EXISTS medium_address on local_threepid_associations(medium, address);
 
 CREATE TABLE IF NOT EXISTS global_threepid_associations (
     id integer primary key,
@@ -39,6 +38,4 @@ CREATE TABLE IF NOT EXISTS global_threepid_associations (
     originId integer not null,
     sgAssoc text not null
 );
-CREATE INDEX IF NOT EXISTS medium_address on global_threepid_associations (medium, address);
-CREATE INDEX IF NOT EXISTS medium_lower_address on global_threepid_associations (medium, lower(address));
 CREATE UNIQUE INDEX IF NOT EXISTS originServer_originId on global_threepid_associations (originServer, originId);

--- a/sydent/db/threepid_validation.sql
+++ b/sydent/db/threepid_validation.sql
@@ -14,5 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+-- Note that this SQL file is not up to date, and migrations can be found in sydent/db/sqlitedb.py
+
 CREATE TABLE IF NOT EXISTS threepid_validation_sessions (id integer primary key, medium varchar(16) not null, address varchar(256) not null, clientSecret varchar(32) not null, validated int default 0, mtime bigint not null);
 CREATE TABLE IF NOT EXISTS threepid_token_auths (id integer primary key, validationSession integer not null, token varchar(32) not null, sendAttemptNumber integer not null, foreign key (validationSession) references threepid_validations(id));


### PR DESCRIPTION
The lookup v2 endpoint was slow due to it not using an index. This is because the indexed column to lookup_hash was `medium`, but we select `mxid`.

Additionally, it was confusing that the `*.sql` files were not representative of the latest state (the migration files are). So, add a note in each file to reflect this and hopefully save future troubleshooter's time.