### PR TITLE
[DINSIC] Parse replicated content dicts as sorted lists, such that they are processed in the correct order

### DIFF
--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -15,22 +15,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import twisted.python.log
 from twisted.web.resource import Resource
 from twisted.web import server
 from twisted.internet import defer
-from sydent.http.servlets import jsonwrap
 from sydent.threepid import threePidAssocFromDict
 from sydent.db.peers import PeerStore
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.replication.peer import NoMatchingSignatureException, NoSignaturesException, RemotePeerError
 from signedjson.sign import SignatureVerifyException
-from collections import OrderedDict
 
 import logging
 import json
-import time
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +34,7 @@ MAX_SG_ASSOCS_LIMIT = 100
 MAX_INVITE_TOKENS_LIMIT = 100
 MAX_INVITE_UPDATES_LIMIT = 100
 MAX_EPHEMERAL_PUBLIC_KEYS_LIMIT = 100
+
 
 class ReplicationPushServlet(Resource):
     def __init__(self, sydent):
@@ -108,9 +105,13 @@ class ReplicationPushServlet(Resource):
             return
 
         # Process signed associations
-        sg_assocs = OrderedDict(
-            sorted(inJson.get('sg_assocs', {}).items(), key=lambda k: k[0])
-        )
+
+        # Ensure associations are processed in order of origin_id.
+        # If we process them out of order, an association with an ID lesser
+        # than a previously processed association will be ignored.
+        sg_assocs = inJson.get('sg_assocs', {})
+        sg_assocs = sorted(sg_assocs.items())
+
         if len(sg_assocs) > MAX_SG_ASSOCS_LIMIT:
             logger.warn("Peer %s made push with 'sg_assocs' field containing %d entries, which is greater than the maximum %d", peer.servername, len(sg_assocs), MAX_SG_ASSOCS_LIMIT)
             request.setResponseCode(400)
@@ -121,7 +122,7 @@ class ReplicationPushServlet(Resource):
         globalAssocsStore = GlobalAssociationStore(self.sydent)
 
         # Check that this message is signed by one of our trusted associated peers
-        for originId, sgAssoc in sg_assocs.items():
+        for originId, sgAssoc in sg_assocs:
             try:
                 yield peer.verifySignedAssociation(sgAssoc)
                 logger.debug("Signed association from %s with origin ID %s verified", peer.servername, originId)
@@ -160,10 +161,13 @@ class ReplicationPushServlet(Resource):
 
         # Process any new invite tokens
 
+        # New and updated invite tokens come is as lists instead of dictionaries
+        # They are wrapped in a dictionary. Extract that first
         invite_tokens = inJson.get('invite_tokens', {})
-        new_invites = OrderedDict(
-            sorted(invite_tokens.get('added', {}).items(), key=lambda k: k[0])
-        )
+
+        # Then extract the list, ensuring tokens are processed in order of origin ID
+        new_invites = sorted(invite_tokens.get('added', []))
+
         if len(new_invites) > MAX_INVITE_TOKENS_LIMIT:
             self.sydent.db.rollback()
             logger.warning(
@@ -178,7 +182,7 @@ class ReplicationPushServlet(Resource):
             request.finish()
             return
 
-        for originId, inviteToken in new_invites.items():
+        for originId, inviteToken in new_invites:
             tokensStore.storeToken(inviteToken['medium'], inviteToken['address'], inviteToken['room_id'],
                                 inviteToken['sender'], inviteToken['token'],
                                 originServer=peer.servername, originId=originId,
@@ -187,9 +191,8 @@ class ReplicationPushServlet(Resource):
 
         # Process any invite token update
 
-        invite_updates = OrderedDict(
-            sorted(invite_tokens.get('updated', {}).items(), key=lambda k: k[0])
-        )
+        invite_updates = sorted(invite_tokens.get('updated', []))
+
         if len(invite_updates) > MAX_INVITE_UPDATES_LIMIT:
             self.sydent.db.rollback()
             logger.warning(
@@ -213,9 +216,9 @@ class ReplicationPushServlet(Resource):
 
         # Process any ephemeral public keys
 
-        ephemeral_public_keys = OrderedDict(
-            sorted(inJson.get('ephemeral_public_keys', {}).items(), key=lambda k: k[0])
-        )
+        ephemeral_public_keys = inJson.get("ephemeral_public_keys", {})
+        ephemeral_public_keys = sorted(ephemeral_public_keys.items())
+
         if len(ephemeral_public_keys) > MAX_EPHEMERAL_PUBLIC_KEYS_LIMIT:
             self.sydent.db.rollback()
             logger.warn("Peer %s made push with 'sg_assocs' field containing %d entries, which is greater than the maximum %d", peer.servername, len(ephemeral_public_keys), MAX_EPHEMERAL_PUBLIC_KEYS_LIMIT)
@@ -224,13 +227,13 @@ class ReplicationPushServlet(Resource):
             request.finish()
             return
 
-        for originId, ephemeralKey in ephemeral_public_keys.items():
+        for originId, ephemeralKey in ephemeral_public_keys:
             tokensStore.storeEphemeralPublicKey(
                 ephemeralKey['public_key'], persistenceTs=ephemeralKey['persistence_ts'],
                 originServer=peer.servername, originId=originId, commit=False)
             logger.info("Stored ephemeral key with origin ID %s from %s", originId, peer.servername)
 
         self.sydent.db.commit()
-        request.write(json.dumps({'success':True}))
+        request.write(json.dumps({'success': True}))
         request.finish()
         return

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -26,6 +26,7 @@ from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.replication.peer import NoMatchingSignatureException, NoSignaturesException, RemotePeerError
 from signedjson.sign import SignatureVerifyException
+from collections import OrderedDict
 
 import logging
 import json
@@ -107,7 +108,9 @@ class ReplicationPushServlet(Resource):
             return
 
         # Process signed associations
-        sg_assocs = inJson.get('sg_assocs', {})
+        sg_assocs = OrderedDict(
+            sorted(inJson.get('sg_assocs', {}).items(), key=lambda k: k[0])
+        )
         if len(sg_assocs) > MAX_SG_ASSOCS_LIMIT:
             logger.warn("Peer %s made push with 'sg_assocs' field containing %d entries, which is greater than the maximum %d", peer.servername, len(sg_assocs), MAX_SG_ASSOCS_LIMIT)
             request.setResponseCode(400)
@@ -158,7 +161,9 @@ class ReplicationPushServlet(Resource):
         # Process any new invite tokens
 
         invite_tokens = inJson.get('invite_tokens', {})
-        new_invites = invite_tokens.get('added', {})
+        new_invites = OrderedDict(
+            sorted(invite_tokens.get('added', {}).items(), key=lambda k: k[0])
+        )
         if len(new_invites) > MAX_INVITE_TOKENS_LIMIT:
             self.sydent.db.rollback()
             logger.warning(
@@ -182,7 +187,9 @@ class ReplicationPushServlet(Resource):
 
         # Process any invite token update
 
-        invite_updates = invite_tokens.get('updated', {})
+        invite_updates = OrderedDict(
+            sorted(invite_tokens.get('updated', {}).items(), key=lambda k: k[0])
+        )
         if len(invite_updates) > MAX_INVITE_UPDATES_LIMIT:
             self.sydent.db.rollback()
             logger.warning(
@@ -206,7 +213,9 @@ class ReplicationPushServlet(Resource):
 
         # Process any ephemeral public keys
 
-        ephemeral_public_keys = inJson.get('ephemeral_public_keys', {})
+        ephemeral_public_keys = OrderedDict(
+            sorted(inJson.get('ephemeral_public_keys', {}).items(), key=lambda k: k[0])
+        )
         if len(ephemeral_public_keys) > MAX_EPHEMERAL_PUBLIC_KEYS_LIMIT:
             self.sydent.db.rollback()
             logger.warn("Peer %s made push with 'sg_assocs' field containing %d entries, which is greater than the maximum %d", peer.servername, len(ephemeral_public_keys), MAX_EPHEMERAL_PUBLIC_KEYS_LIMIT)


### PR DESCRIPTION
When replicating data to other Sydents, we supply an ID of the original server along with each unit of data. This is an ever-incrementing ID, and allows the receiving Sydent to check if it's ever receiving an old update, by checking whether the ID of each item is greater than anything its processed before.

While this makes sense conceptually, unfortunately in implementation these items come wrapped in a dictionary, which if you iterate on may cause items to be processed out of order.

For instance, if a http replication request is sent containing:

```
{
13: add invite for dave
14: add invite for alice
15: add invite for bob
}
```

and since they're stored in a dictionary, it's possible for these value to be processed in the following order instance:

```
{
13: add invite for dave
15: add invite for bob
14: add invite for alice.
}
```

In this case, we'd process 13 and 15 fine, but when reaching 14, we'd silently ignore the update as we assume it's old (because we've processed up to 15).

This PR changes the dictionaries parsed from JSON to sorted lists, thus removing the ability to process items out-or-order accidentally.

Note that this change should be ported to mainline as the bug can occur there as well. Edit: done so: https://github.com/matrix-org/sydent/pull/251

CI is expected to fail.