### PR TITLE
Support replicating updates for 3PID invites

### DIFF
--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -252,7 +252,7 @@ class JoinTokenStore(object):
         # update is replicated to other servers.
         res = cur.execute(
             "SELECT id FROM invite_tokens WHERE medium = ? AND address = ?",
-            (int(time.time()), medium, address,)
+            (medium, address,)
         )
 
         rows = res.fetchall()

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -97,11 +97,11 @@ class JoinTokenStore(object):
         # seen from the server performing the update.
         # If we received an update to an invite that originated from this server,
         # use the id column to identify the invite to update, otherwise use the
-        # origin_server and origin_id to identify the invite.
+        # origin_server and origin_id.
         # Note that we don't replicate 3PID invites that have been received over
         # replication, so we're sure that origin_server and origin_id are the right
         # ones (as opposed to, e.g., a server B replicating an invite on behalf of
-        # another server A so that the origin_server and origin_id are for the B rather
+        # another server A so that the origin_server and origin_id are for B rather
         # than A, from which that invite originated).
         if origin_server == self.sydent.server_name:
             where_clause = """
@@ -394,8 +394,8 @@ class JoinTokenStore(object):
         return None
 
     def getInviteUpdatesAfterId(self, last_id, limit):
-        """Returns every updated token for which update id is higher than the provided
-        last_id, capped at `limit` tokens.
+        """Returns every updated token for which its update id is higher than the provided
+        `last_id`, capped at `limit` tokens.
 
         :param last_id: The last ID processed during the previous run.
         :type last_id: int
@@ -429,7 +429,7 @@ class JoinTokenStore(object):
         invites = []
         for row in rows:
             max_id, invite_id, medium, address, room_id, sender, token, sent_ts, origin_server, origin_id = row
-            # Append a new object to the list containing the token's metadata,
+            # Append a new dict to the list containing the token's metadata,
             # including an `origin_id` and an `origin_server` so that the receiving end
             # can figure out which invite to update in its local database. If the token
             # originated from this server, use its local ID as the value for
@@ -449,4 +449,4 @@ class JoinTokenStore(object):
 
         self.sydent.db.commit()
 
-        return (invites, max_id)
+        return invites, max_id

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -119,13 +119,18 @@ class PeerStore:
         :type lastPokeSucceeded: int
         """
 
+        invite_tokens_ids = ids.get("invite_tokens", {})
+
         cur = self.sydent.db.cursor()
         if ids["sg_assocs"]:
             cur.execute("update peers set lastSentAssocsId = ?, lastPokeSucceededAt = ? "
                         "where name = ?", (ids["sg_assocs"], lastPokeSucceeded, peerName))
-        if ids["invite_tokens"]:
+        if invite_tokens_ids["added"]:
             cur.execute("update peers set lastSentInviteTokensId = ?, lastPokeSucceededAt = ? "
-                        "where name = ?", (ids["invite_tokens"], lastPokeSucceeded, peerName))
+                        "where name = ?", (invite_tokens_ids["added"], lastPokeSucceeded, peerName))
+        if invite_tokens_ids["updated"]:
+            cur.execute("update peers set lastSentInviteUpdatesId = ?, lastPokeSucceededAt = ? "
+                        "where name = ?", (invite_tokens_ids["updated"], lastPokeSucceeded, peerName))
         if ids["ephemeral_public_keys"]:
             cur.execute("update peers set lastSentEphemeralKeysId = ?, lastPokeSucceededAt = ? "
                         "where name = ?", (ids["ephemeral_public_keys"], lastPokeSucceeded, peerName))

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -123,18 +123,18 @@ class PeerStore:
         :type lastPokeSucceeded: int
         """
 
-        invite_tokens_ids = ids.get("invite_tokens", {})
+        invite_token_ids = ids.get("invite_tokens", {})
 
         cur = self.sydent.db.cursor()
         if ids["sg_assocs"]:
             cur.execute("update peers set lastSentAssocsId = ?, lastPokeSucceededAt = ? "
                         "where name = ?", (ids["sg_assocs"], lastPokeSucceeded, peerName))
-        if invite_tokens_ids["added"]:
+        if invite_token_ids["added"]:
             cur.execute("update peers set lastSentInviteTokensId = ?, lastPokeSucceededAt = ? "
-                        "where name = ?", (invite_tokens_ids["added"], lastPokeSucceeded, peerName))
-        if invite_tokens_ids["updated"]:
+                        "where name = ?", (invite_token_ids["added"], lastPokeSucceeded, peerName))
+        if invite_token_ids["updated"]:
             cur.execute("update peers set lastSentInviteUpdatesId = ?, lastPokeSucceededAt = ? "
-                        "where name = ?", (invite_tokens_ids["updated"], lastPokeSucceeded, peerName))
+                        "where name = ?", (invite_token_ids["updated"], lastPokeSucceeded, peerName))
         if ids["ephemeral_public_keys"]:
             cur.execute("update peers set lastSentEphemeralKeysId = ?, lastPokeSucceededAt = ? "
                         "where name = ?", (ids["ephemeral_public_keys"], lastPokeSucceeded, peerName))

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -61,7 +61,7 @@ class PeerStore:
     def getAllPeers(self):
         cur = self.sydent.db.cursor()
         res = cur.execute("select p.name, p.port, "
-                          "p.lastSentAssocsId, p.lastSentInviteTokensId, p.lastSentEphemeralKeysId, "
+                          "p.lastSentAssocsId, p.lastSentInviteTokensId, p.lastSentInviteUpdatesId, p.lastSentEphemeralKeysId, "
                           "p.shadow, pk.alg, pk.key from peers p, peer_pubkeys pk "
                           "where pk.peername = p.name and p.active = 1")
 
@@ -71,6 +71,7 @@ class PeerStore:
         port = None
         lastSentAssocsId = 0
         lastSentInviteTokensId = 0
+        lastSentInviteUpdatesId = 0
         lastSentEphemeralKeysId = 0
         pubkeys = {}
 
@@ -80,6 +81,7 @@ class PeerStore:
                     p = RemotePeer(self.sydent, peername, port, pubkeys)
                     p.lastSentAssocsId = lastSentAssocsId
                     p.lastSentInviteTokensId = lastSentInviteTokensId
+                    p.lastSentInviteUpdatesId = lastSentInviteUpdatesId
                     p.lastSentEphemeralKeysId = lastSentEphemeralKeysId
                     peers.append(p)
                     pubkeys = {}
@@ -95,6 +97,7 @@ class PeerStore:
             p = RemotePeer(self.sydent, peername, port, pubkeys)
             p.lastSentAssocsId = lastSentAssocsId
             p.lastSentInviteTokensId = lastSentInviteTokensId
+            p.lastSentInviteUpdatesId = lastSentInviteUpdatesId
             p.lastSentEphemeralKeysId = lastSentEphemeralKeysId
             p.shadow = True if shadow else False
             peers.append(p)

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -89,9 +89,10 @@ class PeerStore:
                 port = row[1]
                 lastSentAssocsId = row[2]
                 lastSentInviteTokensId = row[3]
-                lastSentEphemeralKeysId = row[4]
-                shadow = row[5]
-            pubkeys[row[6]] = row[7]
+                lastSentInviteUpdatesId = row[4]
+                lastSentEphemeralKeysId = row[5]
+                shadow = row[6]
+            pubkeys[row[7]] = row[8]
 
         if len(pubkeys) > 0:
             p = RemotePeer(self.sydent, peername, port, pubkeys)

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -24,7 +24,7 @@ class PeerStore:
     def getPeerByName(self, name):
         cur = self.sydent.db.cursor()
         res = cur.execute("select p.name, p.port, "
-                          "p.lastSentAssocsId, p.lastSentInviteTokensId, p.lastSentEphemeralKeysId, "
+                          "p.lastSentAssocsId, p.lastSentInviteTokensId, p.lastSentInviteUpdatesId, p.lastSentEphemeralKeysId, "
                           "p.shadow, pk.alg, pk.key from peers p, peer_pubkeys pk "
                           "where p.name = ? and pk.peername = p.name and p.active = 1", (name,))
 
@@ -32,6 +32,7 @@ class PeerStore:
         port = None
         lastSentAssocsId = None
         lastSentInviteTokensId = None
+        lastSentInviteUpdatesId = None
         lastSentEphemeralKeysId = None
         pubkeys = {}
 
@@ -40,9 +41,10 @@ class PeerStore:
             port = row[1]
             lastSentAssocsId = row[2]
             lastSentInviteTokensId = row[3]
-            lastSentEphemeralKeysId = row[4]
-            shadow = row[5]
-            pubkeys[row[6]] = row[7]
+            lastSentInviteUpdatesId = row[4]
+            lastSentEphemeralKeysId = row[5]
+            shadow = row[6]
+            pubkeys[row[7]] = row[8]
 
         if len(pubkeys) == 0:
             return None
@@ -50,6 +52,7 @@ class PeerStore:
         p = RemotePeer(self.sydent, serverName, port, pubkeys)
         p.lastSentAssocsId = lastSentAssocsId
         p.lastSentInviteTokensId = lastSentInviteTokensId
+        p.lastSentInviteUpdatesId = lastSentInviteUpdatesId
         p.lastSentEphemeralKeysId = lastSentEphemeralKeysId
         p.shadow = True if shadow else False
 

--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -166,7 +166,7 @@ class SqliteDatabase:
             )
             cur.execute(
                 """
-                    ALTER TABLE invite_tokens
+                    ALTER TABLE peers
                     ADD COLUMN lastSentInviteUpdatesId INTEGER DEFAULT 0
                 """
             )

--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -154,6 +154,25 @@ class SqliteDatabase:
             self.db.commit()
             logger.info("v3 -> v4 schema migration complete")
             self._setSchemaVersion(4)
+        if curVer < 5:
+            cur = self.db.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS updated_invites (
+                    id INTEGER PRIMARY KEY,
+                    invite_id INTEGER NOT NULL
+                )
+                """
+            )
+            cur.execute(
+                """
+                    ALTER TABLE invite_tokens
+                    ADD COLUMN lastSentInviteUpdatesId INTEGER DEFAULT 0
+                """
+            )
+            self.db.commit()
+            logger.info("v4 -> v5 schema migration complete")
+            self._setSchemaVersion(5)
 
     def _getSchemaVersion(self):
         cur = self.db.cursor()

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -161,7 +161,13 @@ class ReplicationPushServlet(Resource):
         new_invites = invite_tokens.get('added', {})
         if len(new_invites) > MAX_INVITE_TOKENS_LIMIT:
             self.sydent.db.rollback()
-            logger.warn("Peer %s made push with 'invite_tokens.added' field containing %d entries, which is greater than the maximum %d", peer.servername, len(new_invites), MAX_INVITE_TOKENS_LIMIT)
+            logger.warning(
+                "Peer %s made push with 'invite_tokens.added' field containing %d "
+                "entries, which is greater than the maximum %d",
+                peer.servername,
+                len(new_invites),
+                MAX_INVITE_TOKENS_LIMIT,
+            )
             request.setResponseCode(400)
             request.write(json.dumps({'errcode': 'M_BAD_JSON', 'error': '"invite_tokens.added" has more than %d keys' % MAX_INVITE_TOKENS_LIMIT}))
             request.finish()
@@ -179,7 +185,13 @@ class ReplicationPushServlet(Resource):
         invite_updates = invite_tokens.get('updated', {})
         if len(invite_updates) > MAX_INVITE_UPDATES_LIMIT:
             self.sydent.db.rollback()
-            logger.warning("Peer %s made push with 'invite_tokens.updated' field containing %d entries, which is greater than the maximum %d", peer.servername, len(invite_updates), MAX_INVITE_UPDATES_LIMIT)
+            logger.warning(
+                "Peer %s made push with 'invite_tokens.updated' field containing %d "
+                "entries, which is greater than the maximum %d",
+                peer.servername,
+                len(invite_updates),
+                MAX_INVITE_UPDATES_LIMIT,
+            )
             request.setResponseCode(400)
             request.write(json.dumps({'errcode': 'M_BAD_JSON', 'error': '"invite_tokens.updated" has more than %d keys' % MAX_INVITE_UPDATES_LIMIT}))
             request.finish()

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -158,7 +158,7 @@ class ReplicationPushServlet(Resource):
         # Process any new invite tokens
 
         invite_tokens = inJson.get('invite_tokens', {})
-        new_invites = invite_tokens.get('added')
+        new_invites = invite_tokens.get('added', {})
         if len(new_invites) > MAX_INVITE_TOKENS_LIMIT:
             self.sydent.db.rollback()
             logger.warn("Peer %s made push with 'invite_tokens.added' field containing %d entries, which is greater than the maximum %d", peer.servername, len(new_invites), MAX_INVITE_TOKENS_LIMIT)
@@ -176,10 +176,10 @@ class ReplicationPushServlet(Resource):
 
         # Process any invite token update
 
-        invite_updates = invite_tokens.get('updated')
+        invite_updates = invite_tokens.get('updated', {})
         if len(invite_updates) > MAX_INVITE_UPDATES_LIMIT:
             self.sydent.db.rollback()
-            logger.warn("Peer %s made push with 'invite_tokens.updated' field containing %d entries, which is greater than the maximum %d", peer.servername, len(invite_updates), MAX_INVITE_UPDATES_LIMIT)
+            logger.warning("Peer %s made push with 'invite_tokens.updated' field containing %d entries, which is greater than the maximum %d", peer.servername, len(invite_updates), MAX_INVITE_UPDATES_LIMIT)
             request.setResponseCode(400)
             request.write(json.dumps({'errcode': 'M_BAD_JSON', 'error': '"invite_tokens.updated" has more than %d keys' % MAX_INVITE_UPDATES_LIMIT}))
             request.finish()

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -185,9 +185,9 @@ class ReplicationPushServlet(Resource):
             request.finish()
             return
 
-        for updated_invite in new_invites:
+        for updated_invite in invite_updates:
             tokensStore.updateToken(updated_invite['medium'], updated_invite['address'], updated_invite['room_id'],
-                                updated_invite['sender'], updated_invite['token'],
+                                updated_invite['sender'], updated_invite['token'], updated_invite['sent_ts'],
                                 origin_server=updated_invite['origin_server'], origin_id=updated_invite['origin_id'],
                                 commit=False)
             logger.info("Stored invite update with origin ID %s from %s", updated_invite['origin_id'], peer.servername)

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 
 MAX_SG_ASSOCS_LIMIT = 100
 MAX_INVITE_TOKENS_LIMIT = 100
+MAX_INVITE_UPDATES_LIMIT = 100
 MAX_EPHEMERAL_PUBLIC_KEYS_LIMIT = 100
 
 class ReplicationPushServlet(Resource):
@@ -154,23 +155,42 @@ class ReplicationPushServlet(Resource):
 
         tokensStore = JoinTokenStore(self.sydent)
 
-        # Process any invite tokens
+        # Process any new invite tokens
 
         invite_tokens = inJson.get('invite_tokens', {})
-        if len(invite_tokens) > MAX_INVITE_TOKENS_LIMIT:
+        new_invites = invite_tokens.get('added')
+        if len(new_invites) > MAX_INVITE_TOKENS_LIMIT:
             self.sydent.db.rollback()
-            logger.warn("Peer %s made push with 'sg_assocs' field containing %d entries, which is greater than the maximum %d", peer.servername, len(invite_tokens), MAX_INVITE_TOKENS_LIMIT)
+            logger.warn("Peer %s made push with 'invite_tokens.added' field containing %d entries, which is greater than the maximum %d", peer.servername, len(new_invites), MAX_INVITE_TOKENS_LIMIT)
             request.setResponseCode(400)
-            request.write(json.dumps({'errcode': 'M_BAD_JSON', 'error': '"invite_tokens" has more than %d keys' % MAX_INVITE_TOKENS_LIMIT}))
+            request.write(json.dumps({'errcode': 'M_BAD_JSON', 'error': '"invite_tokens.added" has more than %d keys' % MAX_INVITE_TOKENS_LIMIT}))
             request.finish()
             return
 
-        for originId, inviteToken in invite_tokens.items():
+        for originId, inviteToken in new_invites.items():
             tokensStore.storeToken(inviteToken['medium'], inviteToken['address'], inviteToken['room_id'],
                                 inviteToken['sender'], inviteToken['token'],
                                 originServer=peer.servername, originId=originId,
                                 commit=False)
             logger.info("Stored invite token with origin ID %s from %s", originId, peer.servername)
+
+        # Process any invite update
+
+        invite_updates = invite_tokens.get('updated')
+        if len(invite_updates) > MAX_INVITE_UPDATES_LIMIT:
+            self.sydent.db.rollback()
+            logger.warn("Peer %s made push with 'invite_tokens.updated' field containing %d entries, which is greater than the maximum %d", peer.servername, len(invite_updates), MAX_INVITE_UPDATES_LIMIT)
+            request.setResponseCode(400)
+            request.write(json.dumps({'errcode': 'M_BAD_JSON', 'error': '"invite_tokens.updated" has more than %d keys' % MAX_INVITE_UPDATES_LIMIT}))
+            request.finish()
+            return
+
+        for updated_invite in new_invites:
+            tokensStore.updateToken(updated_invite['medium'], updated_invite['address'], updated_invite['room_id'],
+                                updated_invite['sender'], updated_invite['token'],
+                                origin_server=updated_invite['origin_server'], origin_id=updated_invite['origin_id'],
+                                commit=False)
+            logger.info("Stored invite update with origin ID %s from %s", updated_invite['origin_id'], peer.servername)
 
         # Process any ephemeral public keys
 

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -174,7 +174,7 @@ class ReplicationPushServlet(Resource):
                                 commit=False)
             logger.info("Stored invite token with origin ID %s from %s", originId, peer.servername)
 
-        # Process any invite update
+        # Process any invite token update
 
         invite_updates = invite_tokens.get('updated')
         if len(invite_updates) > MAX_INVITE_UPDATES_LIMIT:

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 # Maximum amount of signed objects to replicate to a peer at a time
 EPHEMERAL_PUBLIC_KEYS_PUSH_LIMIT = 100
 INVITE_TOKENS_PUSH_LIMIT = 100
+INVITE_UPDATES_PUSH_LIMIT = 100
 ASSOCIATIONS_PUSH_LIMIT = 100
 
 
@@ -97,10 +98,18 @@ class Pusher:
             push_data["sg_assocs"], ids["sg_assocs"] = associations
 
             # Push invite tokens and ephemeral public keys
+            push_data["invite_tokens"] = {}
+            ids["invite_tokens"] = {}
+
             tokens = self.join_token_store.getInviteTokensAfterId(
                 p.lastSentInviteTokensId, INVITE_TOKENS_PUSH_LIMIT
             )
-            push_data["invite_tokens"], ids["invite_tokens"] = tokens
+            push_data["invite_tokens"]["added"], ids["invite_tokens"]["added"] = tokens
+
+            updates = self.join_token_store.getInviteUpdatesAfterId(
+                p.lastSentInviteUpdatesId, INVITE_UPDATES_PUSH_LIMIT
+            )
+            push_data["invite_tokens"]["updated"], ids["invite_tokens"]["updated"] = updates
 
             keys = self.join_token_store.getEphemeralPublicKeysAfterId(
                 p.lastSentEphemeralKeysId, EPHEMERAL_PUBLIC_KEYS_PUSH_LIMIT


### PR DESCRIPTION
Currently we only replicate new invites to other instances of Sydent. This isn't enough, especially now that we use the updated `sent_ts` column in the `invite_tokens` table to figure out whether to send an invite down to a homeserver.

This PR adds support for replicating updates on 3PID invites.

~I still need to test the code locally to make sure it works as intended, but in the meantime it should be ready for review.~ Commits should be reviewable independently.