### PR TITLE
Add Python 3 compatibility to binding associations

### DIFF
--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -30,6 +30,19 @@ class JoinTokenStore(object):
         self.sydent.db.commit()
 
     def getTokens(self, medium, address):
+        """
+        Retrieves the pending invites tokens for this 3PID that haven't been delivered
+        yet.
+
+        :param medium: The medium of the 3PID to get tokens for.
+        :type medium: unicode
+        :param address: The address of the 3PID to get tokens for.
+        :type address: unicode
+
+        :return: A list of dicts, each containing a pending token and its metadata for
+            this 3PID.
+        :rtype: list[dict[str, unicode or dict[str, unicode]]
+        """
         cur = self.sydent.db.cursor()
 
         res = cur.execute(
@@ -43,6 +56,19 @@ class JoinTokenStore(object):
 
         for row in rows:
             medium, address, roomId, sender, token = row
+
+            # Ensure we're dealing with unicode.
+            if medium and isinstance(medium, bytes):
+                medium = medium.decode("UTF-8")
+            if address and isinstance(address, bytes):
+                address = address.decode("UTF-8")
+            if roomId and isinstance(roomId, bytes):
+                roomId = roomId.decode("UTF-8")
+            if sender and isinstance(sender, bytes):
+                sender = sender.decode("UTF-8")
+            if token and isinstance(token, bytes):
+                token = token.decode("UTF-8")
+
             ret.append({
                 "medium": medium,
                 "address": address,
@@ -54,6 +80,15 @@ class JoinTokenStore(object):
         return ret
 
     def markTokensAsSent(self, medium, address):
+        """
+        Updates the invite tokens associated with a given 3PID to mark them as
+        delivered to a homeserver so they're not delivered again in the future.
+
+        :param medium: The medium of the 3PID to update tokens for.
+        :type medium: unicode
+        :param address: The address of the 3PID to update tokens for.
+        :type address: unicode
+        """
         cur = self.sydent.db.cursor()
 
         cur.execute(

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -130,6 +130,14 @@ class JoinTokenStore(object):
         return None
 
     def deleteTokens(self, medium, address):
+        """
+        Deletes every token for a given 3PID.
+
+        :param medium: The medium of the 3PID to delete tokens for.
+        :type medium: unicode
+        :param address: The address of the 3PID to delete tokens for.
+        :type address: unicode
+        """
         cur = self.sydent.db.cursor()
 
         cur.execute(

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -58,15 +58,15 @@ class JoinTokenStore(object):
             medium, address, roomId, sender, token = row
 
             # Ensure we're dealing with unicode.
-            if medium and isinstance(medium, bytes):
+            if isinstance(medium, bytes):
                 medium = medium.decode("UTF-8")
-            if address and isinstance(address, bytes):
+            if isinstance(address, bytes):
                 address = address.decode("UTF-8")
-            if roomId and isinstance(roomId, bytes):
+            if isinstance(roomId, bytes):
                 roomId = roomId.decode("UTF-8")
-            if sender and isinstance(sender, bytes):
+            if isinstance(sender, bytes):
                 sender = sender.decode("UTF-8")
-            if token and isinstance(token, bytes):
+            if isinstance(token, bytes):
                 token = token.decode("UTF-8")
 
             ret.append({

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from sydent.util import time_msec
 
@@ -30,6 +31,12 @@ class LocalAssociationStore:
         self.sydent = sydent
 
     def addOrUpdateAssociation(self, assoc):
+        """
+        Updates an association, or creates one if none exists with these parameters.
+
+        :param assoc: The association to create or update.
+        :type assoc: ThreepidAssociation
+        """
         cur = self.sydent.db.cursor()
 
         # sqlite's support for upserts is atrocious

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -143,16 +143,26 @@ class ThreePidValSessionStore:
         self.sydent.db.commit()
 
     def getSessionById(self, sid):
-         cur = self.sydent.db.cursor()
+        """
+        Retrieves the session matching the given sid.
 
-         cur.execute("select id, medium, address, clientSecret, validated, mtime from "+
-             "threepid_validation_sessions where id = ?", (sid,))
-         row = cur.fetchone()
+        :param sid: The ID of the session to retrieve.
+        :type sid: int
 
-         if not row:
-             return None
+        :return: The retrieved session, or None if no session could be found with that
+            sid.
+        :rtype: ValidationSession or None
+        """
+        cur = self.sydent.db.cursor()
 
-         return ValidationSession(row[0], row[1], row[2], row[3], row[4], row[5], None, None)
+        cur.execute("select id, medium, address, clientSecret, validated, mtime from "+
+            "threepid_validation_sessions where id = ?", (sid,))
+        row = cur.fetchone()
+
+        if not row:
+            return None
+
+        return ValidationSession(row[0], row[1], row[2], row[3], row[4], row[5], None, None)
 
     def getTokenSessionById(self, sid):
         """
@@ -179,7 +189,24 @@ class ThreePidValSessionStore:
 
     def getValidatedSession(self, sid, clientSecret):
         """
-        Retrieve a validated and still-valid session whose client secret matches the one passed in
+        Retrieve a validated and still-valid session whose client secret matches the
+        one passed in.
+
+        :param sid: The ID of the session to retrieve.
+        :type sid: int
+        :param clientSecret: A client secret to check against the one retrieved from
+            the database.
+        :type clientSecret: unicode
+
+        :return: The retrieved session.
+        :rtype: ValidationSession
+
+        :raise InvalidSessionIdException: No session could be found with this ID.
+        :raise IncorrectClientSecretException: The session's client secret doesn't
+            match the one passed in.
+        :raise SessionExpiredException: The session exists but has expired.
+        :raise SessionNotValidatedException: The session exists but hasn't been
+            validated yet.
         """
         s = self.getSessionById(sid)
 

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -147,7 +147,7 @@ class ThreePidValSessionStore:
         Retrieves the session matching the given sid.
 
         :param sid: The ID of the session to retrieve.
-        :type sid: int
+        :type sid: unicode
 
         :return: The retrieved session, or None if no session could be found with that
             sid.
@@ -193,7 +193,7 @@ class ThreePidValSessionStore:
         one passed in.
 
         :param sid: The ID of the session to retrieve.
-        :type sid: int
+        :type sid: unicode
         :param clientSecret: A client secret to check against the one retrieved from
             the database.
         :type clientSecret: unicode

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -13,11 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import json
 import logging
 
-from StringIO import StringIO
+from six import StringIO
 from twisted.internet import defer
 from twisted.web.client import FileBodyProducer, Agent, readBody
 from twisted.web.http_headers import Headers
@@ -26,6 +27,7 @@ from sydent.http.matrixfederationagent import MatrixFederationAgent
 from sydent.http.federation_tls_options import ClientTLSOptionsFactory
 
 logger = logging.getLogger(__name__)
+
 
 class HTTPClient(object):
     """A base HTTP class that contains methods for making GET and POST HTTP
@@ -36,9 +38,9 @@ class HTTPClient(object):
         """Make a GET request to an endpoint returning JSON and parse result
 
         :param uri: The URI to make a GET request to.
-        :type uri: str
+        :type uri: unicode
         :returns a deferred containing JSON parsed into a Python object.
-        :rtype: Deferred[any]
+        :rtype: twisted.internet.defer.Deferred[dict[any, any]]
         """
         logger.debug("HTTP GET %s", uri)
 
@@ -56,26 +58,26 @@ class HTTPClient(object):
 
     @defer.inlineCallbacks
     def post_json_get_nothing(self, uri, post_json, opts):
-        """Make a GET request to an endpoint returning JSON and parse result
+        """Make a POST request to an endpoint returning JSON and parse result
 
-        :param uri: The URI to make a GET request to.
-        :type uri: str
+        :param uri: The URI to make a POST request to.
+        :type uri: unicode
 
         :param post_json: A Python object that will be converted to a JSON
             string and POSTed to the given URI.
-        :type post_json: any
+        :type post_json: dict[any, any]
 
-        :opts: A dictionary of request options. Currently only opts.headers
+        :param opts: A dictionary of request options. Currently only opts.headers
             is supported.
-        :type opts: Dict[str,any]
+        :type opts: dict[str,any]
 
         :returns a response from the remote server.
-        :rtype: Deferred[twisted.web.iweb.IResponse]
+        :rtype: twisted.internet.defer.Deferred[twisted.web.iweb.IResponse]
         """
         json_str = json.dumps(post_json)
 
         headers = opts.get('headers', Headers({
-            b"Content-Type": [b"application/json"],
+            "Content-Type": ["application/json"],
         }))
 
         logger.debug("HTTP POST %s -> %s", json_str, uri)

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -39,13 +39,14 @@ class HTTPClient(object):
 
         :param uri: The URI to make a GET request to.
         :type uri: unicode
-        :returns a deferred containing JSON parsed into a Python object.
+
+        :return: A deferred containing JSON parsed into a Python object.
         :rtype: twisted.internet.defer.Deferred[dict[any, any]]
         """
         logger.debug("HTTP GET %s", uri)
 
         response = yield self.agent.request(
-            "GET",
+            b"GET",
             uri.encode("ascii"),
         )
         body = yield readBody(response)
@@ -71,19 +72,19 @@ class HTTPClient(object):
             is supported.
         :type opts: dict[str,any]
 
-        :returns a response from the remote server.
+        :return: a response from the remote server.
         :rtype: twisted.internet.defer.Deferred[twisted.web.iweb.IResponse]
         """
         json_str = json.dumps(post_json)
 
         headers = opts.get('headers', Headers({
-            "Content-Type": ["application/json"],
+            b"Content-Type": [b"application/json"],
         }))
 
         logger.debug("HTTP POST %s -> %s", json_str, uri)
 
         response = yield self.agent.request(
-            "POST",
+            b"POST",
             uri.encode("ascii"),
             headers,
             bodyProducer=FileBodyProducer(StringIO(json_str))

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -13,10 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 
-from sydent.http.servlets import get_args, jsonwrap, send_cors, MatrixRestError
+from sydent.http.servlets import get_args, jsonwrap, send_cors
 
 
 class AuthenticatedBindThreePidServlet(Resource):

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 
@@ -20,8 +21,13 @@ from sydent.http.servlets import jsonwrap, get_args
 from sydent.http.auth import authIfV2
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.util.stringutils import is_valid_client_secret
-from sydent.validators import SessionExpiredException, IncorrectClientSecretException, InvalidSessionIdException,\
-    SessionNotValidatedException
+from sydent.validators import (
+    IncorrectClientSecretException,
+    InvalidSessionIdException,
+    SessionExpiredException,
+    SessionNotValidatedException,
+)
+
 
 class GetValidated3pidServlet(Resource):
     isLeaf = True
@@ -64,4 +70,4 @@ class GetValidated3pidServlet(Resource):
             return {'errcode': 'M_SESSION_NOT_VALIDATED',
                     'error': "This validation session has not yet been completed"}
 
-        return { 'medium': s.medium, 'address': s.address, 'validated_at': s.mtime }
+        return {'medium': s.medium, 'address': s.address, 'validated_at': s.mtime}

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -38,7 +38,7 @@ class ThreePidBindServlet(Resource):
 
         args = get_args(request, ('sid', 'client_secret', 'mxid'))
 
-        sid = int(args['sid'])
+        sid = args['sid']
         mxid = args['mxid']
         clientSecret = args['client_secret']
 

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 
@@ -35,7 +36,7 @@ class ThreePidBindServlet(Resource):
 
         args = get_args(request, ('sid', 'client_secret', 'mxid'))
 
-        sid = args['sid']
+        sid = int(args['sid'])
         mxid = args['mxid']
         clientSecret = args['client_secret']
 

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -14,11 +14,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+
 import collections
-import json
 import logging
 import math
-import random
 import signedjson.sign
 from sydent.db.invite_tokens import JoinTokenStore
 
@@ -32,14 +32,7 @@ from sydent.http.httpclient import FederationHttpClient
 
 from sydent.threepid import ThreepidAssociation
 
-from OpenSSL import SSL
-from OpenSSL.SSL import VERIFY_NONE
-from StringIO import StringIO
-from twisted.internet import defer, ssl
-from twisted.names import client, dns
-from twisted.names.error import DNSNameError
-from twisted.web.client import FileBodyProducer, Agent
-from twisted.web.http_headers import Headers
+from twisted.internet import defer
 
 logger = logging.getLogger(__name__)
 
@@ -53,15 +46,21 @@ class ThreepidBinder:
         self.hashing_store = HashingMetadataStore(sydent)
 
     def addBinding(self, medium, address, mxid):
-        """Binds the given 3pid to the given mxid.
+        """
+        Binds the given 3pid to the given mxid.
 
         It's assumed that we have somehow validated that the given user owns
         the given 3pid
 
-        Args:
-            medium (str): the type of 3pid
-            address (str): the 3pid
-            mxid (str): the mxid to bind it to
+        :param medium: The medium of the 3PID to bind.
+        :type medium: unicode
+        :param address: The address of the 3PID to bind.
+        :type address: unicode
+        :param mxid: The MXID to bind the 3PID to.
+        :type mxid: unicode
+
+        :return: The signed association.
+        :rtype: dict[str, any]
         """
         localAssocStore = LocalAssociationStore(self.sydent)
 
@@ -71,7 +70,7 @@ class ThreepidBinder:
 
         # Hash the medium + address and store that hash for the purposes of
         # later lookups
-        str_to_hash = ' '.join(
+        str_to_hash = u' '.join(
             [address, medium, self.hashing_store.get_lookup_pepper()],
         )
         lookup_hash = sha256_and_url_safe_base64(str_to_hash)

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -112,6 +112,15 @@ class ThreepidBinder:
 
     @defer.inlineCallbacks
     def _notify(self, assoc, attempt):
+        """
+        Sends data about a new association (and, if necessary, the associated invites)
+        to the associated MXID's homeserver.
+
+        :param assoc: The association to send down to the homeserver.
+        :type assoc: dict[str, any]
+        :param attempt: The number of previous attempts to send this association.
+        :type attempt: int
+        """
         mxid = assoc["mxid"]
         mxid_parts = mxid.split(":", 1)
         if len(mxid_parts) != 2:
@@ -158,8 +167,23 @@ class ThreepidBinder:
                 )
 
     def _notifyErrback(self, assoc, attempt, error):
-        logger.warn("Error notifying on bind for %s: %s - rescheduling", assoc["mxid"], error)
-        self.sydent.reactor.callLater(math.pow(2, attempt), self._notify, assoc, attempt + 1)
+        """
+        Handles errors when trying to send an association down to a homeserver by
+        logging the error and scheduling a new attempt.
+
+        :param assoc: The association to send down to the homeserver.
+        :type assoc: dict[str, any]
+        :param attempt: The number of previous attempts to send this association.
+        :type attempt: int
+        :param error: The error that was raised when trying to send the association.
+        :type error: Exception
+        """
+        logger.warning(
+            "Error notifying on bind for %s: %s - rescheduling", assoc["mxid"], error
+        )
+        self.sydent.reactor.callLater(
+            math.pow(2, attempt), self._notify, assoc, attempt + 1
+        )
 
     # The below is lovingly ripped off of synapse/http/endpoint.py
 

--- a/sydent/threepid/signer.py
+++ b/sydent/threepid/signer.py
@@ -16,18 +16,29 @@
 
 import signedjson.sign
 
+
 class Signer:
     def __init__(self, sydent):
         self.sydent = sydent
 
     def signedThreePidAssociation(self, assoc):
-        sgassoc = { 'medium': assoc.medium,
-                    'address': assoc.address,
-                    'mxid': assoc.mxid,
-                    'ts': assoc.ts,
-                    'not_before': assoc.not_before,
-                    'not_after': assoc.not_after
-                  }
+        """
+        Signs a 3PID association.
+
+        :param assoc: The association to sign.
+        :type assoc: sydent.threepid.ThreepidAssociation
+
+        :return: A signed representation of the association.
+        :rtype: dict[str, any]
+        """
+        sgassoc = {
+            'medium': assoc.medium,
+            'address': assoc.address,
+            'mxid': assoc.mxid,
+            'ts': assoc.ts,
+            'not_before': assoc.not_before,
+            'not_after': assoc.not_after
+        }
         sgassoc.update(assoc.extra_fields)
         sgassoc = signedjson.sign.sign_json(sgassoc, self.sydent.server_name, self.sydent.keyring.ed25519)
         return sgassoc

--- a/sydent/util/hash.py
+++ b/sydent/util/hash.py
@@ -23,10 +23,10 @@ def sha256_and_url_safe_base64(input_text):
     return
 
     :param input_text: string to hash
-    :type input_text: str
+    :type input_text: unicode
 
     :returns a sha256 hashed and url-safe base64 encoded digest
-    :rtype: str
+    :rtype: bytes
     """
     digest = hashlib.sha256(input_text.encode()).digest()
     return unpaddedbase64.encode_base64(digest, urlsafe=True)

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -42,11 +42,11 @@ def validateSessionWithToken(sydent, sid, clientSecret, token):
     valSessionStore = ThreePidValSessionStore(sydent)
     s = valSessionStore.getTokenSessionById(sid)
     if not s:
-        logger.info("Session ID %s not found", (sid,))
+        logger.info("Session ID %s not found", sid)
         raise InvalidSessionIdException()
 
     if not clientSecret == s.clientSecret:
-        logger.info("Incorrect client secret", (sid,))
+        logger.info("Incorrect client secret", sid)
         raise IncorrectClientSecretException()
 
     if s.mtime + ValidationSession.THREEPID_SESSION_VALIDATION_TIMEOUT_MS < time_msec():
@@ -58,7 +58,7 @@ def validateSessionWithToken(sydent, sid, clientSecret, token):
     #    return True
 
     if s.token == token:
-        logger.info("Setting session %s as validated", (s.id))
+        logger.info("Setting session %s as validated", s.id)
         valSessionStore.setValidated(s.id, True)
 
         return {'success': True}


### PR DESCRIPTION
Built on top of #252, the diff is https://github.com/matrix-org/sydent/compare/babolivier/py3-submit-token...babolivier/py3-bind

Commits should be reviewable independently.

I didn't touch to the replication part of it because that will come in its own PR.