### PR TITLE
[DINSIC] Make info.yaml filepath configurable

### DIFF
--- a/sydent/http/info.py
+++ b/sydent/http/info.py
@@ -24,11 +24,19 @@ logger = logging.getLogger(__name__)
 class Info(object):
     """Returns information from info.yaml, which contains user-specific metadata."""
 
-    def __init__(self, syd):
+    def __init__(self, syd, info_file_path):
+        """
+        :param syd: The global sydent object
+        :type syd: Sydent
+
+        :param info_file_path: Filepath of the info.yaml file that defines which homeservers
+            users belong to
+        :type info_file_path: str
+        """
         self.sydent = syd
 
         try:
-            file = open('info.yaml')
+            file = open(info_file_path)
             self.config = yaml.load(file)
             file.close()
 

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -116,6 +116,9 @@ CONFIG_DEFAULTS = {
     'userdir': {
         'userdir.allowed_homeservers': '',
     },
+    'dinsic': {
+        'info_path': 'info.yaml',
+    }
 }
 
 
@@ -215,7 +218,7 @@ class Sydent:
         self.servlets.profileReplicationServlet = ProfileReplicationServlet(self)
         self.servlets.userDirectorySearchServlet = UserDirectorySearchServlet(self)
 
-        info = Info(self)
+        info = Info(self, self.cfg.get("dinsic", "info_path"))
         self.servlets.info = InfoServlet(self, info)
         self.servlets.internalInfo = InternalInfoServlet(self, info)
 

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -83,6 +83,9 @@ CONFIG_DEFAULTS = {
         # which defines the time during which an invite will be valid on this server
         # from the time it has been received.
         'invites.validity_period': '',
+        # Path to file detailing the configuration of the /info and /internal-info servlets.
+        # More information about them can be found in docs/info.md
+        'info_path': 'info.yaml',
     },
     'db': {
         'db.file': 'sydent.db',
@@ -116,9 +119,6 @@ CONFIG_DEFAULTS = {
     'userdir': {
         'userdir.allowed_homeservers': '',
     },
-    'dinsic': {
-        'info_path': 'info.yaml',
-    }
 }
 
 
@@ -218,7 +218,7 @@ class Sydent:
         self.servlets.profileReplicationServlet = ProfileReplicationServlet(self)
         self.servlets.userDirectorySearchServlet = UserDirectorySearchServlet(self)
 
-        info = Info(self, self.cfg.get("dinsic", "info_path"))
+        info = Info(self, self.cfg.get("general", "info_path"))
         self.servlets.info = InfoServlet(self, info)
         self.servlets.internalInfo = InternalInfoServlet(self, info)
 

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -84,7 +84,7 @@ CONFIG_DEFAULTS = {
         # from the time it has been received.
         'invites.validity_period': '',
         # Path to file detailing the configuration of the /info and /internal-info servlets.
-        # More information about them can be found in docs/info.md
+        # More information can be found in docs/info.md.
         'info_path': 'info.yaml',
     },
     'db': {


### PR DESCRIPTION
This makes the path to DINSIC's `info.yaml` file configurable (but keeps `info.yaml` as the default).

This adds a `dinsic` section to the config, which sounds like a good thing to do in general for DINSIC-specifc configuration options?

This will fail CI until #227 is merged, but #227 requires this PR first :)