### PR TITLE
Add a default 10,000 address /lookup limit

### DIFF
--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -76,7 +76,7 @@ class LookupV2Servlet(Resource):
             return {'errcode': 'M_INVALID_PARAM', 'error': 'algorithm is not supported'}
 
         # Ensure address count is under the configured limit
-        limit = int(self.sydent.cfg.get("http", "clientapi.http.lookup_limit"))
+        limit = int(self.sydent.cfg.get("general", "address_lookup_limit"))
         if len(addresses) > limit:
             request.setResponseCode(400)
             return {'errcode': 'M_TOO_LARGE', 'error': 'More than the maximum amount of '

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -75,6 +75,13 @@ class LookupV2Servlet(Resource):
             request.setResponseCode(400)
             return {'errcode': 'M_INVALID_PARAM', 'error': 'algorithm is not supported'}
 
+        # Ensure address count is under the configured limit
+        limit = int(self.sydent.cfg.get("http", "clientapi.http.lookup_limit"))
+        if len(addresses) > limit:
+            request.setResponseCode(400)
+            return {'errcode': 'M_TOO_LARGE', 'error': 'More than the maximum amount of '
+                                                       'addresses provided'}
+
         pepper = str(args['pepper'])
         if pepper != self.lookup_pepper:
             request.setResponseCode(400)

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -80,6 +80,7 @@ CONFIG_DEFAULTS = {
         'log.level': 'INFO',
         'pidfile.path': 'sydent.pid',
         'terms.path': '',
+        'address_lookup_limit': '10000',  # Maximum amount of addresses in a single /lookup request
 
         # The following can be added to your local config file to enable prometheus
         # support.
@@ -103,7 +104,6 @@ CONFIG_DEFAULTS = {
         'replication.https.port': '4434',
         'obey_x_forwarded_for': 'False',
         'federation.verifycerts': 'True',
-        'clientapi.http.lookup_limit': '10000',  # Maximum amount of addresses in a single /lookup request
     },
     'email': {
         'email.template': 'res/email.template',

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -103,6 +103,7 @@ CONFIG_DEFAULTS = {
         'replication.https.port': '4434',
         'obey_x_forwarded_for': 'False',
         'federation.verifycerts': 'True',
+        'clientapi.http.lookup_limit': '10000',  # Maximum amount of addresses in a single /lookup request
     },
     'email': {
         'email.template': 'res/email.template',


### PR DESCRIPTION
Add a configurable limit to the amount of addresses that can be provided to /lookup.

This limit applies to all hashed and unhashed algorithms.