### PR TITLE
[DINUM] Delete session tokens immediately upon successful 3PID validation

### DIFF
--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -173,10 +173,22 @@ class SqliteDatabase:
             self.db.commit()
             logger.info("v4 -> v5 schema migration complete")
             self._setSchemaVersion(5)
+        if curVer < 6:
+            cur = self.db.cursor()
+            cur.execute(
+                """
+                ALTER TABLE threepid_token_auths
+                ADD COLUMN
+                    next_link_used TEXT
+                """
+            )
+            self.db.commit()
+            logger.info("v5 -> v6 schema migration complete")
+            self._setSchemaVersion(6)
 
     def _getSchemaVersion(self):
         cur = self.db.cursor()
-        res = cur.execute("PRAGMA user_version");
+        res = cur.execute("PRAGMA user_version")
         row = cur.fetchone()
         return row[0]
 
@@ -184,4 +196,4 @@ class SqliteDatabase:
         cur = self.db.cursor()
         # NB. pragma doesn't support variable substitution so we
         # do it in python (as a decimal so we don't risk SQL injection)
-        res = cur.execute("PRAGMA user_version = %d" % (ver,));
+        res = cur.execute("PRAGMA user_version = %d" % (ver,))

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -121,6 +121,61 @@ class ThreePidValSessionStore:
 
         return None
 
+    def next_link_differs(self, sid, token, next_link):
+        """Check whether the specified session has already been validated with a
+        next_link provided, and if  next_link value
+
+        :param sid: The session ID
+        :type sid: str
+
+        :param token: The validation token
+        :type token: str
+
+        :param next_link: The next_link parameter used in submitting this validation
+        :type next_link: str
+
+        :returns: Whether the provided next_link differs from the provided
+            token's associated next_link. Returns False if the stored next_link
+            value is NULL.
+        :rtype: bool
+        """
+        #TODO: Check if it's already been validated, and if so then check next_link is
+        # different. None or not
+        # Get the stored next_link value for this token
+        cur = self.sydent.db.cursor()
+
+        cur.execute("select next_link_used from threepid_token_auths "
+                    "where validationSession = ? and token = ?",
+                    (sid, token))
+
+        row = cur.fetchone()
+        if not row:
+            return False
+        token_next_link = row[0]
+
+        return token_next_link != next_link
+
+    def set_next_link_for_token(self, sid, token, next_link):
+        """Set which next_link was used when using a session token
+
+        :param sid: The session ID
+        :type sid: str
+
+        :param token: The validation token
+        :type token: str
+
+        :param next_link: The next_link parameter used in submitting this validation
+        :type next_link: str
+        """
+        cur = self.sydent.db.cursor()
+
+        cur.execute("update threepid_token_auths "
+                    "set next_link_used = ?"
+                    "where validationSession = ? and token = ?",
+                    (next_link, sid, token))
+
+        self.sydent.db.commit()
+
     def getValidatedSession(self, sid, clientSecret):
         """
         Retrieve a validated and still-valid session whose client secret matches the one passed in

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -18,8 +18,13 @@ from twisted.internet import task
 
 import sydent.util.tokenutils
 
-from sydent.validators import ValidationSession, IncorrectClientSecretException, InvalidSessionIdException, \
-    SessionExpiredException, SessionNotValidatedException
+from sydent.validators import (
+    ValidationSession,
+    IncorrectClientSecretException,
+    InvalidSessionIdException,
+    SessionExpiredException,
+    SessionNotValidatedException,
+)
 from sydent.util import time_msec
 
 from random import SystemRandom
@@ -186,6 +191,8 @@ class ThreePidValSessionStore:
 
         :param next_link: The next_link parameter used in submitting this validation
         :type next_link: str
+
+        :raises IntegrityError: on database transaction failure
         """
         cur = self.sydent.db.cursor()
 
@@ -195,7 +202,7 @@ class ThreePidValSessionStore:
         where validationSession = ? and token = ?
         """
 
-        # Commits and rollsback in case of an exception
+        # Commits and rolls back in case of an exception
         with self.sydent.db:
             cur.execute(sql, (next_link, sid, token))
 

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -93,7 +93,6 @@ class ThreePidValSessionStore:
         :param commit: Whether to commit to the database. Used in applying other
             database operations atomically. Defaults to True
         :type bool: bool
-
         """
         cur = self.sydent.db.cursor()
 
@@ -190,8 +189,15 @@ class ThreePidValSessionStore:
         """
         cur = self.sydent.db.cursor()
 
+        sql = """
+        update threepid_token_auths 
+        set next_link_used = ?
+        where validationSession = ? and token = ?
+        """
 
-        self.sydent.db.commit()
+        # Commits and rollsback in case of an exception
+        with self.sydent.db:
+            cur.execute(sql, (next_link, sid, token))
 
     def getValidatedSession(self, sid, clientSecret):
         """

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -86,26 +86,6 @@ class ThreePidValSessionStore:
         cur.execute("update threepid_token_auths set sendAttemptNumber = ? where id = ?", (attemptNo, sid))
         self.sydent.db.commit()
 
-    def setValidated(self, sid, validated, commit=True):
-        """Set the validation status of a threepid validation session
-
-        :param sid: The session ID
-        :type sid: str
-
-        :param validated: Whether a session is validated or not
-        :type validated: bool
-
-        :param commit: Whether to commit to the database. Used in applying other
-            database operations atomically. Defaults to True
-        :type bool: bool
-        """
-        cur = self.sydent.db.cursor()
-
-        cur.execute("update threepid_validation_sessions set validated = ? where id = ?", (validated, sid))
-
-        if commit:
-            self.sydent.db.commit()
-
     def setMtime(self, sid, mtime):
         cur = self.sydent.db.cursor()
 
@@ -179,32 +159,6 @@ class ThreePidValSessionStore:
         token_next_link = row[0]
 
         return token_next_link != next_link
-
-    def set_next_link_for_token(self, sid, token, next_link):
-        """Set which next_link was used when using a session token
-
-        :param sid: The session ID
-        :type sid: str
-
-        :param token: The validation token
-        :type token: str
-
-        :param next_link: The next_link parameter used in submitting this validation
-        :type next_link: str
-
-        :raises IntegrityError: on database transaction failure
-        """
-        cur = self.sydent.db.cursor()
-
-        sql = """
-        update threepid_token_auths 
-        set next_link_used = ?
-        where validationSession = ? and token = ?
-        """
-
-        # Commits and rolls back in case of an exception
-        with self.sydent.db:
-            cur.execute(sql, (next_link, sid, token))
 
     def getValidatedSession(self, sid, clientSecret):
         """

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -139,10 +139,13 @@ class ThreePidValSessionStore:
             value is NULL.
         :rtype: bool
         """
-        #TODO: Check if it's already been validated, and if so then check next_link is
-        # different. None or not
-        # Get the stored next_link value for this token
         cur = self.sydent.db.cursor()
+
+        # Check if this session has already been validated
+        s = self.getTokenSessionById(sid)
+        if not s.validated:
+            # This session has not been validated before, we allow it to be
+            return False
 
         cur.execute("select next_link_used from threepid_token_auths "
                     "where validationSession = ? and token = ?",

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -132,7 +132,10 @@ class EmailValidateCodeServlet(Resource):
                 'error': 'Invalid value for client_secret',
             }
 
-        next_link = request.args.get('next_link')
+        # Safely extract next_link from request arguments
+        next_link = request.args.get('nextLink')
+        if next_link:
+            next_link = next_link[0]
 
         try:
             resp = self.sydent.validators.email.validateSessionWithToken(

--- a/sydent/validators/__init__.py
+++ b/sydent/validators/__init__.py
@@ -49,3 +49,7 @@ class SessionNotValidatedException(Exception):
 
 class DestinationRejectedException(Exception):
     pass
+
+
+class NextLinkValidationException(Exception):
+    pass

--- a/sydent/validators/__init__.py
+++ b/sydent/validators/__init__.py
@@ -52,4 +52,7 @@ class DestinationRejectedException(Exception):
 
 
 class NextLinkValidationException(Exception):
+    """Occurs when the next_link parameter provided by a client to 3PID
+    validation endpoints is invalid for some reason
+    """
     pass

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -1,16 +1,19 @@
 import logging
 
 from sydent.db.valsession import ThreePidValSessionStore
-from sydent.validators import ValidationSession, SessionExpiredException
+from sydent.validators import (
+    ValidationSession,
+    SessionExpiredException,
+    IncorrectClientSecretException,
+    NextLinkValidationException,
+)
 from sydent.util import time_msec
-
-from sydent.validators import IncorrectClientSecretException, SessionExpiredException
 
 
 logger = logging.getLogger(__name__)
 
 
-def validateSessionWithToken(sydent, sid, clientSecret, token):
+def validateSessionWithToken(sydent, sid, clientSecret, token, next_link=None):
     """
     Attempt to validate a session, identified by the sid, using
     the token from out-of-band. The client secret is given to
@@ -18,6 +21,26 @@ def validateSessionWithToken(sydent, sid, clientSecret, token):
     If the session was sucessfully validated, return a dict
     with 'success': True that can be sent to the client,
     otherwise return False.
+
+    :param sid: The session ID
+    :type sid: str
+
+    :param clientSecret: The client_secret originally set when requesting the session
+    :type clientSecret: str
+
+    :param token: The validation token
+    :type token: str
+
+    :param next_link: The link to redirect the client to after validation, if provided
+    :type next_link: str|None
+
+    :return: The JSON to return to the client on success, or False on fail
+    :rtype: Dict|bool
+
+    :raises IncorrectClientSecretException if the client secret does not match the sid
+    :raises SessionExpiredException is the provided session has expired
+    :raises NextLinkValidationException if the next_link provided is different
+        from one provided in a previous, successful validation attempt
     """
     valSessionStore = ThreePidValSessionStore(sydent)
     s = valSessionStore.getTokenSessionById(sid)
@@ -33,13 +56,25 @@ def validateSessionWithToken(sydent, sid, clientSecret, token):
         logger.info("Session expired")
         raise SessionExpiredException()
 
+    # Check whether this session has already been validated with a next_link provided
+    # If so, and the next_link this time around is different than previously, then the
+    # user may be getting phished. Reject the validation attempt.
+    if next_link and valSessionStore.next_link_differs(sid, token, next_link):
+        logger.info(
+            "Validation attempt rejected as provided next_link is different "
+            "from that in a previous, successful validation attempt with this "
+            "session id"
+        )
+        raise NextLinkValidationException()
+
     # TODO once we can validate the token oob
     #if tokenObj.validated and clientSecret == tokenObj.clientSecret:
     #    return True
 
     if s.token == token:
-        logger.info("Setting session %s as validated", (s.id))
+        logger.info("Setting session %s as validated", s.id)
         valSessionStore.setValidated(s.id, True)
+        valSessionStore.set_next_link_for_token(s.id, s.token, next_link)
 
         return {'success': True}
     else:

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -56,8 +56,8 @@ def validateSessionWithToken(sydent, sid, clientSecret, token, next_link=None):
         logger.info("Session expired")
         raise SessionExpiredException()
 
-    # Check whether this session has already been validated with a next_link provided
-    # If so, and the next_link this time around is different than previously, then the
+    # Check whether this session has already been validated with a next_link
+    # If so, and the next_link this time around is different, then the
     # user may be getting phished. Reject the validation attempt.
     if next_link and valSessionStore.next_link_differs(sid, token, next_link):
         logger.info(

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -45,11 +45,11 @@ def validateSessionWithToken(sydent, sid, clientSecret, token, next_link=None):
     valSessionStore = ThreePidValSessionStore(sydent)
     s = valSessionStore.getTokenSessionById(sid)
     if not s:
-        logger.info("Session ID %s not found", (sid))
+        logger.info("Session ID %s not found", (sid,))
         return False
 
     if not clientSecret == s.clientSecret:
-        logger.info("Incorrect client secret", (sid))
+        logger.info("Incorrect client secret", (sid,))
         raise IncorrectClientSecretException()
 
     if s.mtime + ValidationSession.THREEPID_SESSION_VALIDATION_TIMEOUT_MS < time_msec():
@@ -74,7 +74,8 @@ def validateSessionWithToken(sydent, sid, clientSecret, token, next_link=None):
     if s.token == token:
         logger.info("Setting session %s as validated", s.id)
         valSessionStore.setValidated(s.id, True)
-        valSessionStore.set_next_link_for_token(s.id, s.token, next_link)
+        if next_link:
+            valSessionStore.set_next_link_for_token(s.id, s.token, next_link)
 
         return {'success': True}
     else:

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -23,8 +23,6 @@ from sydent.validators import common
 
 from sydent.util import time_msec
 
-from sydent.validators import IncorrectClientSecretException, SessionExpiredException
-
 logger = logging.getLogger(__name__)
 
 
@@ -82,5 +80,29 @@ class EmailValidator:
             link += "&nextLink=%s" % (urllib.quote(nextLink))
         return link
 
-    def validateSessionWithToken(self, sid, clientSecret, token):
-        return common.validateSessionWithToken(self.sydent, sid, clientSecret, token)
+    def validateSessionWithToken(self, sid, clientSecret, token, next_link=None):
+        """Validate a 3PID validation session
+
+        :param sid: The session ID
+        :type sid: str
+
+        :param clientSecret: The client_secret originally set when requesting the session
+        :type clientSecret: str
+
+        :param token: The validation token
+        :type token: str
+
+        :param next_link: The link to redirect the client to after validation, if provided
+        :type next_link: str|None
+
+        :return: The JSON to return to the client on success, or False on fail
+        :rtype: Dict|bool
+
+        :raises IncorrectClientSecretException if the client secret does not match the sid
+        :raises SessionExpiredException is the provided session has expired
+        :raises NextLinkValidationException if the next_link provided is different
+            from one provided in a previous, successful validation attempt
+        """
+        return common.validateSessionWithToken(
+            self.sydent, sid, clientSecret, token, next_link
+        )


### PR DESCRIPTION
This PR makes sydent delete all tokens for a validation session upon successful validation, thus making it so a validation of a session can only occur once.