### PR TITLE
Add Python 3 compatibility for replication

### DIFF
--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -23,6 +23,15 @@ class PeerStore:
         self.sydent = sydent
 
     def getPeerByName(self, name):
+        """
+        Retrieves a remote peer using it's server name.
+
+        :param name: The server name of the peer.
+        :type name: unicode
+
+        :return: The retrieved peer.
+        :rtype: RemotePeer
+        """
         cur = self.sydent.db.cursor()
         res = cur.execute("select p.name, p.port, p.lastSentVersion, pk.alg, pk.key from peers p, peer_pubkeys pk "
                           "where p.name = ? and pk.peername = p.name and p.active = 1", (name,))

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from sydent.replication.peer import RemotePeer
 
@@ -40,12 +41,17 @@ class PeerStore:
         if len(pubkeys) == 0:
             return None
 
-        p = RemotePeer(self.sydent, serverName, port, pubkeys)
-        p.lastSentVersion = lastSentVer
+        p = RemotePeer(self.sydent, serverName, port, pubkeys, lastSentVer)
 
         return p
 
     def getAllPeers(self):
+        """
+        Retrieve all of the remote peers from the database.
+
+        :return: A list of the remote peers this server knows about.
+        :rtype: list[RemotePeer]
+        """
         cur = self.sydent.db.cursor()
         res = cur.execute("select p.name, p.port, p.lastSentVersion, pk.alg, pk.key from peers p, peer_pubkeys pk "
                           "where pk.peername = p.name and p.active = 1")
@@ -60,8 +66,7 @@ class PeerStore:
         for row in res.fetchall():
             if row[0] != peername:
                 if len(pubkeys) > 0:
-                    p = RemotePeer(self.sydent, peername, port, pubkeys)
-                    p.lastSentVersion = lastSentVer
+                    p = RemotePeer(self.sydent, peername, port, pubkeys, lastSentVer)
                     peers.append(p)
                     pubkeys = {}
                 peername = row[0]
@@ -70,15 +75,25 @@ class PeerStore:
             pubkeys[row[3]] = row[4]
 
         if len(pubkeys) > 0:
-            p = RemotePeer(self.sydent, peername, port, pubkeys)
-            p.lastSentVersion = lastSentVer
+            p = RemotePeer(self.sydent, peername, port, pubkeys, lastSentVer)
             peers.append(p)
-            pubkeys = {}
 
         return peers
 
     def setLastSentVersionAndPokeSucceeded(self, peerName, lastSentVersion, lastPokeSucceeded):
+        """
+        Sets the ID of the last association sent to a given peer and the time of the
+        last successful request sent to that peer.
+
+        :param peerName: The server name of the peer.
+        :type peerName: unicode
+        :param lastSentVersion: The ID of the last association sent to that peer.
+        :type lastSentVersion: int
+        :param lastPokeSucceeded: The timestamp in milliseconds of the last successful
+            request sent to that peer.
+        :type lastPokeSucceeded: int
+        """
         cur = self.sydent.db.cursor()
-        res = cur.execute("update peers set lastSentVersion = ?, lastPokeSucceededAt = ? "
+        cur.execute("update peers set lastSentVersion = ?, lastPokeSucceededAt = ? "
                           "where name = ?", (lastSentVersion, lastPokeSucceeded, peerName))
         self.sydent.db.commit()

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -297,6 +297,16 @@ class GlobalAssociationStore:
             self.sydent.db.commit()
 
     def lastIdFromServer(self, server):
+        """
+        Retrieves the ID of the last association received from the given peer.
+
+        :param server:
+        :type server: str
+
+        :return: The the ID of the last association received from the peer, or None if
+            no association has ever been received from that peer.
+        :rtype: int or None
+        """
         cur = self.sydent.db.cursor()
         res = cur.execute("select max(originId),count(originId) from global_threepid_associations "
                           "where originServer = ?", (server,))
@@ -309,7 +319,7 @@ class GlobalAssociationStore:
 
     def removeAssociation(self, medium, address):
         """
-        Remove any association stored for the provided 3PID.
+        Removes any association stored for the provided 3PID.
 
         :param medium: The medium for the 3PID.
         :type medium: unicode

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -47,6 +47,19 @@ class LocalAssociationStore:
         self.sydent.db.commit()
 
     def getAssociationsAfterId(self, afterId, limit=None):
+        """
+        Retrieves every association after the given ID.
+
+        :param afterId: The ID after which to retrieve associations.
+        :type afterId: int
+        :param limit: The maximum number of associations to retrieve, or None if no
+            limit.
+        :type limit: int or None
+
+        :return: The retrieved associations (in a dict[id, assoc]), and the highest ID
+            retrieved (or None if no ID thus no association was retrieved).
+        :rtype: tuple[dict[int, ThreepidAssociation] or int or None]
+        """
         cur = self.sydent.db.cursor()
 
         if afterId is None:
@@ -70,7 +83,7 @@ class LocalAssociationStore:
             assocs[row[0]] = assoc
             maxId = row[0]
 
-        return (assocs, maxId)
+        return assocs, maxId
 
     def getSignedAssociationsAfterId(self, afterId, limit=None):
         """Get associations after a given ID, and sign them before returning
@@ -78,12 +91,14 @@ class LocalAssociationStore:
         :param afterId: The ID to return results after (not inclusive)
         :type afterId: int
 
-        :param limit: The maximum amount of signed associations to return. None for no limit
+        :param limit: The maximum amount of signed associations to return. None for no
+            limit.
         :type limit: int|None
 
-        :return: A tuple consisting of a dictionary containing the signed associations (id:
-            assoc dict) and an int representing the maximum ID
-        :rtype: Tuple[dict[int, int]]
+        :return: A tuple consisting of a dictionary containing the signed associations
+            (id: assoc dict) and an int representing the maximum ID (which is None if
+            there was no association to retrieve).
+        :rtype: tuple[dict[int, dict[str, any]] or int or None]
         """
         assocs = {}
 
@@ -257,11 +272,23 @@ class GlobalAssociationStore:
 
     def addAssociation(self, assoc, rawSgAssoc, originServer, originId, commit=True):
         """
-        :param assoc: (sydent.threepid.GlobalThreepidAssociation) The association to add as a high level object
-        :param sgAssoc: The original raw bytes of the signed association
+        Saves an association received through either a replication push or a local push.
+
+        :param assoc: The association to add as a high level object.
+        :type assoc: sydent.threepid.ThreepidAssociation
+        :param rawSgAssoc: The original raw bytes of the signed association.
+        :type rawSgAssoc: dict[str, any]
+        :param originServer: The name of the server the association was created on.
+        :type originServer: str
+        :param originId: The ID of the association on the server the association was
+            created on.
+        :type originId: int
+        :param commit: Whether to commit the database transaction after inserting the
+            association.
+        :type commit: bool
         """
         cur = self.sydent.db.cursor()
-        res = cur.execute("insert or ignore into global_threepid_associations "
+        cur.execute("insert or ignore into global_threepid_associations "
                           "(medium, address, lookup_hash, mxid, ts, notBefore, notAfter, originServer, originId, sgAssoc) values "
                           "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                           (assoc.medium, assoc.address, assoc.lookup_hash, assoc.mxid, assoc.ts, assoc.not_before, assoc.not_after,
@@ -281,6 +308,14 @@ class GlobalAssociationStore:
         return row[0]
 
     def removeAssociation(self, medium, address):
+        """
+        Remove any association stored for the provided 3PID.
+
+        :param medium: The medium for the 3PID.
+        :type medium: unicode
+        :param address: The address for the 3PID.
+        :type address: unicode
+        """
         cur = self.sydent.db.cursor()
         cur.execute(
             "DELETE FROM global_threepid_associations WHERE "

--- a/sydent/http/httpsclient.py
+++ b/sydent/http/httpsclient.py
@@ -13,11 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 import json
 
-from StringIO import StringIO
+from six import StringIO
 
 from zope.interface import implementer
 
@@ -48,13 +49,24 @@ class ReplicationHttpsClient:
             self.agent = Agent(self.sydent.reactor, SydentPolicyForHTTPS(self.sydent))
 
     def postJson(self, uri, jsonObject):
+        """
+        Sends an POST request over HTTPS.
+
+        :param uri: The URI to send the request to.
+        :type uri: unicode
+        :param jsonObject: The request's body.
+        :type jsonObject: dict[any, any]
+
+        :return: The request's response.
+        :rtype: twisted.internet.defer.Deferred[twisted.web.iweb.IResponse]
+        """
         logger.debug("POSTing request to %s", uri)
         if not self.agent:
             logger.error("HTTPS post attempted but HTTPS is not configured")
             return
 
         headers = Headers({'Content-Type': ['application/json'], 'User-Agent': ['Sydent']})
-        reqDeferred = self.agent.request('POST', uri.encode('utf8'), headers,
+        reqDeferred = self.agent.request(b'POST', uri.encode('utf8'), headers,
                                          FileBodyProducer(StringIO(json.dumps(jsonObject))))
 
         return reqDeferred

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import twisted.python.log
 from twisted.web.resource import Resource
@@ -94,7 +95,7 @@ class ReplicationPushServlet(Resource):
 
                 if assocObj.mxid is not None:
                     # Calculate the lookup hash with our own pepper for this association
-                    str_to_hash = ' '.join(
+                    str_to_hash = u' '.join(
                         [assocObj.address, assocObj.medium,
                          self.hashing_store.get_lookup_pepper()],
                     )

--- a/sydent/http/servlets/v1_servlet.py
+++ b/sydent/http/servlets/v1_servlet.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/v2_servlet.py
+++ b/sydent/http/servlets/v2_servlet.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -166,10 +166,11 @@ class RemotePeer(Peer):
         self.verify_key.version = 0
 
     def verifySignedAssociation(self, assoc):
-        """Verifies a signature on a signed association.
+        """Verifies a signature on a signed association. Raises an exception if the
+        signature is incorrect or couldn't be verified.
 
         :param assoc: A signed association.
-        :type assoc: Dict
+        :type assoc: dict[any, any]
         """
         if not 'signatures' in assoc:
             raise NoSignaturesException()

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 import logging
 
@@ -74,6 +75,14 @@ class Pusher:
 
     @defer.inlineCallbacks
     def _push_to_peer(self, p):
+        """
+        For a given peer, retrieves the list of associations that were created since
+        the last successful push to this peer (limited to ASSOCIATIONS_PUSH_LIMIT) and
+        sends them.
+
+        :param p: The peer to send associations to.
+        :type p: sydent.replication.peer.RemotePeer
+        """
         logger.debug("Looking for updates to push to %s", p.servername)
 
         # Check if a push operation is already active. If so, don't start another

--- a/sydent/threepid/__init__.py
+++ b/sydent/threepid/__init__.py
@@ -14,7 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 def threePidAssocFromDict(d):
+    """
+    Instantiates a ThreepidAssociation from the given dict.
+
+    :param d: The dict to use when instantiating the ThreepidAssociation.
+    :type d: dict[str, any]
+
+    :return: The instantiated ThreepidAssociation.
+    :rtype: ThreepidAssociation
+    """
     assoc = ThreepidAssociation(
         d['medium'],
         d['address'],
@@ -25,6 +35,7 @@ def threePidAssocFromDict(d):
         d['not_after'],
     )
     return assoc
+
 
 class ThreepidAssociation:
     def __init__(self, medium, address, lookup_hash, mxid, ts, not_before, not_after):

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -139,13 +139,28 @@ class ReplicationTestCase(unittest.TestCase):
         sent_assocs = {}
 
         def request(method, uri, headers, body):
+            """
+            Processes a request sent to the mocked agent.
+
+            :param method: The method of the request.
+            :type method: bytes
+            :param uri: The URI of the request.
+            :type uri: bytes
+            :param headers: The headers of the request.
+            :type headers: twisted.web.http_headers.Headers
+            :param body: The body of the request.
+            :type body: twisted.web.client.FileBodyProducer[six.StringIO]
+
+            :return: A deferred that resolves into a 200 OK response.
+            :rtype: twisted.internet.defer.Deferred[Response]
+            """
             # Check the method and the URI.
-            assert method == 'POST'
-            assert uri == 'https://fake.server:1234/_matrix/identity/replicate/v1/push'
+            assert method == b'POST'
+            assert uri == b'https://fake.server:1234/_matrix/identity/replicate/v1/push'
 
             # postJson calls the agent with a StringIO within a FileBodyProducer, so we
             # need to unpack the payload correctly.
-            payload = json.loads(body._inputFile.buf)
+            payload = json.loads(body._inputFile.read())
             for assoc_id, assoc in payload['sgAssocs'].items():
                 sent_assocs[assoc_id] = assoc
 


### PR DESCRIPTION
Based off #258, the diff is https://github.com/matrix-org/sydent/compare/babolivier/py3-store-invite...babolivier/py3-replication

Commits should be reviewable independently.
