### PR TITLE
Count replication updates correctly when deciding whether to push

### DIFF
--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -116,7 +116,12 @@ class Pusher:
             )
             push_data["ephemeral_public_keys"], ids["ephemeral_public_keys"] = keys
 
-            token_count = len(push_data["invite_tokens"])
+            # Count each of the inner dictionaries instead of the outer
+            # (which will always have len 2)
+            token_count = (
+                len(push_data["invite_tokens"]["added"]) +
+                len(push_data["invite_tokens"]["updated"])
+            )
             key_count = len(push_data["ephemeral_public_keys"])
             association_count = len(push_data["sg_assocs"])
 


### PR DESCRIPTION
We've been using `len(push_updates["invite_tokens"])` as part of counting how many items we need to replicate to other peers.

Since https://github.com/matrix-org/sydent/pull/236, `push_updates["invite_tokens"]` is no longer a dict of invite tokens, but a dict containing two more dicts: one for new `invite_token`s, and one for updates to existing tokens.

Unfortunately, this means that `len(push_updates["invite_tokens"])` now always returns 2, meaning we're always pushing updates out even if we don't need to be.

This PR changes the check to count the inner dicts instead.

CI is expected to fail.