### PR TITLE
Correctly process datatypes coming from replication, make things clearer

### DIFF
--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -209,7 +209,7 @@ class JoinTokenStore(object):
                 "token": token,
             }
 
-        return (invite_tokens, maxId)
+        return invite_tokens, maxId
 
     def getLastTokenIdFromServer(self, server):
         """Returns the last known invite token that was received from the
@@ -352,7 +352,7 @@ class JoinTokenStore(object):
                 "persistence_ts": persistence_ts,
             }
 
-        return (ephemeral_keys, maxId)
+        return ephemeral_keys, maxId
 
     def getLastEphemeralPublicKeyIdFromServer(self, server):
         """Returns the last known ephemeral public key that was received from

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -41,7 +41,7 @@ class JoinTokenStore(object):
             coming from replication).
         :type originServer: str, None
         :param originId: The id of the token in the DB of originServer. Used
-        for determining if we've already received a token or not.
+            for determining if we've already received a token or not.
         :type originId: int, None
         :param commit: Whether DB changes should be committed by this
             function (or an external one).

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -62,7 +62,7 @@ class LocalAssociationStore:
             assocs[row[0]] = assoc
             maxId = row[0]
 
-        return (assocs, maxId)
+        return assocs, maxId
 
     def getSignedAssociationsAfterId(self, afterId, limit, shadow=False):
         """Return max `limit` associations from the database after a given

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -110,7 +110,7 @@ class ReplicationPushServlet(Resource):
         # If we process them out of order, an association with an ID lesser
         # than a previously processed association will be ignored.
         sg_assocs = inJson.get('sg_assocs', {})
-        sg_assocs = sorted(sg_assocs.items())
+        sg_assocs = sorted(sg_assocs.items(), cmp=lambda k: k[0])
 
         if len(sg_assocs) > MAX_SG_ASSOCS_LIMIT:
             logger.warn("Peer %s made push with 'sg_assocs' field containing %d entries, which is greater than the maximum %d", peer.servername, len(sg_assocs), MAX_SG_ASSOCS_LIMIT)
@@ -161,12 +161,17 @@ class ReplicationPushServlet(Resource):
 
         # Process any new invite tokens
 
-        # New and updated invite tokens come is as lists instead of dictionaries
-        # They are wrapped in a dictionary. Extract that first
+        # Get the container dictionary of new and updated invites
         invite_tokens = inJson.get('invite_tokens', {})
 
-        # Then extract the list, ensuring tokens are processed in order of origin ID
-        new_invites = sorted(invite_tokens.get('added', []))
+        # Extract the dictionary of new invites
+        new_invites = invite_tokens.get('added', {})
+
+        # Convert to an ordered list to ensure we process invites in order.
+        #
+        # Otherwise we have a risk of ignoring certain updates due to our behaviour of
+        # ignoring old updates that may've been accidentally sent twice
+        new_invites = sorted(new_invites.items(), cmp=lambda k: k[0])
 
         if len(new_invites) > MAX_INVITE_TOKENS_LIMIT:
             self.sydent.db.rollback()
@@ -191,7 +196,15 @@ class ReplicationPushServlet(Resource):
 
         # Process any invite token update
 
-        invite_updates = sorted(invite_tokens.get('updated', []))
+        # Updated invite tokens come as a list of dictionaries rather than a
+        # dictionary of dictionaries
+        #
+        # Extract them from invite_tokens first
+        invite_updates = invite_tokens.get('updated', [])
+
+        # Then extract the list of invite token update dictionaries, ensuring
+        # tokens are processed in order of origin_id
+        invite_updates = sorted(invite_updates, cmp=lambda k: k["origin_id"])
 
         if len(invite_updates) > MAX_INVITE_UPDATES_LIMIT:
             self.sydent.db.rollback()
@@ -217,7 +230,7 @@ class ReplicationPushServlet(Resource):
         # Process any ephemeral public keys
 
         ephemeral_public_keys = inJson.get("ephemeral_public_keys", {})
-        ephemeral_public_keys = sorted(ephemeral_public_keys.items())
+        ephemeral_public_keys = sorted(ephemeral_public_keys.items(), cmp=lambda k: k[0])
 
         if len(ephemeral_public_keys) > MAX_EPHEMERAL_PUBLIC_KEYS_LIMIT:
             self.sydent.db.rollback()

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -92,29 +92,33 @@ class Pusher:
             total_updates = 0
 
             # Push associations
-            associations = self.local_assoc_store.getSignedAssociationsAfterId(
+            associations, max_id = self.local_assoc_store.getSignedAssociationsAfterId(
                 p.lastSentAssocsId, ASSOCIATIONS_PUSH_LIMIT
             )
-            push_data["sg_assocs"], ids["sg_assocs"] = associations
+            push_data["sg_assocs"] = associations
+            ids["sg_assocs"] = max_id
 
             # Push invite tokens and ephemeral public keys
             push_data["invite_tokens"] = {}
             ids["invite_tokens"] = {}
 
-            tokens = self.join_token_store.getInviteTokensAfterId(
+            added, max_id = self.join_token_store.getInviteTokensAfterId(
                 p.lastSentInviteTokensId, INVITE_TOKENS_PUSH_LIMIT
             )
-            push_data["invite_tokens"]["added"], ids["invite_tokens"]["added"] = tokens
+            push_data["invite_tokens"]["added"] = added
+            ids["invite_tokens"]["added"] = max_id
 
-            updates = self.join_token_store.getInviteUpdatesAfterId(
+            updated, max_id = self.join_token_store.getInviteUpdatesAfterId(
                 p.lastSentInviteUpdatesId, INVITE_UPDATES_PUSH_LIMIT
             )
-            push_data["invite_tokens"]["updated"], ids["invite_tokens"]["updated"] = updates
+            push_data["invite_tokens"]["updated"] = updated
+            ids["invite_tokens"]["updated"] = max_id
 
-            keys = self.join_token_store.getEphemeralPublicKeysAfterId(
+            keys, max_id = self.join_token_store.getEphemeralPublicKeysAfterId(
                 p.lastSentEphemeralKeysId, EPHEMERAL_PUBLIC_KEYS_PUSH_LIMIT
             )
-            push_data["ephemeral_public_keys"], ids["ephemeral_public_keys"] = keys
+            push_data["ephemeral_public_keys"] = keys
+            ids["ephemeral_public_keys"] = max_id
 
             # Count each of the inner dictionaries instead of the outer
             # (which will always have len 2)


### PR DESCRIPTION
During https://github.com/matrix-org/sydent/pull/250, I got confused in that new invites coming over replication is represented as a dictionary of dictionaries, whereas invite updates come over as a list of dictionaries.

We were processing both as a list of dictionaries.

This PR instead processes new invites as a dictionary of dictionaries, as well as clears up the code a little bit in both pushing and receiving areas.