### PR TITLE
Add Python 3 support for requesting tokens

### DIFF
--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -35,7 +35,7 @@ class ThreePidValSessionStore:
         or creates one if none was found.
 
         :param medium: The medium to use when looking up or creating the session.
-        :type medium: str
+        :type medium: unicode
         :param address: The address to use when looking up or creating the session.
         :type address: unicode
         :param clientSecret: The client secret to use when looking up or creating the
@@ -73,7 +73,7 @@ class ThreePidValSessionStore:
         Creates a validation session with the given parameters.
 
         :param medium: The medium to create the session for.
-        :type medium: str
+        :type medium: unicode
         :param address: The address to create the session for.
         :type address: unicode
         :param clientSecret: The client secret to use when looking up or creating the

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -38,9 +38,7 @@ class ThreePidValSessionStore:
         row = cur.fetchone()
 
         if row:
-            s = ValidationSession(row[0], row[1], row[2], row[3], row[4], row[5])
-            s.token = row[6]
-            s.sendAttemptNumber = row[7]
+            s = ValidationSession(row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7])
             return s
 
         sid = self.addValSession(medium, address, clientSecret, time_msec(), commit=False)
@@ -51,9 +49,7 @@ class ThreePidValSessionStore:
                     (sid, tokenString, -1))
         self.sydent.db.commit()
 
-        s = ValidationSession(sid, medium, address, clientSecret, False, time_msec())
-        s.token = tokenString
-        s.sendAttemptNumber = -1
+        s = ValidationSession(sid, medium, address, clientSecret, False, time_msec(), tokenString, -1)
         return s
 
     def addValSession(self, medium, address, clientSecret, mtime, commit=True):
@@ -97,7 +93,7 @@ class ThreePidValSessionStore:
          if not row:
              return None
 
-         return ValidationSession(row[0], row[1], row[2], row[3], row[4], row[5])
+         return ValidationSession(row[0], row[1], row[2], row[3], row[4], row[5], None, None)
 
     def getTokenSessionById(self, sid):
         cur = self.sydent.db.cursor()
@@ -108,9 +104,7 @@ class ThreePidValSessionStore:
         row = cur.fetchone()
 
         if row:
-            s = ValidationSession(row[0], row[1], row[2], row[3], row[4], row[5])
-            s.token = row[6]
-            s.sendAttemptNumber = row[7]
+            s = ValidationSession(row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7])
             return s
 
         return None

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import sydent.util.tokenutils
 
@@ -29,6 +30,21 @@ class ThreePidValSessionStore:
         self.random = SystemRandom()
 
     def getOrCreateTokenSession(self, medium, address, clientSecret):
+        """
+        Retrieves the validation session for a given medium, address and client secret,
+        or creates one if none was found.
+
+        :param medium: The medium to use when looking up or creating the session.
+        :type medium: str
+        :param address: The address to use when looking up or creating the session.
+        :type address: unicode
+        :param clientSecret: The client secret to use when looking up or creating the
+            session.
+        :type clientSecret: unicode
+
+        :return: The session that was retrieved or created.
+        :rtype: ValidationSession
+        """
         cur = self.sydent.db.cursor()
 
         cur.execute("select s.id, s.medium, s.address, s.clientSecret, s.validated, s.mtime, "
@@ -53,6 +69,25 @@ class ThreePidValSessionStore:
         return s
 
     def addValSession(self, medium, address, clientSecret, mtime, commit=True):
+        """
+        Creates a validation session with the given parameters.
+
+        :param medium: The medium to create the session for.
+        :type medium: str
+        :param address: The address to create the session for.
+        :type address: unicode
+        :param clientSecret: The client secret to use when looking up or creating the
+            session.
+        :type clientSecret: unicode
+        :param mtime: The current time in milliseconds.
+        :type mtime: int
+        :param commit: Whether to commit the transaction after executing the insert
+            statement.
+        :type commit: bool
+
+        :return: The ID of the created session.
+        :rtype: int
+        """
         cur = self.sydent.db.cursor()
 
         # Let's make up a random sid rather than using sequential ones. This
@@ -66,6 +101,14 @@ class ThreePidValSessionStore:
         return sid
 
     def setSendAttemptNumber(self, sid, attemptNo):
+        """
+        Updates the send attempt number for the session with the given ID.
+
+        :param sid: The ID of the session to update
+        :type sid: int
+        :param attemptNo: The send attempt number to update the session with.
+        :type attemptNo: int
+        """
         cur = self.sydent.db.cursor()
 
         cur.execute("update threepid_token_auths set sendAttemptNumber = ? where id = ?", (attemptNo, sid))
@@ -78,6 +121,14 @@ class ThreePidValSessionStore:
         self.sydent.db.commit()
 
     def setMtime(self, sid, mtime):
+        """
+        Set the time of the last send attempt for the session with the given ID
+
+        :param sid: The ID of the session to update.
+        :type sid: int
+        :param mtime: The time of the last send attempt for that session.
+        :type mtime: int
+        """
         cur = self.sydent.db.cursor()
 
         cur.execute("update threepid_validation_sessions set mtime = ? where id = ?", (mtime, sid))

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -51,7 +51,7 @@ def get_args(request, required_args):
     :type request: twisted.web.server.Request
     :param required_args: The args that needs to be found in the
         request's parameters.
-    :type required_args: tuple[bytes]
+    :type required_args: tuple[unicode]
 
     :return: A dict containing the requested args and their values. String values
         are of type unicode.

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -48,8 +48,6 @@ class EmailRequestCodeServlet(Resource):
         if 'next_link' in args and not args['next_link'].startswith("file:///"):
             nextLink = args['next_link']
 
-        resp = None
-
         try:
             sid = self.sydent.validators.email.requestToken(
                 email, clientSecret, sendAttempt, nextLink, ipaddress=ipaddress

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -13,12 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 
 from sydent.util.emailutils import EmailAddressException, EmailSendException
-from sydent.validators.emailvalidator import SessionExpiredException
-from sydent.validators.emailvalidator import IncorrectClientSecretException
+from sydent.validators import IncorrectClientSecretException, SessionExpiredException
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.http.auth import authIfV2
@@ -54,15 +54,13 @@ class EmailRequestCodeServlet(Resource):
             sid = self.sydent.validators.email.requestToken(
                 email, clientSecret, sendAttempt, nextLink, ipaddress=ipaddress
             )
+            resp = {'success': True, 'sid': str(sid)}
         except EmailAddressException:
             request.setResponseCode(400)
-            resp = {'errcode': 'M_INVALID_EMAIL', 'error':'Invalid email address'}
+            resp = {'errcode': 'M_INVALID_EMAIL', 'error': 'Invalid email address'}
         except EmailSendException:
             request.setResponseCode(500)
             resp = {'errcode': 'M_EMAIL_SEND_ERROR', 'error': 'Failed to send email'}
-
-        if not resp:
-            resp = {'success': True, 'sid': str(sid)}
 
         return resp
 

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 from twisted.web.resource import Resource
@@ -66,26 +67,22 @@ class MsisdnRequestCodeServlet(Resource):
             phone_number_object, phonenumbers.PhoneNumberFormat.INTERNATIONAL
         )
 
-        resp = None
-
         try:
             sid = self.sydent.validators.msisdn.requestToken(
-                phone_number_object, clientSecret, sendAttempt, None
+                phone_number_object, clientSecret, sendAttempt
             )
+            resp = {
+                'success': True, 'sid': str(sid),
+                'msisdn': msisdn, 'intl_fmt': intl_fmt,
+            }
         except DestinationRejectedException:
             logger.error("Destination rejected for number: %s", msisdn);
             request.setResponseCode(400)
             resp = {'errcode': 'M_DESTINATION_REJECTED', 'error': 'Phone numbers in this country are not currently supported'}
         except Exception as e:
-            logger.error("Exception sending SMS: %r", e);
+            logger.error("Exception sending SMS: %r", e)
             request.setResponseCode(500)
-            resp = {'errcode': 'M_UNKNOWN', 'error':'Internal Server Error'}
-
-        if not resp:
-            resp = {
-                'success': True, 'sid': str(sid),
-                'msisdn': msisdn, 'intl_fmt': intl_fmt,
-            }
+            resp = {'errcode': 'M_UNKNOWN', 'error': 'Internal Server Error'}
 
         return resp
 

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -76,7 +76,7 @@ class MsisdnRequestCodeServlet(Resource):
                 'msisdn': msisdn, 'intl_fmt': intl_fmt,
             }
         except DestinationRejectedException:
-            logger.error("Destination rejected for number: %s", msisdn);
+            logger.error("Destination rejected for number: %s", msisdn)
             request.setResponseCode(400)
             resp = {'errcode': 'M_DESTINATION_REJECTED', 'error': 'Phone numbers in this country are not currently supported'}
         except Exception as e:

--- a/sydent/sms/openmarket.py
+++ b/sydent/sms/openmarket.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 from base64 import b64encode
@@ -37,7 +38,17 @@ TONS = {
     'alpha': 5,
 }
 
+
 def tonFromType(t):
+    """
+    Get the type of number from the originator's type.
+
+    :param t: Type from the originator.
+    :type t: str
+
+    :return: The type of number.
+    :rtype: int
+    """
     if t in TONS:
         return TONS[t]
     raise Exception("Unknown number type (%s) for originator" % t)
@@ -50,6 +61,15 @@ class OpenMarketSMS:
 
     @defer.inlineCallbacks
     def sendTextSMS(self, body, dest, source=None):
+        """
+        Sends a text message with the given body to the given MSISDN.
+
+        :param body: The message to send.
+        :type body: str
+        :param dest: The destination MSISDN to send the text message to.
+        :type dest: unicode
+        :type source: dict[str, str] or None
+        """
         body = {
             "mobileTerminate": {
                 "message": {
@@ -77,7 +97,7 @@ class OpenMarketSMS:
         })
 
         resp = yield self.http_cli.post_json_get_nothing(
-            API_BASE_URL, body, { "headers": headers }
+            API_BASE_URL, body, {"headers": headers}
         )
         headers = dict(resp.headers.getAllRawHeaders())
 
@@ -88,4 +108,3 @@ class OpenMarketSMS:
         parts = headers['Location'][0].split('/')
         if len(parts) < 2:
             raise Exception("Got response from sending SMS with malformed location header")
-        defer.returnValue(parts[-1])

--- a/sydent/sms/openmarket.py
+++ b/sydent/sms/openmarket.py
@@ -89,14 +89,8 @@ class OpenMarketSMS:
 
         # Make sure username and password are bytes otherwise we can't use them with
         # b64encode.
-        username = self.sydent.cfg.get('sms', 'username')
-        password = self.sydent.cfg.get('sms', 'password')
-
-        if not isinstance(username, bytes):
-            username = username.encode("UTF-8")
-
-        if not isinstance(password, bytes):
-            password = password.encode("UTF-8")
+        username = self.sydent.cfg.get('sms', 'username').encode("UTF-8")
+        password = self.sydent.cfg.get('sms', 'password').encode("UTF-8")
 
         b64creds = b64encode(b"%s:%s" % (username, password))
         headers = Headers({

--- a/sydent/sms/openmarket.py
+++ b/sydent/sms/openmarket.py
@@ -87,10 +87,18 @@ class OpenMarketSMS:
                 "address": source['text'],
             }
 
-        b64creds = b64encode(b"%s:%s" % (
-            self.sydent.cfg.get('sms', 'username'),
-            self.sydent.cfg.get('sms', 'password'),
-        ))
+        # Make sure username and password are bytes otherwise we can't use them with
+        # b64encode.
+        username = self.sydent.cfg.get('sms', 'username')
+        password = self.sydent.cfg.get('sms', 'password')
+
+        if not isinstance(username, bytes):
+            username = username.encode("UTF-8")
+
+        if not isinstance(password, bytes):
+            password = password.encode("UTF-8")
+
+        b64creds = b64encode(b"%s:%s" % (username, password))
         headers = Headers({
             b"Authorization": [b"Basic " + b64creds],
             b"Content-Type": [b"application/json"],

--- a/sydent/util/__init__.py
+++ b/sydent/util/__init__.py
@@ -16,5 +16,12 @@
 
 import time
 
+
 def time_msec():
+    """
+    Get the current time in milliseconds.
+
+    :return: The current time in milliseconds.
+    :rtype: int
+    """
     return int(time.time() * 1000)

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 import socket
@@ -21,8 +22,14 @@ import smtplib
 import email.utils
 import string
 import twisted.python.log
-import cgi
-import urllib
+import six
+from six.moves import urllib
+from six.moves import range
+
+if six.PY2:
+    from cgi import escape
+else:
+    from html import escape
 
 import email.utils
 
@@ -32,68 +39,81 @@ logger = logging.getLogger(__name__)
 
 
 def sendEmail(sydent, templateName, mailTo, substitutions):
-        mailFrom = sydent.cfg.get('email', 'email.from')
-        mailTemplateFile = sydent.cfg.get('email', templateName)
+    """
+    Sends an email with the given parameters.
 
-        myHostname = sydent.cfg.get('email', 'email.hostname')
-        if myHostname == '':
-            myHostname = socket.getfqdn()
-        midRandom = "".join([random.choice(string.ascii_letters) for _ in range(16)])
-        messageid = "<%d%s@%s>" % (time_msec(), midRandom, myHostname)
+    :param sydent: The Sydent instance to use when building the configuration to send the
+        email with.
+    :type sydent: sydent.sydent.Sydent
+    :param templateName: The name of the template to use when building the body of the
+        email.
+    :type templateName: str
+    :param mailTo: The email address to send the email to.
+    :type mailTo: unicode
+    :param substitutions: The substitutions to use with the template.
+    :type substitutions: dict[str, str]
+    """
+    mailFrom = sydent.cfg.get('email', 'email.from')
+    mailTemplateFile = sydent.cfg.get('email', templateName)
 
-        allSubstitutions = {}
-        allSubstitutions.update(substitutions)
-        allSubstitutions.update({
-            'messageid': messageid,
-            'date': email.utils.formatdate(localtime=False),
-            'to': mailTo,
-            'from': mailFrom,
-        })
+    myHostname = sydent.cfg.get('email', 'email.hostname')
+    if myHostname == '':
+        myHostname = socket.getfqdn()
+    midRandom = "".join([random.choice(string.ascii_letters) for _ in range(16)])
+    messageid = "<%d%s@%s>" % (time_msec(), midRandom, myHostname)
 
-        for k,v in allSubstitutions.items():
-            allSubstitutions[k] = v.decode('utf8')
-            allSubstitutions[k+"_forhtml"] = cgi.escape(v.decode('utf8'))
-            allSubstitutions[k+"_forurl"] = urllib.quote(v)
+    substitutions.update({
+        'messageid': messageid,
+        'date': email.utils.formatdate(localtime=False),
+        'to': mailTo,
+        'from': mailFrom,
+    })
 
-        mailString = open(mailTemplateFile).read().decode('utf8') % allSubstitutions
-        parsedFrom = email.utils.parseaddr(mailFrom)[1]
-        parsedTo = email.utils.parseaddr(mailTo)[1]
-        if parsedFrom == '' or parsedTo == '':
-            logger.info("Couldn't parse from / to address %s / %s", mailFrom, mailTo)
-            raise EmailAddressException()
+    allSubstitutions = {}
+    for k, v in substitutions.items():
+        allSubstitutions[k] = v
+        allSubstitutions[k+"_forhtml"] = escape(v)
+        allSubstitutions[k+"_forurl"] = urllib.parse.quote(v)
 
-        if parsedTo != mailTo:
-            logger.info("Parsed to address changed the address: %s -> %s", mailTo, parsedTo)
-            raise EmailAddressException()
+    mailString = open(mailTemplateFile).read() % allSubstitutions
+    parsedFrom = email.utils.parseaddr(mailFrom)[1]
+    parsedTo = email.utils.parseaddr(mailTo)[1]
+    if parsedFrom == '' or parsedTo == '':
+        logger.info("Couldn't parse from / to address %s / %s", mailFrom, mailTo)
+        raise EmailAddressException()
 
-        mailServer = sydent.cfg.get('email', 'email.smtphost')
-        mailPort = sydent.cfg.get('email', 'email.smtpport')
-        mailUsername = sydent.cfg.get('email', 'email.smtpusername')
-        mailPassword = sydent.cfg.get('email', 'email.smtppassword')
-        mailTLSMode = sydent.cfg.get('email', 'email.tlsmode')
-        logger.info("Sending mail to %s with mail server: %s" % (mailTo, mailServer,))
-        try:
-            if mailTLSMode == 'SSL' or mailTLSMode == 'TLS':
-                smtp = smtplib.SMTP_SSL(mailServer, mailPort, myHostname)
-            elif mailTLSMode == 'STARTTLS':
-                smtp = smtplib.SMTP(mailServer, mailPort, myHostname)
-                smtp.starttls()
-            else:
-                smtp = smtplib.SMTP(mailServer, mailPort, myHostname)
-            if mailUsername != '':
-                smtp.login(mailUsername, mailPassword)
+    if parsedTo != mailTo:
+        logger.info("Parsed to address changed the address: %s -> %s", mailTo, parsedTo)
+        raise EmailAddressException()
 
-            # We're using the parsing above to do basic validation, but instead of
-            # failing it may munge the address it returns. So we should *not* use
-            # that parsed address, as it may not match any validation done
-            # elsewhere.
-            smtp.sendmail(mailFrom, mailTo, mailString.encode('utf-8'))
-            smtp.quit()
-        except Exception as origException:
-            twisted.python.log.err()
-            ese = EmailSendException()
-            ese.cause = origException
-            raise ese
+    mailServer = sydent.cfg.get('email', 'email.smtphost')
+    mailPort = sydent.cfg.get('email', 'email.smtpport')
+    mailUsername = sydent.cfg.get('email', 'email.smtpusername')
+    mailPassword = sydent.cfg.get('email', 'email.smtppassword')
+    mailTLSMode = sydent.cfg.get('email', 'email.tlsmode')
+    logger.info("Sending mail to %s with mail server: %s" % (mailTo, mailServer,))
+    try:
+        if mailTLSMode == 'SSL' or mailTLSMode == 'TLS':
+            smtp = smtplib.SMTP_SSL(mailServer, mailPort, myHostname)
+        elif mailTLSMode == 'STARTTLS':
+            smtp = smtplib.SMTP(mailServer, mailPort, myHostname)
+            smtp.starttls()
+        else:
+            smtp = smtplib.SMTP(mailServer, mailPort, myHostname)
+        if mailUsername != '':
+            smtp.login(mailUsername, mailPassword)
+
+        # We're using the parsing above to do basic validation, but instead of
+        # failing it may munge the address it returns. So we should *not* use
+        # that parsed address, as it may not match any validation done
+        # elsewhere.
+        smtp.sendmail(mailFrom, mailTo, mailString.encode('utf-8'))
+        smtp.quit()
+    except Exception as origException:
+        twisted.python.log.err()
+        ese = EmailSendException()
+        ese.cause = origException
+        raise ese
 
 
 class EmailAddressException(Exception):

--- a/sydent/util/stringutils.py
+++ b/sydent/util/stringutils.py
@@ -22,8 +22,9 @@ client_secret_regex = re.compile(r"^[0-9a-zA-Z\.\=\_\-\:]+$")
 
 def is_valid_client_secret(client_secret):
     """Validate that a given string matches the client_secret regex defined by the spec
+
     :param client_secret: The client_secret to validate
-    :type client_secret: str
+    :type client_secret: unicode
     :returns: Whether the client_secret is valid
     :rtype: bool
     """

--- a/sydent/util/tokenutils.py
+++ b/sydent/util/tokenutils.py
@@ -19,24 +19,36 @@ import random
 
 r = random.SystemRandom()
 
+
 def generateTokenForMedium(medium):
     """
     Generates a token of a different format depending on the medium, a 32 characters
     alphanumeric one if the medium is email, a 6 characters numeric one otherwise.
 
     :param medium: The medium to generate a token for.
-    :type medium: str
+    :type medium: unicode
 
     :return: The generated token.
-    :rtype: str
+    :rtype: unicode
     """
     if medium == 'email':
         return generateAlphanumericTokenOfLength(32)
     else:
         return generateNumericTokenOfLength(6)
 
+
 def generateNumericTokenOfLength(length):
-    return "".join([r.choice(string.digits) for _ in range(length)])
+    """
+    Generates a token of the given length with the character set [0-9].
+
+    :param length: The length of the token to generate.
+    :type length: int
+
+    :return: The generated token.
+    :rtype: unicode
+    """
+    return u"".join([r.choice(string.digits) for _ in range(length)])
+
 
 def generateAlphanumericTokenOfLength(length):
     """

--- a/sydent/util/tokenutils.py
+++ b/sydent/util/tokenutils.py
@@ -20,6 +20,16 @@ import random
 r = random.SystemRandom()
 
 def generateTokenForMedium(medium):
+    """
+    Generates a token of a different format depending on the medium, a 32 characters
+    alphanumeric one if the medium is email, a 6 characters numeric one otherwise.
+
+    :param medium: The medium to generate a token for.
+    :type medium: str
+
+    :return: The generated token.
+    :rtype: str
+    """
     if medium == 'email':
         return generateAlphanumericTokenOfLength(32)
     else:

--- a/sydent/validators/__init__.py
+++ b/sydent/validators/__init__.py
@@ -22,13 +22,15 @@ class ValidationSession:
     # how long we keep sessions for after they've been validated
     THREEPID_SESSION_VALID_LIFETIME_MS = 24 * 60 * 60 * 1000
 
-    def __init__(self, _id, _medium, _address, _clientSecret, _validated, _mtime):
+    def __init__(self, _id, _medium, _address, _clientSecret, _validated, _mtime, _token, _sendAttemptNumber):
         self.id = _id
         self.medium = _medium
         self.address = _address
         self.clientSecret = _clientSecret
         self.validated = _validated
         self.mtime = _mtime
+        self.token = _token
+        self.sendAttemptNumber = _sendAttemptNumber
 
 
 class IncorrectClientSecretException(Exception):

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -53,7 +53,7 @@ class EmailValidator:
         """
         valSessionStore = ThreePidValSessionStore(self.sydent)
 
-        valSession = valSessionStore.getOrCreateTokenSession(medium='email', address=emailAddress,
+        valSession = valSessionStore.getOrCreateTokenSession(medium=u'email', address=emailAddress,
                                                              clientSecret=clientSecret)
 
         valSessionStore.setMtime(valSession.id, time_msec())
@@ -62,7 +62,7 @@ class EmailValidator:
             logger.info("Not mailing code because current send attempt (%d) is not less than given send attempt (%s)", int(sendAttempt), int(valSession.sendAttemptNumber))
             return valSession.id
 
-        ipstring = ipaddress if ipaddress else "an unknown location"
+        ipstring = ipaddress if ipaddress else u"an unknown location"
 
         substitutions = {
             'ipaddress': ipstring,

--- a/sydent/validators/msisdnvalidator.py
+++ b/sydent/validators/msisdnvalidator.py
@@ -14,13 +14,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
-import urllib
 import phonenumbers
 
 from sydent.db.valsession import ThreePidValSessionStore
-from sydent.validators import ValidationSession, common
+from sydent.validators import common
 from sydent.sms.openmarket import OpenMarketSMS
 
 from sydent.validators import DestinationRejectedException
@@ -64,8 +64,21 @@ class MsisdnValidator:
 
                 self.smsRules[country] = action
 
+    def requestToken(self, phoneNumber, clientSecret, sendAttempt):
+        """
+        Creates or retrieves a validation session and sends an text message to the
+        corresponding phone number address with a token to use to verify the association.
 
-    def requestToken(self, phoneNumber, clientSecret, sendAttempt, nextLink):
+        :param phoneNumber: The phone number to send the email to.
+        :type phoneNumber: phonenumbers.PhoneNumber
+        :param clientSecret: The client secret to use.
+        :type clientSecret: unicode
+        :param sendAttempt: The current send attempt.
+        :type sendAttempt: int
+
+        :return: The ID of the session created (or of the existing one if any)
+        :rtype: int
+        """
         if str(phoneNumber.country_code) in self.smsRules:
             action = self.smsRules[str(phoneNumber.country_code)]
             if action == 'reject':
@@ -104,6 +117,15 @@ class MsisdnValidator:
         return valSession.id
 
     def getOriginator(self, destPhoneNumber):
+        """
+        Gets an originator for a given phone number.
+
+        :param destPhoneNumber: The phone number to find the originator for.
+        :type destPhoneNumber: phonenumbers.PhoneNumber
+
+        :return: The originator (a dict with a "type" key and a "text" key).
+        :rtype: dict[str, str]
+        """
         countryCode = str(destPhoneNumber.country_code)
 
         origs = [{


### PR DESCRIPTION
Add Python 3 support to token requests via MSISDN and email.

Based on #242, the new commits are the two "Add Python 3 support for requesting a token [...]" ones (and subsequent ones), and they should be reviewable independently.