### PR TITLE
Make 3PID validation tokens configurable

### DIFF
--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -210,11 +210,11 @@ class Sydent:
             hashing_metadata_store.store_lookup_pepper(sha256_and_url_safe_base64,
                                                        lookup_pepper)
 
-        self.threepid_session_validation_timeout = parse_duration(
+        self.cfg.threepid_session_validation_timeout = parse_duration(
             self.cfg.get('general', 'threepid.session_validation_timeout'),
             default=24 * 60 * 60 * 1000,  # 24 hrs
         )
-        self.threepid_session_valid_lifetime = parse_duration(
+        self.cfg.threepid_session_valid_lifetime = parse_duration(
             self.cfg.get('general', 'threepid.session_valid_lifetime'),
             default=24 * 60 * 60 * 1000,  # 24 hrs
         )

--- a/sydent/validators/__init__.py
+++ b/sydent/validators/__init__.py
@@ -16,11 +16,6 @@
 
 
 class ValidationSession:
-    # how long a user can wait before validating a session after starting it
-    THREEPID_SESSION_VALIDATION_TIMEOUT_MS = 24 * 60 * 60 * 1000
-
-    # how long we keep sessions for after they've been validated
-    THREEPID_SESSION_VALID_LIFETIME_MS = 24 * 60 * 60 * 1000
 
     def __init__(self, _id, _medium, _address, _clientSecret, _validated, _mtime):
         self.id = _id

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -29,7 +29,7 @@ def validateSessionWithToken(sydent, sid, clientSecret, token):
         logger.info("Incorrect client secret", (sid))
         raise IncorrectClientSecretException()
 
-    if s.mtime + ValidationSession.THREEPID_SESSION_VALIDATION_TIMEOUT_MS < time_msec():
+    if s.mtime + sydent.cfg.threepid_session_validation_timeout < time_msec():
         logger.info("Session expired")
         raise SessionExpiredException()
 


### PR DESCRIPTION
This PR makes two values configurable in sydent that were previously hardcoded:

* How long a 3PID validation session is valid for after creation (`general->threepid.session_validation_timeout`, default '24h')
* How long a user has to validate a session from starting it (`general->threepid.session_valid_lifetime`, default `24h`)

Born out of some DINUM work, but not required for any sprints.