### PR TITLE
Fix response field name in /register

### DIFF
--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -57,8 +57,12 @@ class RegisterServlet(Resource):
         user_id = result['sub']
         tok = yield issueToken(self.sydent, user_id)
 
+        # XXX: `token` is correct for the spec, but we released with `access_token`
+        # for a substantial amount of time. Serve both to make spec-compliant clients
+        # happy.
         defer.returnValue({
             "access_token": tok,
+            "token": tok,
         })
 
     def render_OPTIONS(self, request):


### PR DESCRIPTION
The spec wants it to be `token`, and we shipped with `access_token`.

Why not fix the spec? The spec has already been released, the MSC says this endpoint mirrors MSC1961, and it's effectively not an access token from a Matrix client-writer's perspective.

**Test: https://github.com/matrix-org/matrix-is-tester/pull/10**