### PR TITLE
Add Python 3 compatibility for storing invites

### DIFF
--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -150,6 +150,16 @@ class JoinTokenStore(object):
         return cur.rowcount > 0
 
     def getSenderForToken(self, token):
+        """
+        Retrieves the MXID of the user that sent the invite the provided token is for.
+
+        :param token: The token to retrieve the sender of.
+        :type token: unicode
+
+        :return: The invite's sender, or None if the token doesn't match an existing
+            invite.
+        :rtype: unicode or None
+        """
         cur = self.sydent.db.cursor()
         res = cur.execute(
             "SELECT sender FROM invite_tokens WHERE token = ?",

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -128,6 +128,17 @@ class JoinTokenStore(object):
         self.sydent.db.commit()
 
     def validateEphemeralPublicKey(self, publicKey):
+        """
+        Checks if an ephemeral public key is valid, and, if it is, updates its
+        verification count.
+
+        :param publicKey: The public key to validate.
+        :type publicKey: unicode
+
+        :return: Whether the key is valid.
+        :rtype: bool
+        """
+        print(type(publicKey))
         cur = self.sydent.db.cursor()
         cur.execute(
             "UPDATE ephemeral_public_keys"

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -21,6 +21,20 @@ class JoinTokenStore(object):
         self.sydent = sydent
 
     def storeToken(self, medium, address, roomId, sender, token):
+        """
+        Store a new invite token and its metadata.
+
+        :param medium: The medium of the 3PID the token is associated to.
+        :type medium: unicode
+        :param address: The address of the 3PID the token is associated to.
+        :type address: unicode
+        :param roomId: The ID of the room the 3PID is invited in.
+        :type roomId: unicode
+        :param sender: The MXID of the user that sent the invite.
+        :type sender: unicode
+        :param token: The token to store.
+        :type token: unicode
+        """
         cur = self.sydent.db.cursor()
 
         cur.execute("INSERT INTO invite_tokens"
@@ -98,6 +112,12 @@ class JoinTokenStore(object):
         self.sydent.db.commit()
 
     def storeEphemeralPublicKey(self, publicKey):
+        """
+        Saves the provided ephemeral public key.
+
+        :param publicKey: The key to store.
+        :type publicKey: unicode
+        """
         cur = self.sydent.db.cursor()
         cur.execute(
             "INSERT INTO ephemeral_public_keys"

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -13,8 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import time
+
 
 class JoinTokenStore(object):
     def __init__(self, sydent):
@@ -138,7 +138,6 @@ class JoinTokenStore(object):
         :return: Whether the key is valid.
         :rtype: bool
         """
-        print(type(publicKey))
         cur = self.sydent.db.cursor()
         cur.execute(
             "UPDATE ephemeral_public_keys"

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -181,6 +181,17 @@ class GlobalAssociationStore:
         return sgAssocStr
 
     def getMxid(self, medium, address):
+        """
+        Retrieves the MXID associated with a 3PID.
+
+        :param medium: The medium of the 3PID.
+        :type medium: unicode
+        :param address: The address of the 3PID.
+        :type address: unicode
+
+        :return: The associated MXID, or None if no MXID is associated with this 3PID.
+        :rtype: unicode or None
+        """
         cur = self.sydent.db.cursor()
         res = cur.execute("select mxid from global_threepid_associations where "
                     "medium = ? and lower(address) = lower(?) and notBefore < ? and notAfter > ? "

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -13,14 +13,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+
 from twisted.web.resource import Resource
 
-import json
+import logging
 import signedjson.key
 import signedjson.sign
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.servlets import get_args, jsonwrap, send_cors, MatrixRestError
 from sydent.http.auth import authIfV2
+
+logger = logging.getLogger(__name__)
 
 
 class BlindlySignStuffServlet(Resource):

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+
 from twisted.web.resource import Resource
 from unpaddedbase64 import encode_base64
 

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
+
 import nacl.signing
 import random
 import string
@@ -22,7 +24,6 @@ from six import string_types
 from twisted.web.resource import Resource
 from unpaddedbase64 import encode_base64
 
-import json
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.db.threepid_associations import GlobalAssociationStore
 
@@ -53,7 +54,7 @@ class StoreInviteServlet(Resource):
         if mxid:
             request.setResponseCode(400)
             return {
-                "errcode": "THREEPID_IN_USE",
+                "errcode": "M_THREEPID_IN_USE",
                 "error": "Binding already known",
                 "mxid": mxid,
             }
@@ -131,15 +132,46 @@ class StoreInviteServlet(Resource):
         return resp
 
     def redact(self, address):
-        return "@".join(map(self._redact, address.split("@", 1)))
+        """
+        Redacts the content of a 3PID address. If the address is an email address,
+        then redacts both the address's localpart and domain independently. Otherwise,
+        redacts the whole address.
+
+        :param address: The address to redact.
+        :type address: unicode
+
+        :return: The redacted address.
+        :rtype: unicode
+        """
+        return u"@".join(map(self._redact, address.split(u"@", 1)))
 
     def _redact(self, s):
+        """
+        Redacts the content of a 3PID address. If the address is an email address,
+        then redacts both the address's localpart and domain independently. Otherwise,
+        redacts the whole address.
+
+        :param s: The address to redact.
+        :type s: unicode
+
+        :return: The redacted address.
+        :rtype: unicode
+        """
         if len(s) > 5:
-            return s[:3] + "..."
+            return s[:3] + u"..."
         elif len(s) > 1:
-            return s[0] + "..."
+            return s[0] + u"..."
         else:
-            return "..."
+            return u"..."
 
     def _randomString(self, length):
-        return ''.join(self.random.choice(string.ascii_letters) for _ in xrange(length))
+        """
+        Generate a random string of the given length.
+
+        :param length: The length of the string to generate.
+        :type length: int
+
+        :return: The generated string.
+        :rtype: unicode
+        """
+        return u''.join(self.random.choice(string.ascii_letters) for _ in range(length))


### PR DESCRIPTION
Based off #256, the diff is https://github.com/matrix-org/sydent/compare/babolivier/py3-lookup...babolivier/py3-store-invite

Also fixes the expected error code when storing an invite for a 3PID that's already in use (hence the CI failure), the corresponding matrix-is-tester PR is https://github.com/matrix-org/matrix-is-tester/pull/14