### PR TITLE
[DINUM] Validate client_secret parameter according to the spec

### DIFF
--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -19,6 +19,7 @@ from twisted.web.resource import Resource
 from sydent.util.emailutils import EmailAddressException, EmailSendException
 from sydent.validators.emailvalidator import SessionExpiredException
 from sydent.validators.emailvalidator import IncorrectClientSecretException
+from sydent.util.stringutils import is_valid_client_secret
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 
@@ -40,6 +41,14 @@ class EmailRequestCodeServlet(Resource):
 
         email = args['email']
         clientSecret = args['client_secret']
+
+        if not is_valid_client_secret(clientSecret):
+            request.setResponseCode(400)
+            return {
+                'errcode': 'M_INVALID_PARAM',
+                'error': 'Invalid value for client_secret',
+            }
+
         sendAttempt = args['send_attempt']
 
         ipaddress = self.sydent.ip_from_request(request)
@@ -112,6 +121,13 @@ class EmailValidateCodeServlet(Resource):
         sid = args['sid']
         tokenString = args['token']
         clientSecret = args['client_secret']
+
+        if not is_valid_client_secret(clientSecret):
+            request.setResponseCode(400)
+            return {
+                'errcode': 'M_INVALID_PARAM',
+                'error': 'Invalid value for client_secret',
+            }
 
         try:
             resp = self.sydent.validators.email.validateSessionWithToken(sid, clientSecret, tokenString)

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -22,6 +22,7 @@ from sydent.http.servlets import jsonwrap, get_args
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.validators import SessionExpiredException, IncorrectClientSecretException, InvalidSessionIdException,\
     SessionNotValidatedException
+from sydent.util.stringutils import is_valid_client_secret
 
 class GetValidated3pidServlet(Resource):
     isLeaf = True
@@ -37,6 +38,13 @@ class GetValidated3pidServlet(Resource):
 
         sid = args['sid']
         clientSecret = args['client_secret']
+
+        if not is_valid_client_secret(clientSecret):
+            request.setResponseCode(400)
+            return {
+                'errcode': 'M_INVALID_PARAM',
+                'error': 'Invalid value for client_secret',
+            }
 
         valSessionStore = ThreePidValSessionStore(self.sydent)
 

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -24,6 +24,7 @@ from sydent.validators import (
 )
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
+from sydent.util.stringutils import is_valid_client_secret
 
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,13 @@ class MsisdnRequestCodeServlet(Resource):
         country = args['country']
         clientSecret = args['client_secret']
         sendAttempt = args['send_attempt']
+
+        if not is_valid_client_secret(clientSecret):
+            request.setResponseCode(400)
+            return {
+                'errcode': 'M_INVALID_PARAM',
+                'error': 'Invalid value for client_secret',
+            }
 
         try:
             phone_number_object = phonenumbers.parse(raw_phone_number, country)
@@ -138,6 +146,12 @@ class MsisdnValidateCodeServlet(Resource):
         sid = args['sid']
         tokenString = args['token']
         clientSecret = args['client_secret']
+
+        if not is_valid_client_secret(clientSecret):
+            return {
+                'errcode': 'M_INVALID_PARAM',
+                'error': 'Invalid value for client_secret',
+            }
 
         try:
             resp = self.sydent.validators.msisdn.validateSessionWithToken(sid, clientSecret, tokenString)

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -16,11 +16,13 @@
 
 from twisted.web.resource import Resource
 
+from sydent.util.stringutils import is_valid_client_secret
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.validators import SessionExpiredException, IncorrectClientSecretException, InvalidSessionIdException,\
     SessionNotValidatedException
 from sydent.threepid.bind import BindingNotPermittedException
+
 
 class ThreePidBindServlet(Resource):
     def __init__(self, sydent):
@@ -36,6 +38,13 @@ class ThreePidBindServlet(Resource):
         sid = args['sid']
         mxid = args['mxid']
         clientSecret = args['client_secret']
+
+        if not is_valid_client_secret(clientSecret):
+            request.setResponseCode(400)
+            return {
+                'errcode': 'M_INVALID_PARAM',
+                'error': 'Invalid value for client_secret',
+            }
 
         # Return the same error for not found / bad client secret otherwise people can get information about
         # sessions without knowing the secret

--- a/sydent/util/stringutils.py
+++ b/sydent/util/stringutils.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+client_secret_regex = re.compile(r"^[0-9a-zA-Z.=_-]+$")
+
+
+def is_valid_client_secret(client_secret):
+    """Validate that a given string matches the client_secret regex defined by the spec
+
+    :param client_secret: The client_secret to validate
+    :type client_secret: str
+
+    :returns: Whether the client_secret is valid
+    :rtype: bool
+    """
+    return client_secret_regex.match(client_secret) is not None

--- a/sydent/util/stringutils.py
+++ b/sydent/util/stringutils.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 import re
 
-client_secret_regex = re.compile(r"^[0-9a-zA-Z.=_-]+$")
+# https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-register-email-requesttoken
+client_secret_regex = re.compile(r"^[0-9a-zA-Z\.\=\_\-]+$")
 
 
 def is_valid_client_secret(client_secret):


### PR DESCRIPTION
[According to the spec](https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-register-email-requesttoken), `client_secret` should follow the regex `[0-9a-zA-Z.=_-]`.

This PR asserts that.

CI is expected to fail as unit tests nor matrix-is-tester are on the `dinsic` branch yet :/