### PR TITLE
[DINSIC] Prevent a single failure aborting the federation loop

### DIFF
--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -127,32 +127,3 @@ class PeerStore:
             cur.execute("update peers set lastSentEphemeralKeysId = ?, lastPokeSucceededAt = ? "
                         "where name = ?", (ids["ephemeral_public_keys"], lastPokeSucceeded, peerName))
         self.sydent.db.commit()
-
-    def setLastSentIdAndPokeSucceeded(self, peerName, ids, lastPokeSucceeded):
-        """Set last successful replication of data to this peer.
-
-        If an id for a replicated database table is None, the last sent value
-        will not be updated.
-
-        :param peerName: The name of the peer.
-        :type peerName: str
-        :param ids: A Dictionary of ids that represent the last database
-            table ids that were replicated to this peer.
-        :type ids: Dict[str, int]
-        :param lastPokeSucceeded: The time of when the last successful
-            replication succeeded (even if no actual replication of data was
-            necessary).
-        :type lastPokeSucceeded: int
-        """
-
-        cur = self.sydent.db.cursor()
-        if ids["sg_assocs"]:
-            cur.execute("update peers set lastSentAssocsId = ?, lastPokeSucceededAt = ? "
-                        "where name = ?", (ids["sg_assocs"], lastPokeSucceeded, peerName))
-        if ids["invite_tokens"]:
-            cur.execute("update peers set lastSentInviteTokensId = ?, lastPokeSucceededAt = ? "
-                        "where name = ?", (ids["invite_tokens"], lastPokeSucceeded, peerName))
-        if ids["ephemeral_public_keys"]:
-            cur.execute("update peers set lastSentEphemeralKeysId = ?, lastPokeSucceededAt = ? "
-                        "where name = ?", (ids["ephemeral_public_keys"], lastPokeSucceeded, peerName))
-        self.sydent.db.commit()

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -127,3 +127,32 @@ class PeerStore:
             cur.execute("update peers set lastSentEphemeralKeysId = ?, lastPokeSucceededAt = ? "
                         "where name = ?", (ids["ephemeral_public_keys"], lastPokeSucceeded, peerName))
         self.sydent.db.commit()
+
+    def setLastSentIdAndPokeSucceeded(self, peerName, ids, lastPokeSucceeded):
+        """Set last successful replication of data to this peer.
+
+        If an id for a replicated database table is None, the last sent value
+        will not be updated.
+
+        :param peerName: The name of the peer.
+        :type peerName: str
+        :param ids: A Dictionary of ids that represent the last database
+            table ids that were replicated to this peer.
+        :type ids: Dict[str, int]
+        :param lastPokeSucceeded: The time of when the last successful
+            replication succeeded (even if no actual replication of data was
+            necessary).
+        :type lastPokeSucceeded: int
+        """
+
+        cur = self.sydent.db.cursor()
+        if ids["sg_assocs"]:
+            cur.execute("update peers set lastSentAssocsId = ?, lastPokeSucceededAt = ? "
+                        "where name = ?", (ids["sg_assocs"], lastPokeSucceeded, peerName))
+        if ids["invite_tokens"]:
+            cur.execute("update peers set lastSentInviteTokensId = ?, lastPokeSucceededAt = ? "
+                        "where name = ?", (ids["invite_tokens"], lastPokeSucceeded, peerName))
+        if ids["ephemeral_public_keys"]:
+            cur.execute("update peers set lastSentEphemeralKeysId = ?, lastPokeSucceededAt = ? "
+                        "where name = ?", (ids["ephemeral_public_keys"], lastPokeSucceeded, peerName))
+        self.sydent.db.commit()

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -71,7 +71,7 @@ class LocalAssociationStore:
             are returned.
         :type afterId: int
         :param limit: Max amount of database rows to return.
-        :type limit: int
+        :type limit: int|None
         :param shadow: Whether these associations are intended for a shadow
             server.
         :type shadow: bool

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -16,9 +16,9 @@
 
 from sydent.util import time_msec
 
-from sydent.threepid import ThreepidAssociation, threePidAssocFromDict
+from sydent.threepid import ThreepidAssociation
+from sydent.threepid.signer import Signer
 
-import json
 import logging
 
 
@@ -63,6 +63,20 @@ class LocalAssociationStore:
             maxId = row[0]
 
         return (assocs, maxId)
+
+    def getSignedAssociationsAfterId(self, afterId, limit):
+        assocs = {}
+
+        localAssocStore = LocalAssociationStore(self.sydent)
+        (localAssocs, maxId) = localAssocStore.getAssociationsAfterId(afterId, limit)
+
+        signer = Signer(self.sydent)
+
+        for localId in localAssocs:
+            sgAssoc = signer.signedThreePidAssociation(localAssocs[localId])
+            assocs[localId] = sgAssoc
+
+        return assocs, maxId
 
     def removeAssociation(self, threepid, mxid):
         cur = self.sydent.db.cursor()

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -41,6 +41,7 @@ class Peer(object):
         self.servername = servername
         self.pubkeys = pubkeys
         self.shadow = False
+        self.is_being_pushed_to = False
 
 
 class LocalPeer(Peer):

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -29,6 +29,7 @@ from sydent.db.peers import PeerStore
 
 logger = logging.getLogger(__name__)
 
+# Maximum amount of signed objects to replicate to a peer at a time
 EPHEMERAL_PUBLIC_KEYS_PUSH_LIMIT = 100
 INVITE_TOKENS_PUSH_LIMIT = 100
 ASSOCIATIONS_PUSH_LIMIT = 100

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2014 OpenMarket Ltd
+# Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +16,8 @@
 # limitations under the License.
 
 import logging
-import copy
 
+from twisted.internet import defer
 import twisted.internet.reactor
 import twisted.internet.task
 
@@ -25,7 +26,6 @@ from sydent.replication.peer import LocalPeer
 from sydent.db.threepid_associations import LocalAssociationStore
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.db.peers import PeerStore
-from sydent.threepid.signer import Signer
 
 logger = logging.getLogger(__name__)
 
@@ -33,75 +33,53 @@ EPHEMERAL_PUBLIC_KEYS_PUSH_LIMIT = 100
 INVITE_TOKENS_PUSH_LIMIT = 100
 ASSOCIATIONS_PUSH_LIMIT = 100
 
+
 class Pusher:
     def __init__(self, sydent):
         self.sydent = sydent
         self.pushing = False
         self.peerStore = PeerStore(self.sydent)
+        self.join_token_store = JoinTokenStore(self.sydent)
+        self.local_assoc_store = LocalAssociationStore(self.sydent)
 
     def setup(self):
         cb = twisted.internet.task.LoopingCall(Pusher.scheduledPush, self)
         cb.start(10.0)
 
-    def getSignedAssociationsAfterId(self, afterId, limit, shadow=False):
-        """Return max `limit` associations from the database after a given
-        DB table id.
-
-        :param afterId: A database id to act as an offset. Rows after this id
-            are returned.
-        :type afterId: int
-        :param limit: Max amount of database rows to return.
-        :type limit: int
-        :param shadow: Whether these associations are intended for a shadow
-            server.
-        :type shadow: bool
-        :returns a tuple with the first item being a dict of associations,
-            and the second being the maximum table id of the returned
-            associations.
-        :rtype: Tuple[Dict[Dict, Dict], int|None]
-        """
-        assocs = {}
-
-        localAssocStore = LocalAssociationStore(self.sydent)
-        (localAssocs, maxId) = localAssocStore.getAssociationsAfterId(afterId, limit)
-
-        signer = Signer(self.sydent)
-
-        for localId, assoc in localAssocs.items():
-            if shadow and self.sydent.shadow_hs_master and self.sydent.shadow_hs_slave:
-                # mxid is null if 3pid has been unbound
-                if assoc.mxid:
-                    assoc.mxid = assoc.mxid.replace(
-                        ":" + self.sydent.shadow_hs_master,
-                        ":" + self.sydent.shadow_hs_slave
-                    )
-
-            assocs[localId] = signer.signedThreePidAssociation(assoc)
-
-        return (assocs, maxId)
-
     def doLocalPush(self):
         """
         Synchronously push local associations to this server (ie. copy them to globals table)
-        The local server is essentially treated the same as any other peer except we don't do the
-        network round-trip and this function can be used so the association goes into the global table
-        before the http call returns (so clients know it will be available on at least the same ID server they used)
+        The local server is essentially treated the same as any other peer except we don't do
+        the network round-trip and this function can be used so the association goes into the
+        global table before the http call returns (so clients know it will be available on at
+        least the same ID server they used)
         """
         localPeer = LocalPeer(self.sydent)
 
-        (signedAssocs, _) = self.getSignedAssociationsAfterId(localPeer.lastId, None)
+        signedAssocs, _ = self.local_assoc_store.getSignedAssociationsAfterId(
+            localPeer.lastId, None
+        )
 
         localPeer.pushUpdates(signedAssocs)
 
     def scheduledPush(self):
-        """Push pending updates to a remote peer. To be called regularly."""
-        if self.pushing:
+        """Push pending updates to a remote peer. To be called regularly.
+
+        :returns deferred.DeferredList
+        """
+        peers = self.peerStore.getAllPeers()
+
+        # Push to all peers in parallel
+        return defer.DeferredList([self._push_to_peer(p) for p in peers])
+
+    @defer.inlineCallbacks
+    def _push_to_peer(self, p):
+        logger.debug("Looking for updates to push to %s", p.servername)
+
+        # Check if a push operation is already active. If so, don't start another
+        if p.is_being_pushed_to:
+            logger.debug("Waiting for %s:%d to finish pushing...", p.servername, p.port)
             return
-        self.pushing = True
-
-        updateDeferred = None
-
-        join_token_store = JoinTokenStore(self.sydent)
 
         try:
             peers = self.peerStore.getAllPeers()
@@ -112,42 +90,48 @@ class Pusher:
                 # Dictionary for holding all data to push
                 push_data = {}
 
-                # Dictionary for holding all the ids of db tables we've successfully replicated up to
+                # Dictionary for holding all the ids of db tables we've successfully replicated
                 ids = {}
                 total_updates = 0
 
                 # Push associations
-                (push_data["sg_assocs"], ids["sg_assocs"]) = self.getSignedAssociationsAfterId(p.lastSentAssocsId, ASSOCIATIONS_PUSH_LIMIT, p.shadow)
-                total_updates += len(push_data["sg_assocs"])
+                associations = self.local_assoc_store.getSignedAssociationsAfterId(
+                    p.lastSentAssocsId, ASSOCIATIONS_PUSH_LIMIT
+                )
+                push_data["sg_assocs"], ids["sg_assocs"] = associations
 
                 # Push invite tokens and ephemeral public keys
-                (push_data["invite_tokens"], ids["invite_tokens"]) = join_token_store.getInviteTokensAfterId(p.lastSentInviteTokensId, INVITE_TOKENS_PUSH_LIMIT)
-                (push_data["ephemeral_public_keys"], ids["ephemeral_public_keys"]) = join_token_store.getEphemeralPublicKeysAfterId(p.lastSentEphemeralKeysId, EPHEMERAL_PUBLIC_KEYS_PUSH_LIMIT)
-                total_updates += len(push_data["invite_tokens"]) + len(push_data["ephemeral_public_keys"])
+                tokens = self.join_token_store.getInviteTokensAfterId(
+                    p.lastSentInviteTokensId, INVITE_TOKENS_PUSH_LIMIT
+                )
+                push_data["invite_tokens"], ids["invite_tokens"] = tokens
 
-                logger.debug("%d updates to push to %s", total_updates, p.servername)
-                if total_updates:
-                    logger.info("Pushing %d updates to %s:%d", total_updates, p.servername, p.port)
-                    updateDeferred = p.pushUpdates(push_data)
-                    updateDeferred.addCallback(self._pushSucceeded, peer=p, ids=ids)
-                    updateDeferred.addErrback(self._pushFailed, peer=p)
+                keys = self.join_token_store.getEphemeralPublicKeysAfterId(
+                    p.lastSentEphemeralKeysId, EPHEMERAL_PUBLIC_KEYS_PUSH_LIMIT
+                )
+                push_data["ephemeral_public_keys"], ids["ephemeral_public_keys"] = keys
+
+                token_count = len(push_data["invite_tokens"])
+                key_count = len(push_data["ephemeral_public_keys"])
+                association_count = len(push_data["sg_assocs"])
+
+                total_updates += token_count + key_count + association_count
+
+                logger.debug(
+                    "%d updates to push to %s:%d",
+                    total_updates, p.servername, p.port
+                )
+
+                # If there are no updates left to send, break the loop
+                if not total_updates:
+                    logger.info("Pushing updates to %s:%d finished", p.servername, p.port)
                     break
+
+                yield self.peerStore.setLastSentIdAndPokeSucceeded(
+                    p.servername, ids, time_msec()
+                )
+        except Exception:
+            logger.exception("Error pushing updates to %s:%d: %r", p.servername, p.port)
         finally:
-            if not updateDeferred:
-                self.pushing = False
-
-    def _pushSucceeded(self, result, peer, ids):
-        """To be called after a successful push to a remote peer."""
-        logger.info("Pushed updates to %s with result %d %s",
-                    peer.servername, result.code, result.phrase)
-
-        self.peerStore.setLastSentIdAndPokeSucceeded(peer.servername, ids, time_msec())
-
-        self.pushing = False
-        self.scheduledPush()
-
-    def _pushFailed(self, failure, peer):
-        """To be called after an unsuccessful push to a remote peer."""
-        logger.info("Failed to push updates to %s:%s: %s", peer.servername, peer.port, failure)
-        self.pushing = False
-        return None
+            # Whether pushing completed or an error occurred, signal that pushing has finished
+            p.is_being_pushed_to = False


### PR DESCRIPTION
The DINSIC version of #141. The `dinsic` branch has the ability to replicate more than just associations to other sydent's. It can also send invite tokens and ephemeral keys. Thus, the code is structured in a bit of a different way where a dict containing all of these are sent (whereas in the `master` branch version, only associations are sent, which isn't wrapped in a bigger dict).

Also DINSIC's doesn't seem to work with matrix-is-tester, which is very sad indeed.