### PR TITLE
Add Python 3 compatibility to token validation

### DIFF
--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -105,7 +105,7 @@ class ThreePidValSessionStore:
         Updates the send attempt number for the session with the given ID.
 
         :param sid: The ID of the session to update
-        :type sid: int
+        :type sid: unicode
         :param attemptNo: The send attempt number to update the session with.
         :type attemptNo: int
         """
@@ -119,7 +119,7 @@ class ThreePidValSessionStore:
         Updates a session to set the validated flag to the given value.
 
         :param sid: The ID of the session to update.
-        :type sid: int
+        :type sid: unicode
         :param validated: The value to set the validated flag.
         :type validated: bool
         """
@@ -133,7 +133,7 @@ class ThreePidValSessionStore:
         Set the time of the last send attempt for the session with the given ID
 
         :param sid: The ID of the session to update.
-        :type sid: int
+        :type sid: unicode
         :param mtime: The time of the last send attempt for that session.
         :type mtime: int
         """

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -115,6 +115,14 @@ class ThreePidValSessionStore:
         self.sydent.db.commit()
 
     def setValidated(self, sid, validated):
+        """
+        Updates a session to set the validated flag to the given value.
+
+        :param sid: The ID of the session to update.
+        :type sid: int
+        :param validated: The value to set the validated flag.
+        :type validated: bool
+        """
         cur = self.sydent.db.cursor()
 
         cur.execute("update threepid_validation_sessions set validated = ? where id = ?", (validated, sid))
@@ -147,6 +155,15 @@ class ThreePidValSessionStore:
          return ValidationSession(row[0], row[1], row[2], row[3], row[4], row[5], None, None)
 
     def getTokenSessionById(self, sid):
+        """
+        Retrieves a validation session using the session's ID.
+
+        :param sid: The ID of the session to retrieve.
+        :type sid: unicode
+
+        :return: The validation session, or None if no session was found with that ID.
+        :rtype: ValidationSession or None
+        """
         cur = self.sydent.db.cursor()
 
         cur.execute("select s.id, s.medium, s.address, s.clientSecret, s.validated, s.mtime, "

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -111,6 +111,8 @@ class EmailValidateCodeServlet(Resource):
 
     @jsonwrap
     def render_POST(self, request):
+        send_cors(request)
+
         authIfV2(self.sydent, request)
 
         return self.do_validate_request(request)
@@ -128,8 +130,6 @@ class EmailValidateCodeServlet(Resource):
             a "errcode" and a "error" keys which include information about the failure.
         :rtype: dict[str, bool or str]
         """
-        send_cors(request)
-
         args = get_args(request, ('token', 'sid', 'client_secret'))
 
         sid = args['sid']

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -21,7 +21,11 @@ from twisted.web.resource import Resource
 import phonenumbers
 
 from sydent.validators import (
-    IncorrectClientSecretException, SessionExpiredException, DestinationRejectedException
+    DestinationRejectedException,
+    IncorrectClientSecretException,
+    InvalidSessionIdException,
+    IncorrectSessionTokenException,
+    SessionExpiredException,
 )
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
@@ -122,32 +126,45 @@ class MsisdnValidateCodeServlet(Resource):
 
     @jsonwrap
     def render_POST(self, request):
-        send_cors(request)
-
         authIfV2(self.sydent, request)
+
+        return self.do_validate_request(request)
+
+    def do_validate_request(self, request):
+        """
+        Extracts information about a validation session from the request and
+        attempts to validate that session.
+
+        :param request: The request to extract information about the session from.
+        :type request: twisted.web.server.Request
+
+        :return: A dict with a "success" key which value indicates whether the
+            validation succeeded. If the validation failed, this dict also includes
+            a "errcode" and a "error" keys which include information about the failure.
+        :rtype: dict[str, bool or str]
+        """
+        send_cors(request)
 
         args = get_args(request, ('token', 'sid', 'client_secret'))
 
-        return self.do_validate_request(args)
-
-    def do_validate_request(self, args):
         sid = args['sid']
         tokenString = args['token']
         clientSecret = args['client_secret']
 
         try:
-            resp = self.sydent.validators.msisdn.validateSessionWithToken(sid, clientSecret, tokenString)
+            return self.sydent.validators.msisdn.validateSessionWithToken(sid, clientSecret, tokenString)
         except IncorrectClientSecretException:
-            return {'success': False, 'errcode': 'M_INCORRECT_CLIENT_SECRET',
+            return {'success': False, 'errcode': 'M_INVALID_PARAM',
                     'error': "Client secret does not match the one given when requesting the token"}
         except SessionExpiredException:
             return {'success': False, 'errcode': 'M_SESSION_EXPIRED',
                     'error': "This validation session has expired: call requestToken again"}
-
-        if not resp:
-            resp = {'success': False}
-
-        return resp
+        except InvalidSessionIdException:
+            return {'success': False, 'errcode': 'M_INVALID_PARAM',
+                    'error': "The token doesn't match"}
+        except IncorrectSessionTokenException:
+            return {'success': False, 'errcode': 'M_NO_VALID_SESSION',
+                    'error': "No session could be found with this sid"}
 
     def render_OPTIONS(self, request):
         send_cors(request)

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -134,6 +134,8 @@ class MsisdnValidateCodeServlet(Resource):
 
     @jsonwrap
     def render_POST(self, request):
+        send_cors(request)
+
         authIfV2(self.sydent, request)
 
         return self.do_validate_request(request)
@@ -151,7 +153,6 @@ class MsisdnValidateCodeServlet(Resource):
             a "errcode" and a "error" keys which include information about the failure.
         :rtype: dict[str, bool or str]
         """
-        send_cors(request)
 
         args = get_args(request, ('token', 'sid', 'client_secret'))
 

--- a/sydent/util/stringutils.py
+++ b/sydent/util/stringutils.py
@@ -25,7 +25,8 @@ def is_valid_client_secret(client_secret):
 
     :param client_secret: The client_secret to validate
     :type client_secret: unicode
-    :returns: Whether the client_secret is valid
+
+    :return: Whether the client_secret is valid
     :rtype: bool
     """
     return client_secret_regex.match(client_secret) is not None

--- a/sydent/validators/__init__.py
+++ b/sydent/validators/__init__.py
@@ -45,6 +45,10 @@ class InvalidSessionIdException(Exception):
     pass
 
 
+class IncorrectSessionTokenException(Exception):
+    pass
+
+
 class SessionNotValidatedException(Exception):
     pass
 

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -1,11 +1,17 @@
+from __future__ import absolute_import
+
 import logging
 
 from sydent.db.valsession import ThreePidValSessionStore
-from sydent.validators import ValidationSession, SessionExpiredException
 from sydent.util import time_msec
 
-from sydent.validators import IncorrectClientSecretException, SessionExpiredException
-
+from sydent.validators import (
+    IncorrectClientSecretException,
+    InvalidSessionIdException,
+    IncorrectSessionTokenException,
+    SessionExpiredException,
+    ValidationSession,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -15,18 +21,32 @@ def validateSessionWithToken(sydent, sid, clientSecret, token):
     Attempt to validate a session, identified by the sid, using
     the token from out-of-band. The client secret is given to
     prevent attempts to guess the token for a sid.
-    If the session was sucessfully validated, return a dict
-    with 'success': True that can be sent to the client,
-    otherwise return False.
+
+    :param sid: The ID of the session to validate.
+    :type sid: unicode
+    :param clientSecret: The client secret to validate.
+    :type clientSecret: unicode
+    :param token: The token to validate.
+    :type token: unicode
+
+    :return: A dict with a "success" key which is True if the session
+        was successfully validated, False otherwise.
+    :rtype: dict[str, bool]
+
+    :raise IncorrectClientSecretException: The provided client_secret is incorrect.
+    :raise SessionExpiredException: The session has expired.
+    :raise InvalidSessionIdException: The session ID couldn't be matched with an
+        existing session.
+    :raise IncorrectSessionTokenException: The provided token is incorrect
     """
     valSessionStore = ThreePidValSessionStore(sydent)
     s = valSessionStore.getTokenSessionById(sid)
     if not s:
-        logger.info("Session ID %s not found", (sid))
-        return False
+        logger.info("Session ID %s not found", (sid,))
+        raise InvalidSessionIdException()
 
     if not clientSecret == s.clientSecret:
-        logger.info("Incorrect client secret", (sid))
+        logger.info("Incorrect client secret", (sid,))
         raise IncorrectClientSecretException()
 
     if s.mtime + ValidationSession.THREEPID_SESSION_VALIDATION_TIMEOUT_MS < time_msec():
@@ -44,4 +64,4 @@ def validateSessionWithToken(sydent, sid, clientSecret, token):
         return {'success': True}
     else:
         logger.info("Incorrect token submitted")
-        return False
+        return IncorrectSessionTokenException()

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -115,4 +115,18 @@ class EmailValidator:
         return link
 
     def validateSessionWithToken(self, sid, clientSecret, token):
+        """
+        Validates the session with the given ID.
+
+        :param sid: The ID of the session to validate.
+        :type sid: unicode
+        :param clientSecret: The client secret to validate.
+        :type clientSecret: unicode
+        :param token: The token to validate.
+        :type token: unicode
+
+        :return: A dict with a "success" key which is True if the session
+            was successfully validated, False otherwise.
+        :rtype: dict[str, bool]
+        """
         return common.validateSessionWithToken(self.sydent, sid, clientSecret, token)

--- a/sydent/validators/msisdnvalidator.py
+++ b/sydent/validators/msisdnvalidator.py
@@ -148,4 +148,18 @@ class MsisdnValidator:
         return origs[sum([int(i) for i in msisdn]) % len(origs)]
 
     def validateSessionWithToken(self, sid, clientSecret, token):
+        """
+        Validates the session with the given ID.
+
+        :param sid: The ID of the session to validate.
+        :type sid: unicode
+        :param clientSecret: The client secret to validate.
+        :type clientSecret: unicode
+        :param token: The token to validate.
+        :type token: unicode
+
+        :return: A dict with a "success" key which is True if the session
+            was successfully validated, False otherwise.
+        :rtype: dict[str, bool]
+        """
         return common.validateSessionWithToken(self.sydent, sid, clientSecret, token)


### PR DESCRIPTION
Built on top of #248, the diff is https://github.com/matrix-org/sydent/compare/babolivier/py3-request-token...babolivier/py3-submit-token

Commits should be reviewable independently.