### PR TITLE
Add Python 3 compatibility to the authentication features

### DIFF
--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -96,6 +96,12 @@ class AccountStore(object):
         self.sydent.db.commit()
 
     def delToken(self, token):
+        """
+        Deletes an authentication token from the database.
+
+        :param token: The token to delete from the database.
+        :type token: str
+        """
         cur = self.sydent.db.cursor()
         res = cur.execute(
             "delete from tokens where token = ?",

--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -27,7 +27,7 @@ class AccountStore(object):
         Select the account matching the given token, if any.
 
         :param token: The token to identify the account, if any.
-        :type token: str
+        :type token: unicode
 
         :return: The account matching the token, or None if no account matched.
         :rtype: Account or None
@@ -70,7 +70,7 @@ class AccountStore(object):
         :param user_id: The Matrix ID of the user that has agreed to the terms.
         :type user_id: str
         :param consent_version: The version of the document the user has agreed to.
-        :type consent_version: str or None
+        :type consent_version: unicode or None
         """
         cur = self.sydent.db.cursor()
         res = cur.execute(
@@ -86,7 +86,7 @@ class AccountStore(object):
         :param user_id: The Matrix user ID to save the given token for.
         :type user_id: unicode
         :param token: The token to store for that user ID.
-        :type token: str
+        :type token: unicode
         """
         cur = self.sydent.db.cursor()
         res = cur.execute(
@@ -100,7 +100,7 @@ class AccountStore(object):
         Deletes an authentication token from the database.
 
         :param token: The token to delete from the database.
-        :type token: str
+        :type token: unicode
         """
         cur = self.sydent.db.cursor()
         res = cur.execute(

--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -23,6 +23,15 @@ class AccountStore(object):
         self.sydent = sydent
 
     def getAccountByToken(self, token):
+        """
+        Select the account matching the given token, if any.
+
+        :param token: The token to identify the account, if any.
+        :type token: str
+
+        :return: The account matching the token, or None if no account matched.
+        :rtype: Account or None
+        """
         cur = self.sydent.db.cursor()
         res = cur.execute("select a.user_id, a.created_ts, a.consent_version from accounts a, tokens t "
                           "where t.user_id = a.user_id and t.token = ?", (token,))
@@ -54,6 +63,15 @@ class AccountStore(object):
         self.sydent.db.commit()
 
     def setConsentVersion(self, user_id, consent_version):
+        """
+        Saves that the given user has agreed to all of the terms in the document of the
+        given version.
+
+        :param user_id: The Matrix ID of the user that has agreed to the terms.
+        :type user_id: str
+        :param consent_version: The version of the document the user has agreed to.
+        :type consent_version: str or None
+        """
         cur = self.sydent.db.cursor()
         res = cur.execute(
             "update accounts set consent_version = ? where user_id = ?",

--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -13,8 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from sydent.users.accounts import Account
+
 
 class AccountStore(object):
     def __init__(self, sydent):
@@ -32,6 +34,17 @@ class AccountStore(object):
         return Account(*row)
 
     def storeAccount(self, user_id, creation_ts, consent_version):
+        """
+        Stores an account for the given user ID.
+
+        :param user_id: The Matrix user ID to create an account for.
+        :type user_id: unicode
+        :param creation_ts: The timestamp in milliseconds.
+        :type creation_ts: int
+        :param consent_version: The version of the terms of services that the user last
+            accepted.
+        :type consent_version: str or None
+        """
         cur = self.sydent.db.cursor()
         res = cur.execute(
             "insert or ignore into accounts (user_id, created_ts, consent_version) "
@@ -49,6 +62,14 @@ class AccountStore(object):
         self.sydent.db.commit()
 
     def addToken(self, user_id, token):
+        """
+        Stores the authentication token for a given user.
+
+        :param user_id: The Matrix user ID to save the given token for.
+        :type user_id: unicode
+        :param token: The token to store for that user ID.
+        :type token: str
+        """
         cur = self.sydent.db.cursor()
         res = cur.execute(
             "insert into tokens (user_id, token) values (?, ?)",

--- a/sydent/db/terms.py
+++ b/sydent/db/terms.py
@@ -26,7 +26,7 @@ class TermsStore(object):
         :type user_id: str
 
         :return: A list of the URLs of the terms accepted by the user.
-        :rtype: list[str]
+        :rtype: list[unicode]
         """
         cur = self.sydent.db.cursor()
         res = cur.execute(
@@ -36,6 +36,10 @@ class TermsStore(object):
 
         urls = []
         for url, in res:
+            # Ensure we're dealing with unicode.
+            if url and isinstance(url, bytes):
+                url = url.decode("UTF-8")
+
             urls.append(url)
 
         return urls

--- a/sydent/db/terms.py
+++ b/sydent/db/terms.py
@@ -19,6 +19,15 @@ class TermsStore(object):
         self.sydent = sydent
 
     def getAgreedUrls(self, user_id):
+        """
+        Retrieves the URLs of the terms the given user has agreed to.
+
+        :param user_id: Matrix user ID to fetch the URLs for.
+        :type user_id: str
+
+        :return: A list of the URLs of the terms accepted by the user.
+        :rtype: list[str]
+        """
         cur = self.sydent.db.cursor()
         res = cur.execute(
             "select url from accepted_terms_urls "
@@ -32,6 +41,14 @@ class TermsStore(object):
         return urls
 
     def addAgreedUrls(self, user_id, urls):
+        """
+        Saves that the given user has accepted the terms at the given URLs.
+
+        :param user_id: The Matrix user ID that has accepted the terms.
+        :type user_id: str
+        :param urls: The list of URLs.
+        :type urls: list[unicode]
+        """
         cur = self.sydent.db.cursor()
         res = cur.executemany(
             "insert or ignore into accepted_terms_urls (user_id, url) values (?, ?)",

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -33,7 +33,8 @@ def tokenFromRequest(request):
     :param request: The request to look for an access token in.
     :type request: twisted.web.server.Request
 
-    :returns str|None: The token or None if not found
+    :return: The token or None if not found
+    :rtype: unicode or None
     """
     token = None
     # check for Authorization header first
@@ -44,6 +45,10 @@ def tokenFromRequest(request):
     # no? try access_token query param
     if token is None and 'access_token' in request.args:
         token = request.args['access_token'][0]
+
+    # Ensure we're dealing with unicode.
+    if token and isinstance(token, bytes):
+        token = token.decode("UTF-8")
 
     return token
 

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 
@@ -25,8 +26,12 @@ from sydent.http.servlets import MatrixRestError
 
 logger = logging.getLogger(__name__)
 
+
 def tokenFromRequest(request):
     """Extract token from header of query parameter.
+
+    :param request: The request to look for an access token in.
+    :type request: twisted.web.server.Request
 
     :returns str|None: The token or None if not found
     """
@@ -42,13 +47,23 @@ def tokenFromRequest(request):
 
     return token
 
+
 def authIfV2(sydent, request, requireTermsAgreed=True):
     """For v2 APIs check that the request has a valid access token associated with it
 
-    :returns Account|None: The account object if there is correct auth, or None for v1 APIs
-    :raises MatrixRestError: If the request is v2 but could not be authed or the user has not accepted terms
+    :param sydent: The Sydent instance to use.
+    :type sydent: sydent.sydent.Sydent
+    :param request: The request to look for an access token in.
+    :type request: twisted.web.server.Request
+    :param requireTermsAgreed: Whether to deny authentication if the user hasn't accepted
+        the terms of service.
+
+    :returns Account|None: The account object if there is correct auth, or None for v1
+        APIs.
+    :raises MatrixRestError: If the request is v2 but could not be authed or the user has
+        not accepted terms.
     """
-    if request.path.startswith('/_matrix/identity/v2'):
+    if request.path.startswith(b'/_matrix/identity/v2'):
         token = tokenFromRequest(request)
 
         if token is None:

--- a/sydent/http/servlets/accountservlet.py
+++ b/sydent/http/servlets/accountservlet.py
@@ -13,11 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 
-from sydent.http.servlets import get_args, jsonwrap, send_cors
-from sydent.users.tokens import issueToken
+from sydent.http.servlets import jsonwrap, send_cors
 from sydent.http.auth import authIfV2
 
 

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -13,12 +13,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 
 import logging
 
-from sydent.http.servlets import get_args, jsonwrap, send_cors, MatrixRestError
+from sydent.http.servlets import jsonwrap, send_cors
 from sydent.db.accounts import AccountStore
 from sydent.http.auth import authIfV2, tokenFromRequest
 
@@ -39,7 +40,7 @@ class LogoutServlet(Resource):
         """
         send_cors(request)
 
-        account = authIfV2(self.sydent, request, False)
+        authIfV2(self.sydent, request, False)
 
         token = tokenFromRequest(request)
 

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -13,13 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 from twisted.internet import defer
 
 import logging
 import json
-import urllib
+from six.moves import urllib
 
 from sydent.http.servlets import get_args, jsonwrap, deferjsonwrap, send_cors
 from sydent.http.httpclient import FederationHttpClient
@@ -48,11 +49,11 @@ class RegisterServlet(Resource):
 
         result = yield self.client.get_json(
             "matrix://%s/_matrix/federation/v1/openid/userinfo?access_token=%s" % (
-                args['matrix_server_name'], urllib.quote(args['access_token']),
+                args['matrix_server_name'], urllib.parse.quote(args['access_token']),
             ),
         )
         if 'sub' not in result:
-            raise Exception("Invalid response from Homeserver")
+            raise Exception("Invalid response from homeserver")
 
         user_id = result['sub']
         tok = yield issueToken(self.sydent, user_id)

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -13,11 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 
 import logging
-import json
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.terms.terms import get_terms

--- a/sydent/terms/terms.py
+++ b/sydent/terms/terms.py
@@ -33,9 +33,15 @@ class Terms(object):
         """
         :return: The global (master) version of the terms, or None if there
             are no terms of service for this server.
-        :rtype: str or None
+        :rtype: unicode or None
         """
-        return None if self._rawTerms is None else self._rawTerms['master_version']
+        version = None if self._rawTerms is None else self._rawTerms['master_version']
+
+        # Ensure we're dealing with unicode.
+        if version and isinstance(version, bytes):
+            version = version.decode("UTF-8")
+
+        return version
 
     def getForClient(self):
         """
@@ -55,13 +61,19 @@ class Terms(object):
     def getUrlSet(self):
         """
         :return: All the URLs for the terms in a set. Empty set if no terms.
-        :rtype: set[str]
+        :rtype: set[unicode]
         """
         urls = set()
         if self._rawTerms is not None:
             for docName, doc in self._rawTerms['docs'].items():
                 for langName, lang in doc['langs'].items():
-                    urls.add(lang['url'])
+                    url = lang['url']
+
+                    # Ensure we're dealing with unicode.
+                    if url and isinstance(url, bytes):
+                        url = url.decode("UTF-8")
+
+                    urls.add(url)
         return urls
 
     def urlListIsSufficient(self, urls):

--- a/sydent/terms/terms.py
+++ b/sydent/terms/terms.py
@@ -23,12 +23,26 @@ logger = logging.getLogger(__name__)
 
 class Terms(object):
     def __init__(self, yamlObj):
+        """
+        :param yamlObj: The parsed YAML.
+        :type yamlObj: dict[str, any] or None
+        """
         self._rawTerms = yamlObj
 
     def getMasterVersion(self):
+        """
+        :return: The global (master) version of the terms, or None if there
+            are no terms of service for this server.
+        :rtype: str or None
+        """
         return None if self._rawTerms is None else self._rawTerms['master_version']
 
     def getForClient(self):
+        """
+        :return: A dict which value for the "policies" key is a dict which contains the
+            "docs" part of the terms' YAML. That nested dict is empty if no terms.
+        :rtype: dict[str, dict]
+        """
         policies = {}
         if self._rawTerms is not None:
             for docName, doc in self._rawTerms['docs'].items():
@@ -39,6 +53,10 @@ class Terms(object):
         return { 'policies': policies }
 
     def getUrlSet(self):
+        """
+        :return: All the URLs for the terms in a set. Empty set if no terms.
+        :rtype: set[str]
+        """
         urls = set()
         if self._rawTerms is not None:
             for docName, doc in self._rawTerms['docs'].items():
@@ -47,6 +65,17 @@ class Terms(object):
         return urls
 
     def urlListIsSufficient(self, urls):
+        """
+        Checks whether the provided list of URLs (which represents the list of terms
+        accepted by the user) is enough to allow the creation of the user's account.
+
+        :param urls: The list of URLs of terms the user has accepted.
+        :type urls: list[unicode]
+
+        :return: Whether the list is sufficient to allow the creation of the user's
+            account.
+        :rtype: bool
+        """
         agreed = set()
         urlset = set(urls)
 

--- a/sydent/users/accounts.py
+++ b/sydent/users/accounts.py
@@ -13,8 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class Account(object):
     def __init__(self, user_id, creation_ts, consent_version):
+        """
+        :param user_id: The Matrix user ID for the account.
+        :type user_id: str
+        :param creation_ts: The timestamp in milliseconds of the account's creation.
+        :type creation_ts: int
+        :param consent_version: The version of the terms of services that the user last
+            accepted.
+        """
         self.userId = user_id
-        self.creationTs = creation_ts;
+        self.creationTs = creation_ts
         self.consentVersion = consent_version

--- a/sydent/users/tokens.py
+++ b/sydent/users/tokens.py
@@ -33,7 +33,7 @@ def issueToken(sydent, user_id):
     :type user_id: unicode
 
     :return: The access token for that account.
-    :rtype: str
+    :rtype: unicode
     """
     accountStore = AccountStore(sydent)
     accountStore.storeAccount(user_id, int(time.time() * 1000), None)

--- a/sydent/users/tokens.py
+++ b/sydent/users/tokens.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 import time
@@ -22,6 +23,18 @@ from sydent.db.accounts import AccountStore
 logger = logging.getLogger(__name__)
 
 def issueToken(sydent, user_id):
+    """
+    Creates an account for the given Matrix user ID, then generates, saves and returns
+    an access token for that account.
+
+    :param sydent: The Sydent instance to use for storing the token.
+    :type sydent: sydent.sydent.Sydent
+    :param user_id: The Matrix user ID to issue a token for.
+    :type user_id: unicode
+
+    :return: The access token for that account.
+    :rtype: str
+    """
     accountStore = AccountStore(sydent)
     accountStore.storeAccount(user_id, int(time.time() * 1000), None)
 

--- a/sydent/util/tokenutils.py
+++ b/sydent/util/tokenutils.py
@@ -36,6 +36,6 @@ def generateAlphanumericTokenOfLength(length):
     :type length: int
 
     :return: The generated token.
-    :rtype: str
+    :rtype: unicode
     """
-    return "".join([r.choice(string.digits + string.ascii_lowercase + string.ascii_uppercase) for _ in range(length)])
+    return u"".join([r.choice(string.digits + string.ascii_lowercase + string.ascii_uppercase) for _ in range(length)])

--- a/sydent/util/tokenutils.py
+++ b/sydent/util/tokenutils.py
@@ -29,4 +29,13 @@ def generateNumericTokenOfLength(length):
     return "".join([r.choice(string.digits) for _ in range(length)])
 
 def generateAlphanumericTokenOfLength(length):
+    """
+    Generates a token of the given length with the character set [a-zA-Z0-9].
+
+    :param length: The length of the token to generate.
+    :type length: int
+
+    :return: The generated token.
+    :rtype: str
+    """
     return "".join([r.choice(string.digits + string.ascii_lowercase + string.ascii_uppercase) for _ in range(length)])


### PR DESCRIPTION
Based on https://github.com/matrix-org/sydent/pull/241

Adds Python 3 compatibility to the registration, authentication via token, terms and logout.

The commits that differ from #241 are the three last `Add Python 3 support to` ones (and the ones after that), and they should be reviewable independently.