### PR TITLE
Make Sydent's base compatible with Python 3

### DIFF
--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -64,59 +64,59 @@ class ClientApiHttpServer:
 
         pk_ed25519 = self.sydent.servlets.pubkey_ed25519
 
-        root.putChild('_matrix', matrix)
-        matrix.putChild('identity', identity)
-        identity.putChild('api', api)
-        identity.putChild('v2', v2)
-        api.putChild('v1', v1)
+        root.putChild(b'_matrix', matrix)
+        matrix.putChild(b'identity', identity)
+        identity.putChild(b'api', api)
+        identity.putChild(b'v2', v2)
+        api.putChild(b'v1', v1)
 
-        v1.putChild('validate', validate)
-        validate.putChild('email', email)
-        validate.putChild('msisdn', msisdn)
+        v1.putChild(b'validate', validate)
+        validate.putChild(b'email', email)
+        validate.putChild(b'msisdn', msisdn)
 
-        v1.putChild('lookup', lookup)
-        v1.putChild('bulk_lookup', bulk_lookup)
+        v1.putChild(b'lookup', lookup)
+        v1.putChild(b'bulk_lookup', bulk_lookup)
 
-        v1.putChild('pubkey', pubkey)
-        pubkey.putChild('isvalid', self.sydent.servlets.pubkeyIsValid)
-        pubkey.putChild('ed25519:0', pk_ed25519)
-        pubkey.putChild('ephemeral', ephemeralPubkey)
-        ephemeralPubkey.putChild('isvalid', self.sydent.servlets.ephemeralPubkeyIsValid)
+        v1.putChild(b'pubkey', pubkey)
+        pubkey.putChild(b'isvalid', self.sydent.servlets.pubkeyIsValid)
+        pubkey.putChild(b'ed25519:0', pk_ed25519)
+        pubkey.putChild(b'ephemeral', ephemeralPubkey)
+        ephemeralPubkey.putChild(b'isvalid', self.sydent.servlets.ephemeralPubkeyIsValid)
 
-        v1.putChild('3pid', threepid)
-        threepid.putChild('bind', bind)
-        threepid.putChild('unbind', unbind)
-        threepid.putChild('getValidated3pid', getValidated3pid)
+        v1.putChild(b'3pid', threepid)
+        threepid.putChild(b'bind', bind)
+        threepid.putChild(b'unbind', unbind)
+        threepid.putChild(b'getValidated3pid', getValidated3pid)
 
-        email.putChild('requestToken', emailReqCode)
-        email.putChild('submitToken', emailValCode)
+        email.putChild(b'requestToken', emailReqCode)
+        email.putChild(b'submitToken', emailValCode)
 
-        msisdn.putChild('requestToken', msisdnReqCode)
-        msisdn.putChild('submitToken', msisdnValCode)
+        msisdn.putChild(b'requestToken', msisdnReqCode)
+        msisdn.putChild(b'submitToken', msisdnValCode)
 
-        v1.putChild('store-invite', self.sydent.servlets.storeInviteServlet)
+        v1.putChild(b'store-invite', self.sydent.servlets.storeInviteServlet)
 
-        v1.putChild('sign-ed25519', self.sydent.servlets.blindlySignStuffServlet)
+        v1.putChild(b'sign-ed25519', self.sydent.servlets.blindlySignStuffServlet)
 
         # v2
         # note v2 loses the /api so goes on 'identity' not 'api'
-        identity.putChild('v2', v2)
+        identity.putChild(b'v2', v2)
 
         # v2 exclusive APIs
-        v2.putChild('terms', self.sydent.servlets.termsServlet)
+        v2.putChild(b'terms', self.sydent.servlets.termsServlet)
         account = self.sydent.servlets.accountServlet
-        v2.putChild('account', account)
-        account.putChild('register', self.sydent.servlets.registerServlet)
-        account.putChild('logout', self.sydent.servlets.logoutServlet)
+        v2.putChild(b'account', account)
+        account.putChild(b'register', self.sydent.servlets.registerServlet)
+        account.putChild(b'logout', self.sydent.servlets.logoutServlet)
 
         # v2 versions of existing APIs
-        v2.putChild('validate', validate)
-        v2.putChild('pubkey', pubkey)
-        v2.putChild('3pid', threepid)
-        v2.putChild('store-invite', self.sydent.servlets.storeInviteServlet)
-        v2.putChild('sign-ed25519', self.sydent.servlets.blindlySignStuffServlet)
-        v2.putChild('lookup', lookup_v2)
-        v2.putChild('hash_details', hash_details)
+        v2.putChild(b'validate', validate)
+        v2.putChild(b'pubkey', pubkey)
+        v2.putChild(b'3pid', threepid)
+        v2.putChild(b'store-invite', self.sydent.servlets.storeInviteServlet)
+        v2.putChild(b'sign-ed25519', self.sydent.servlets.blindlySignStuffServlet)
+        v2.putChild(b'lookup', lookup_v2)
+        v2.putChild(b'hash_details', hash_details)
 
         self.factory = Site(root)
         self.factory.displayTracebacks = False
@@ -139,16 +139,16 @@ class InternalApiHttpServer(object):
         root = Resource()
 
         matrix = Resource()
-        root.putChild('_matrix', matrix)
+        root.putChild(b'_matrix', matrix)
 
         identity = Resource()
-        matrix.putChild('identity', identity)
+        matrix.putChild(b'identity', identity)
 
         internal = Resource()
-        identity.putChild('internal', internal)
+        identity.putChild(b'internal', internal)
 
         authenticated_bind = AuthenticatedBindThreePidServlet(self.sydent)
-        internal.putChild('bind', authenticated_bind)
+        internal.putChild(b'bind', authenticated_bind)
 
         factory = Site(root)
         factory.displayTracebacks = False
@@ -163,15 +163,15 @@ class ReplicationHttpsServer:
         matrix = Resource()
         identity = Resource()
 
-        root.putChild('_matrix', matrix)
-        matrix.putChild('identity', identity)
+        root.putChild(b'_matrix', matrix)
+        matrix.putChild(b'identity', identity)
 
         replicate = Resource()
         replV1 = Resource()
 
-        identity.putChild('replicate', replicate)
-        replicate.putChild('v1', replV1)
-        replV1.putChild('push', self.sydent.servlets.replicationPush)
+        identity.putChild(b'replicate', replicate)
+        replicate.putChild(b'v1', replV1)
+        replV1.putChild(b'push', self.sydent.servlets.replicationPush)
 
         self.factory = Site(root)
         self.factory.displayTracebacks = False

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -15,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.server import Site
 from twisted.web.resource import Resource

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -87,7 +87,18 @@ def get_args(request, required_args):
         args = {}
         for k, v in args_bytes.items():
             if isinstance(v, list) and len(v) == 1:
-                args[k.decode("UTF-8")] = v[0].decode("UTF-8")
+                try:
+                    args[k.decode("UTF-8")] = v[0].decode("UTF-8")
+                except UnicodeDecodeError:
+                    # Get a version of the key that has non-UTF-8 characters replaced by
+                    # their \xNN escape sequence so it doesn't raise another exception.
+                    safe_k = k.decode("UTF-8", errors="backslashreplace")
+                    raise MatrixRestError(
+                        400,
+                        'M_INVALID_PARAM',
+                        "Parameter %s or its value must be UTF-8" % safe_k,
+                    )
+
     elif args is None:
         args = {}
 

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -51,7 +51,7 @@ def get_args(request, required_args):
     :type request: twisted.web.server.Request
     :param required_args: The args that needs to be found in the
         request's parameters.
-    :type required_args: tuple[bytes]
+    :type required_args: tuple[unicode]
 
     :return: A dict containing the requested args and their values. String values
         are of type unicode.

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -42,7 +42,7 @@ def get_args(request, required_args):
     """
     Helper function to get arguments for an HTTP request.
     Currently takes args from the top level keys of a json object or
-    www-form-urlencoded for backwards comparability on v1 endpoints only.
+    www-form-urlencoded for backwards compatibility on v1 endpoints only.
     Returns a tuple (error, args) where if error is non-null,
     the request is malformed. Otherwise, args contains the
     parameters passed.

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -42,7 +42,7 @@ def get_args(request, required_args):
     """
     Helper function to get arguments for an HTTP request.
     Currently takes args from the top level keys of a json object or
-    www-form-urlencoded for backwards compatability on v1 endpoints only.
+    www-form-urlencoded for backwards comparability on v1 endpoints only.
     Returns a tuple (error, args) where if error is non-null,
     the request is malformed. Otherwise, args contains the
     parameters passed.
@@ -109,7 +109,7 @@ def jsonwrap(f):
     def inner(self, request, *args, **kwargs):
         """
         Runs a web handler function with the given request and parameters, then
-        converts its result in JSON and returns it. If an error happens, also sets
+        converts its result intoto JSON and returns it. If an error happens, also sets
         the HTTP response code.
 
         :param self: The current object.

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -120,7 +120,7 @@ def jsonwrap(f):
     def inner(self, request, *args, **kwargs):
         """
         Runs a web handler function with the given request and parameters, then
-        converts its result intoto JSON and returns it. If an error happens, also sets
+        converts its result into JSON and returns it. If an error happens, also sets
         the HTTP response code.
 
         :param self: The current object.

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -15,8 +15,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
-import ConfigParser
+from six.moves import configparser
 import logging
 import logging.handlers
 import os
@@ -26,50 +27,50 @@ import twisted.internet.reactor
 from twisted.internet import task
 from twisted.python import log
 
-from db.sqlitedb import SqliteDatabase
+from sydent.db.sqlitedb import SqliteDatabase
 
-from http.httpcommon import SslComponents
-from http.httpserver import (
+from sydent.http.httpcommon import SslComponents
+from sydent.http.httpserver import (
     ClientApiHttpServer, ReplicationHttpsServer,
     InternalApiHttpServer,
 )
-from http.httpsclient import ReplicationHttpsClient
-from http.servlets.blindlysignstuffservlet import BlindlySignStuffServlet
-from http.servlets.pubkeyservlets import EphemeralPubkeyIsValidServlet, PubkeyIsValidServlet
-from http.servlets.termsservlet import TermsServlet
-from validators.emailvalidator import EmailValidator
-from validators.msisdnvalidator import MsisdnValidator
-from hs_federation.verifier import Verifier
+from sydent.http.httpsclient import ReplicationHttpsClient
+from sydent.http.servlets.blindlysignstuffservlet import BlindlySignStuffServlet
+from sydent.http.servlets.pubkeyservlets import EphemeralPubkeyIsValidServlet, PubkeyIsValidServlet
+from sydent.http.servlets.termsservlet import TermsServlet
+from sydent.validators.emailvalidator import EmailValidator
+from sydent.validators.msisdnvalidator import MsisdnValidator
+from sydent.hs_federation.verifier import Verifier
 
-from util.hash import sha256_and_url_safe_base64
-from util.tokenutils import generateAlphanumericTokenOfLength
+from sydent.util.hash import sha256_and_url_safe_base64
+from sydent.util.tokenutils import generateAlphanumericTokenOfLength
 
-from sign.ed25519 import SydentEd25519
+from sydent.sign.ed25519 import SydentEd25519
 
-from http.servlets.emailservlet import EmailRequestCodeServlet, EmailValidateCodeServlet
-from http.servlets.msisdnservlet import MsisdnRequestCodeServlet, MsisdnValidateCodeServlet
-from http.servlets.lookupservlet import LookupServlet
-from http.servlets.bulklookupservlet import BulkLookupServlet
-from http.servlets.lookupv2servlet import LookupV2Servlet
-from http.servlets.hashdetailsservlet import HashDetailsServlet
-from http.servlets.pubkeyservlets import Ed25519Servlet
-from http.servlets.threepidbindservlet import ThreePidBindServlet
-from http.servlets.threepidunbindservlet import ThreePidUnbindServlet
-from http.servlets.replication import ReplicationPushServlet
-from http.servlets.getvalidated3pidservlet import GetValidated3pidServlet
-from http.servlets.store_invite_servlet import StoreInviteServlet
-from http.servlets.v1_servlet import V1Servlet
-from http.servlets.accountservlet import AccountServlet
-from http.servlets.registerservlet import RegisterServlet
-from http.servlets.logoutservlet import LogoutServlet
-from http.servlets.v2_servlet import V2Servlet
+from sydent.http.servlets.emailservlet import EmailRequestCodeServlet, EmailValidateCodeServlet
+from sydent.http.servlets.msisdnservlet import MsisdnRequestCodeServlet, MsisdnValidateCodeServlet
+from sydent.http.servlets.lookupservlet import LookupServlet
+from sydent.http.servlets.bulklookupservlet import BulkLookupServlet
+from sydent.http.servlets.lookupv2servlet import LookupV2Servlet
+from sydent.http.servlets.hashdetailsservlet import HashDetailsServlet
+from sydent.http.servlets.pubkeyservlets import Ed25519Servlet
+from sydent.http.servlets.threepidbindservlet import ThreePidBindServlet
+from sydent.http.servlets.threepidunbindservlet import ThreePidUnbindServlet
+from sydent.http.servlets.replication import ReplicationPushServlet
+from sydent.http.servlets.getvalidated3pidservlet import GetValidated3pidServlet
+from sydent.http.servlets.store_invite_servlet import StoreInviteServlet
+from sydent.http.servlets.v1_servlet import V1Servlet
+from sydent.http.servlets.accountservlet import AccountServlet
+from sydent.http.servlets.registerservlet import RegisterServlet
+from sydent.http.servlets.logoutservlet import LogoutServlet
+from sydent.http.servlets.v2_servlet import V2Servlet
 
-from db.valsession import ThreePidValSessionStore
-from db.hashing_metadata import HashingMetadataStore
+from sydent.db.valsession import ThreePidValSessionStore
+from sydent.db.hashing_metadata import HashingMetadataStore
 
-from threepid.bind import ThreepidBinder
+from sydent.threepid.bind import ThreepidBinder
 
-from replication.pusher import Pusher
+from sydent.replication.pusher import Pusher
 
 logger = logging.getLogger(__name__)
 
@@ -268,7 +269,7 @@ class Sydent:
         if internalport:
             try:
                 interface = self.cfg.get('http', 'internalapi.http.bind_address')
-            except ConfigParser.NoOptionError:
+            except configparser.NoOptionError:
                 interface = '::1'
             self.internalApiHttpServer = InternalApiHttpServer(self)
             self.internalApiHttpServer.setup(interface, int(internalport))
@@ -305,7 +306,7 @@ def parse_config(config_file):
         config_file (str): the file to be parsed
     """
 
-    cfg = ConfigParser.SafeConfigParser()
+    cfg = configparser.ConfigParser()
 
     # if the config file doesn't exist, prepopulate the config object
     # with the defaults, in the right section.
@@ -322,7 +323,7 @@ def parse_config(config_file):
         for sect, entries in CONFIG_DEFAULTS.items():
             cfg.add_section(sect)
             for k, v in entries.items():
-                cfg.set(ConfigParser.DEFAULTSECT, k, v)
+                cfg.set(configparser.DEFAULTSECT, k, v)
 
         cfg.read(config_file)
 


### PR DESCRIPTION
This PR brings the ground work for Python3-ifying Sydent, by fixing compatibility issues in `sydent/sydent.py` and in `sydent/http/httpserver.py` (see details in commit messages).