### PR TITLE
Make Sydent compatible with Python 3

### DIFF
--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from sydent.users.accounts import Account
 

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from sydent.replication.peer import RemotePeer
 

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from sydent.util import time_msec
 

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import sydent.util.tokenutils
 

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 import time

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -48,7 +48,7 @@ def authIfV2(sydent, request, requireTermsAgreed=True):
     :returns Account|None: The account object if there is correct auth, or None for v1 APIs
     :raises MatrixRestError: If the request is v2 but could not be authed or the user has not accepted terms
     """
-    if request.path.startswith('/_matrix/identity/v2'):
+    if request.path.startswith(b'/_matrix/identity/v2'):
         token = tokenFromRequest(request)
 
         if token is None:

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -13,11 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import json
 import logging
 
-from io import StringIO
+from six import StringIO
 from twisted.internet import defer
 from twisted.web.client import FileBodyProducer, Agent, readBody
 from twisted.web.http_headers import Headers

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -17,7 +17,7 @@
 import json
 import logging
 
-from StringIO import StringIO
+from io import StringIO
 from twisted.internet import defer
 from twisted.web.client import FileBodyProducer, Agent, readBody
 from twisted.web.http_headers import Headers

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -43,7 +43,7 @@ class HTTPClient(object):
         logger.debug("HTTP GET %s", uri)
 
         response = yield self.agent.request(
-            "GET",
+            b"GET",
             uri.encode("ascii"),
         )
         body = yield readBody(response)

--- a/sydent/http/httpsclient.py
+++ b/sydent/http/httpsclient.py
@@ -17,7 +17,7 @@
 import logging
 import json
 
-from StringIO import StringIO
+from io import StringIO
 
 from zope.interface import implementer
 

--- a/sydent/http/httpsclient.py
+++ b/sydent/http/httpsclient.py
@@ -13,15 +13,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 import json
 
-from io import StringIO
+from six import StringIO
 
 from zope.interface import implementer
 
-import twisted.internet.defer
 from twisted.internet.ssl import optionsForClientTLS
 from twisted.web.client import Agent, FileBodyProducer
 from twisted.web.iweb import IPolicyForHTTPS

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -64,59 +64,59 @@ class ClientApiHttpServer:
 
         pk_ed25519 = self.sydent.servlets.pubkey_ed25519
 
-        root.putChild('_matrix', matrix)
-        matrix.putChild('identity', identity)
-        identity.putChild('api', api)
-        identity.putChild('v2', v2)
-        api.putChild('v1', v1)
+        root.putChild(b'_matrix', matrix)
+        matrix.putChild(b'identity', identity)
+        identity.putChild(b'api', api)
+        identity.putChild(b'v2', v2)
+        api.putChild(b'v1', v1)
 
-        v1.putChild('validate', validate)
-        validate.putChild('email', email)
-        validate.putChild('msisdn', msisdn)
+        v1.putChild(b'validate', validate)
+        validate.putChild(b'email', email)
+        validate.putChild(b'msisdn', msisdn)
 
-        v1.putChild('lookup', lookup)
-        v1.putChild('bulk_lookup', bulk_lookup)
+        v1.putChild(b'lookup', lookup)
+        v1.putChild(b'bulk_lookup', bulk_lookup)
 
-        v1.putChild('pubkey', pubkey)
-        pubkey.putChild('isvalid', self.sydent.servlets.pubkeyIsValid)
-        pubkey.putChild('ed25519:0', pk_ed25519)
-        pubkey.putChild('ephemeral', ephemeralPubkey)
-        ephemeralPubkey.putChild('isvalid', self.sydent.servlets.ephemeralPubkeyIsValid)
+        v1.putChild(b'pubkey', pubkey)
+        pubkey.putChild(b'isvalid', self.sydent.servlets.pubkeyIsValid)
+        pubkey.putChild(b'ed25519:0', pk_ed25519)
+        pubkey.putChild(b'ephemeral', ephemeralPubkey)
+        ephemeralPubkey.putChild(b'isvalid', self.sydent.servlets.ephemeralPubkeyIsValid)
 
-        v1.putChild('3pid', threepid)
-        threepid.putChild('bind', bind)
-        threepid.putChild('unbind', unbind)
-        threepid.putChild('getValidated3pid', getValidated3pid)
+        v1.putChild(b'3pid', threepid)
+        threepid.putChild(b'bind', bind)
+        threepid.putChild(b'unbind', unbind)
+        threepid.putChild(b'getValidated3pid', getValidated3pid)
 
-        email.putChild('requestToken', emailReqCode)
-        email.putChild('submitToken', emailValCode)
+        email.putChild(b'requestToken', emailReqCode)
+        email.putChild(b'submitToken', emailValCode)
 
-        msisdn.putChild('requestToken', msisdnReqCode)
-        msisdn.putChild('submitToken', msisdnValCode)
+        msisdn.putChild(b'requestToken', msisdnReqCode)
+        msisdn.putChild(b'submitToken', msisdnValCode)
 
-        v1.putChild('store-invite', self.sydent.servlets.storeInviteServlet)
+        v1.putChild(b'store-invite', self.sydent.servlets.storeInviteServlet)
 
-        v1.putChild('sign-ed25519', self.sydent.servlets.blindlySignStuffServlet)
+        v1.putChild(b'sign-ed25519', self.sydent.servlets.blindlySignStuffServlet)
 
         # v2
         # note v2 loses the /api so goes on 'identity' not 'api'
-        identity.putChild('v2', v2)
+        identity.putChild(b'v2', v2)
 
         # v2 exclusive APIs
-        v2.putChild('terms', self.sydent.servlets.termsServlet)
+        v2.putChild(b'terms', self.sydent.servlets.termsServlet)
         account = self.sydent.servlets.accountServlet
-        v2.putChild('account', account)
-        account.putChild('register', self.sydent.servlets.registerServlet)
-        account.putChild('logout', self.sydent.servlets.logoutServlet)
+        v2.putChild(b'account', account)
+        account.putChild(b'register', self.sydent.servlets.registerServlet)
+        account.putChild(b'logout', self.sydent.servlets.logoutServlet)
 
         # v2 versions of existing APIs
-        v2.putChild('validate', validate)
-        v2.putChild('pubkey', pubkey)
-        v2.putChild('3pid', threepid)
-        v2.putChild('store-invite', self.sydent.servlets.storeInviteServlet)
-        v2.putChild('sign-ed25519', self.sydent.servlets.blindlySignStuffServlet)
-        v2.putChild('lookup', lookup_v2)
-        v2.putChild('hash_details', hash_details)
+        v2.putChild(b'validate', validate)
+        v2.putChild(b'pubkey', pubkey)
+        v2.putChild(b'3pid', threepid)
+        v2.putChild(b'store-invite', self.sydent.servlets.storeInviteServlet)
+        v2.putChild(b'sign-ed25519', self.sydent.servlets.blindlySignStuffServlet)
+        v2.putChild(b'lookup', lookup_v2)
+        v2.putChild(b'hash_details', hash_details)
 
         self.factory = Site(root)
         self.factory.displayTracebacks = False
@@ -139,16 +139,16 @@ class InternalApiHttpServer(object):
         root = Resource()
 
         matrix = Resource()
-        root.putChild('_matrix', matrix)
+        root.putChild(b'_matrix', matrix)
 
         identity = Resource()
-        matrix.putChild('identity', identity)
+        matrix.putChild(b'identity', identity)
 
         internal = Resource()
-        identity.putChild('internal', internal)
+        identity.putChild(b'internal', internal)
 
         authenticated_bind = AuthenticatedBindThreePidServlet(self.sydent)
-        internal.putChild('bind', authenticated_bind)
+        internal.putChild(b'bind', authenticated_bind)
 
         factory = Site(root)
         factory.displayTracebacks = False

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -15,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.server import Site
 from twisted.web.resource import Resource

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+
 import json
 import logging
 import random

--- a/sydent/http/servlets/accountservlet.py
+++ b/sydent/http/servlets/accountservlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+
 from twisted.web.resource import Resource
 
 import json

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 from sydent.db.threepid_associations import GlobalAssociationStore

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -56,7 +56,7 @@ class EmailRequestCodeServlet(Resource):
             )
         except EmailAddressException:
             request.setResponseCode(400)
-            resp = {'errcode': 'M_INVALID_EMAIL', 'error':'Invalid email address'}
+            resp = {'errcode': 'M_INVALID_EMAIL', 'error': 'Invalid email address'}
         except EmailSendException:
             request.setResponseCode(500)
             resp = {'errcode': 'M_EMAIL_SEND_ERROR', 'error': 'Failed to send email'}

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -97,7 +97,8 @@ class EmailValidateCodeServlet(Resource):
         templateFile = self.sydent.cfg.get('http', 'verify_response_template')
 
         request.setHeader("Content-Type", "text/html")
-        return open(templateFile).read() % {'message': msg}
+        res = open(templateFile).read() % {'message': msg}
+        return res.encode("UTF-8")
 
     @jsonwrap
     def render_POST(self, request):

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/hashdetailsservlet.py
+++ b/sydent/http/servlets/hashdetailsservlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 from sydent.db.threepid_associations import GlobalAssociationStore

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 from sydent.db.threepid_associations import GlobalAssociationStore

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 from twisted.web.resource import Resource

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+
 from twisted.web.resource import Resource
 from unpaddedbase64 import encode_base64
 

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -19,7 +19,7 @@ from twisted.internet import defer
 
 import logging
 import json
-import urllib
+import urllib.parse
 
 from sydent.http.servlets import get_args, jsonwrap, deferjsonwrap, send_cors
 from sydent.http.httpclient import FederationHttpClient
@@ -48,7 +48,7 @@ class RegisterServlet(Resource):
 
         result = yield self.client.get_json(
             "matrix://%s/_matrix/federation/v1/openid/userinfo?access_token=%s" % (
-                args['matrix_server_name'], urllib.quote(args['access_token']),
+                args['matrix_server_name'], urllib.parse.quote(args['access_token']),
             ),
         )
         if 'sub' not in result:

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -52,7 +52,7 @@ class RegisterServlet(Resource):
             ),
         )
         if 'sub' not in result:
-            raise Exception("Invalid response from Homeserver")
+            raise Exception("Invalid response from homeserver")
 
         user_id = result['sub']
         tok = yield issueToken(self.sydent, user_id)

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -13,13 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 from twisted.internet import defer
 
 import logging
 import json
-import urllib.parse
+from six.moves import urllib
 
 from sydent.http.servlets import get_args, jsonwrap, deferjsonwrap, send_cors
 from sydent.http.httpclient import FederationHttpClient

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import twisted.python.log
 from twisted.web.resource import Resource

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -13,11 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+
 import nacl.signing
 import random
 import string
 from email.header import Header
 
+from six import string_types
 from twisted.web.resource import Resource
 from unpaddedbase64 import encode_base64
 
@@ -78,7 +81,7 @@ class StoreInviteServlet(Resource):
 
         substitutions = {}
         for k, v in args.items():
-            if isinstance(v, str):
+            if isinstance(v, string_types):
                 substitutions[k] = v
         substitutions["token"] = token
 

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -18,11 +18,9 @@ import random
 import string
 from email.header import Header
 
-from six import string_types
 from twisted.web.resource import Resource
 from unpaddedbase64 import encode_base64
 
-import json
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.db.threepid_associations import GlobalAssociationStore
 
@@ -80,7 +78,7 @@ class StoreInviteServlet(Resource):
 
         substitutions = {}
         for k, v in args.items():
-            if isinstance(v, string_types):
+            if isinstance(v, str):
                 substitutions[k] = v
         substitutions["token"] = token
 
@@ -142,4 +140,4 @@ class StoreInviteServlet(Resource):
             return "..."
 
     def _randomString(self, length):
-        return ''.join(self.random.choice(string.ascii_letters) for _ in xrange(length))
+        return ''.join(self.random.choice(string.ascii_letters) for _ in range(length))

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import json
 import logging

--- a/sydent/http/servlets/v1_servlet.py
+++ b/sydent/http/servlets/v1_servlet.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/v2_servlet.py
+++ b/sydent/http/servlets/v2_servlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -14,7 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import ConfigParser
+import configparser
 
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.db.hashing_metadata import HashingMetadataStore
@@ -100,7 +100,7 @@ class RemotePeer(Peer):
             replication_url = sydent.cfg.get(
                 "peer.%s" % server_name, "base_replication_url",
             )
-        except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+        except (configparser.NoSectionError, configparser.NoOptionError):
             if not port:
                 port = 1001
             replication_url = "https://%s:%i" % (server_name, port)

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -14,7 +14,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import configparser
+from __future__ import absolute_import
+
+from six.moves import configparser
 
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.db.hashing_metadata import HashingMetadataStore

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 

--- a/sydent/sms/openmarket.py
+++ b/sydent/sms/openmarket.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 from base64 import b64encode

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -15,8 +15,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
-import configparser
+from six.moves import configparser
 import logging
 import logging.handlers
 import os

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ConfigParser
+import configparser
 import logging
 import logging.handlers
 import os
@@ -268,7 +268,7 @@ class Sydent:
         if internalport:
             try:
                 interface = self.cfg.get('http', 'internalapi.http.bind_address')
-            except ConfigParser.NoOptionError:
+            except configparser.NoOptionError:
                 interface = '::1'
             self.internalApiHttpServer = InternalApiHttpServer(self)
             self.internalApiHttpServer.setup(interface, int(internalport))
@@ -305,7 +305,7 @@ def parse_config(config_file):
         config_file (str): the file to be parsed
     """
 
-    cfg = ConfigParser.SafeConfigParser()
+    cfg = configparser.ConfigParser()
 
     # if the config file doesn't exist, prepopulate the config object
     # with the defaults, in the right section.
@@ -322,7 +322,7 @@ def parse_config(config_file):
         for sect, entries in CONFIG_DEFAULTS.items():
             cfg.add_section(sect)
             for k, v in entries.items():
-                cfg.set(ConfigParser.DEFAULTSECT, k, v)
+                cfg.set(configparser.DEFAULTSECT, k, v)
 
         cfg.read(config_file)
 

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -26,50 +26,50 @@ import twisted.internet.reactor
 from twisted.internet import task
 from twisted.python import log
 
-from db.sqlitedb import SqliteDatabase
+from sydent.db.sqlitedb import SqliteDatabase
 
-from http.httpcommon import SslComponents
-from http.httpserver import (
+from sydent.http.httpcommon import SslComponents
+from sydent.http.httpserver import (
     ClientApiHttpServer, ReplicationHttpsServer,
     InternalApiHttpServer,
 )
-from http.httpsclient import ReplicationHttpsClient
-from http.servlets.blindlysignstuffservlet import BlindlySignStuffServlet
-from http.servlets.pubkeyservlets import EphemeralPubkeyIsValidServlet, PubkeyIsValidServlet
-from http.servlets.termsservlet import TermsServlet
-from validators.emailvalidator import EmailValidator
-from validators.msisdnvalidator import MsisdnValidator
-from hs_federation.verifier import Verifier
+from sydent.http.httpsclient import ReplicationHttpsClient
+from sydent.http.servlets.blindlysignstuffservlet import BlindlySignStuffServlet
+from sydent.http.servlets.pubkeyservlets import EphemeralPubkeyIsValidServlet, PubkeyIsValidServlet
+from sydent.http.servlets.termsservlet import TermsServlet
+from sydent.validators.emailvalidator import EmailValidator
+from sydent.validators.msisdnvalidator import MsisdnValidator
+from sydent.hs_federation.verifier import Verifier
 
-from util.hash import sha256_and_url_safe_base64
-from util.tokenutils import generateAlphanumericTokenOfLength
+from sydent.util.hash import sha256_and_url_safe_base64
+from sydent.util.tokenutils import generateAlphanumericTokenOfLength
 
-from sign.ed25519 import SydentEd25519
+from sydent.sign.ed25519 import SydentEd25519
 
-from http.servlets.emailservlet import EmailRequestCodeServlet, EmailValidateCodeServlet
-from http.servlets.msisdnservlet import MsisdnRequestCodeServlet, MsisdnValidateCodeServlet
-from http.servlets.lookupservlet import LookupServlet
-from http.servlets.bulklookupservlet import BulkLookupServlet
-from http.servlets.lookupv2servlet import LookupV2Servlet
-from http.servlets.hashdetailsservlet import HashDetailsServlet
-from http.servlets.pubkeyservlets import Ed25519Servlet
-from http.servlets.threepidbindservlet import ThreePidBindServlet
-from http.servlets.threepidunbindservlet import ThreePidUnbindServlet
-from http.servlets.replication import ReplicationPushServlet
-from http.servlets.getvalidated3pidservlet import GetValidated3pidServlet
-from http.servlets.store_invite_servlet import StoreInviteServlet
-from http.servlets.v1_servlet import V1Servlet
-from http.servlets.accountservlet import AccountServlet
-from http.servlets.registerservlet import RegisterServlet
-from http.servlets.logoutservlet import LogoutServlet
-from http.servlets.v2_servlet import V2Servlet
+from sydent.http.servlets.emailservlet import EmailRequestCodeServlet, EmailValidateCodeServlet
+from sydent.http.servlets.msisdnservlet import MsisdnRequestCodeServlet, MsisdnValidateCodeServlet
+from sydent.http.servlets.lookupservlet import LookupServlet
+from sydent.http.servlets.bulklookupservlet import BulkLookupServlet
+from sydent.http.servlets.lookupv2servlet import LookupV2Servlet
+from sydent.http.servlets.hashdetailsservlet import HashDetailsServlet
+from sydent.http.servlets.pubkeyservlets import Ed25519Servlet
+from sydent.http.servlets.threepidbindservlet import ThreePidBindServlet
+from sydent.http.servlets.threepidunbindservlet import ThreePidUnbindServlet
+from sydent.http.servlets.replication import ReplicationPushServlet
+from sydent.http.servlets.getvalidated3pidservlet import GetValidated3pidServlet
+from sydent.http.servlets.store_invite_servlet import StoreInviteServlet
+from sydent.http.servlets.v1_servlet import V1Servlet
+from sydent.http.servlets.accountservlet import AccountServlet
+from sydent.http.servlets.registerservlet import RegisterServlet
+from sydent.http.servlets.logoutservlet import LogoutServlet
+from sydent.http.servlets.v2_servlet import V2Servlet
 
-from db.valsession import ThreePidValSessionStore
-from db.hashing_metadata import HashingMetadataStore
+from sydent.db.valsession import ThreePidValSessionStore
+from sydent.db.hashing_metadata import HashingMetadataStore
 
-from threepid.bind import ThreepidBinder
+from sydent.threepid.bind import ThreepidBinder
 
-from replication.pusher import Pusher
+from sydent.replication.pusher import Pusher
 
 logger = logging.getLogger(__name__)
 

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -34,7 +34,7 @@ from sydent.threepid import ThreepidAssociation
 
 from OpenSSL import SSL
 from OpenSSL.SSL import VERIFY_NONE
-from StringIO import StringIO
+from io import StringIO
 from twisted.internet import defer, ssl
 from twisted.names import client, dns
 from twisted.names.error import DNSNameError

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -14,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+
 import collections
 import json
 import logging
@@ -34,7 +36,7 @@ from sydent.threepid import ThreepidAssociation
 
 from OpenSSL import SSL
 from OpenSSL.SSL import VERIFY_NONE
-from io import StringIO
+from six import StringIO
 from twisted.internet import defer, ssl
 from twisted.names import client, dns
 from twisted.names.error import DNSNameError

--- a/sydent/users/tokens.py
+++ b/sydent/users/tokens.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 import time

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -41,21 +41,20 @@ def sendEmail(sydent, templateName, mailTo, substitutions):
         midRandom = "".join([random.choice(string.ascii_letters) for _ in range(16)])
         messageid = "<%d%s@%s>" % (time_msec(), midRandom, myHostname)
 
-        allSubstitutions = {}
-        allSubstitutions.update(substitutions)
-        allSubstitutions.update({
+        substitutions.update({
             'messageid': messageid,
             'date': email.utils.formatdate(localtime=False),
             'to': mailTo,
             'from': mailFrom,
         })
 
-        for k,v in allSubstitutions.items():
-            allSubstitutions[k] = v.decode('utf8')
-            allSubstitutions[k+"_forhtml"] = cgi.escape(v.decode('utf8'))
-            allSubstitutions[k+"_forurl"] = urllib.quote(v)
+        allSubstitutions = {}
+        for k, v in substitutions.items():
+            allSubstitutions[k] = v
+            allSubstitutions[k+"_forhtml"] = html.escape(v)
+            allSubstitutions[k+"_forurl"] = urllib.parse.quote(v)
 
-        mailString = open(mailTemplateFile).read().decode('utf8') % allSubstitutions
+        mailString = open(mailTemplateFile).read() % allSubstitutions
         parsedFrom = email.utils.parseaddr(mailFrom)[1]
         parsedTo = email.utils.parseaddr(mailTo)[1]
         if parsedFrom == '' or parsedTo == '':

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -21,8 +21,8 @@ import smtplib
 import email.utils
 import string
 import twisted.python.log
-import cgi
-import urllib
+import html
+import urllib.parse
 
 import email.utils
 

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 import socket
@@ -21,8 +22,14 @@ import smtplib
 import email.utils
 import string
 import twisted.python.log
-import html
-import urllib.parse
+import six
+from six.moves import urllib
+from six.moves import range
+
+if six.PY2:
+    from cgi import escape
+else:
+    from html import escape
 
 import email.utils
 
@@ -51,7 +58,7 @@ def sendEmail(sydent, templateName, mailTo, substitutions):
         allSubstitutions = {}
         for k, v in substitutions.items():
             allSubstitutions[k] = v
-            allSubstitutions[k+"_forhtml"] = html.escape(v)
+            allSubstitutions[k+"_forhtml"] = escape(v)
             allSubstitutions[k+"_forurl"] = urllib.parse.quote(v)
 
         mailString = open(mailTemplateFile).read() % allSubstitutions

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 
 from sydent.db.valsession import ThreePidValSessionStore

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import logging
-import urllib
+import urllib.parse
 
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.util.emailutils import sendEmail
@@ -65,8 +65,8 @@ class EmailValidator:
         base = self.sydent.cfg.get('http', 'client_http_base')
         link = "%s/_matrix/identity/api/v1/validate/email/submitToken?token=%s&client_secret=%s&sid=%d" % (
             base,
-            urllib.quote(valSession.token),
-            urllib.quote(clientSecret),
+            urllib.parse.quote(valSession.token),
+            urllib.parse.quote(clientSecret),
             valSession.id,
         )
         if nextLink:
@@ -77,9 +77,9 @@ class EmailValidator:
                 nextLink += '&'
             else:
                 nextLink += '?'
-            nextLink += "sid=" + urllib.quote(str(valSession.id))
+            nextLink += "sid=" + urllib.parse.quote(str(valSession.id))
 
-            link += "&nextLink=%s" % (urllib.quote(nextLink))
+            link += "&nextLink=%s" % (urllib.parse.quote(nextLink))
         return link
 
     def validateSessionWithToken(self, sid, clientSecret, token):

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -44,7 +44,7 @@ class EmailValidator:
             logger.info("Not mailing code because current send attempt (%d) is not less than given send attempt (%s)", int(sendAttempt), int(valSession.sendAttemptNumber))
             return valSession.id
 
-        ipstring = ipaddress if ipaddress else u"an unknown location"
+        ipstring = ipaddress if ipaddress else "an unknown location"
 
         substitutions = {
             'ipaddress': ipstring,

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -13,9 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
-import urllib.parse
+from six.moves import urllib
 
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.util.emailutils import sendEmail

--- a/sydent/validators/msisdnvalidator.py
+++ b/sydent/validators/msisdnvalidator.py
@@ -14,9 +14,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
-import urllib
 import phonenumbers
 
 from sydent.db.valsession import ThreePidValSessionStore


### PR DESCRIPTION
* Replace the import of the py2 package `StringIO` with the py3 package `io`
* Update the import path for the `urllib` parsing functions which live in `urllib.parse` in py3
* Replace the import of the py2 package `ConfigParser` with the py3 package `configparser`
* Replace the import of `cgi` with `html` because the `escape` function used for processing substitutions when sending an email moved there
* Replace the use of `xrange` by `range` because it got renamed in py3
* Fix the import paths for internal packages so that they start with `sydent.` and are correctly imported by py3

Paired with https://github.com/matrix-org/matrix-is-tester/pull/11

Fixes https://github.com/matrix-org/sydent/issues/237