### PR TITLE
Use `key` param instead of `cmp` for sorted

### DIFF
--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -124,7 +124,7 @@ class ReplicationPushServlet(Resource):
         # than a previously processed association will be ignored.
         sg_assocs = inJson.get('sg_assocs', {})
         sg_assocs = sorted(
-            sg_assocs.items(), cmp=lambda k: int(k[0])
+            sg_assocs.items(), key=lambda k: k[0]
         )
 
         if len(sg_assocs) > MAX_SG_ASSOCS_LIMIT:
@@ -200,7 +200,7 @@ class ReplicationPushServlet(Resource):
         # Otherwise we have a risk of ignoring certain updates due to our behaviour of
         # ignoring old updates that may've been accidentally sent twice
         new_invites = sorted(
-            new_invites.items(), cmp=lambda k: int(k[0])
+            new_invites.items(), key=lambda k: k[0]
         )
 
         if len(new_invites) > MAX_INVITE_TOKENS_LIMIT:
@@ -247,7 +247,7 @@ class ReplicationPushServlet(Resource):
         # Then extract the list of invite token update dictionaries, ensuring
         # tokens are processed in order of origin_id
         invite_updates = sorted(
-            invite_updates, cmp=lambda k: int(k["origin_id"]),
+            invite_updates, key=lambda k: k["origin_id"]
         )
 
         if len(invite_updates) > MAX_INVITE_UPDATES_LIMIT:
@@ -285,7 +285,7 @@ class ReplicationPushServlet(Resource):
 
         ephemeral_public_keys = inJson.get("ephemeral_public_keys", {})
         ephemeral_public_keys = sorted(
-            ephemeral_public_keys.items(), cmp=lambda k: int(k[0])
+            ephemeral_public_keys.items(), key=lambda k: k[0]
         )
 
         if len(ephemeral_public_keys) > MAX_EPHEMERAL_PUBLIC_KEYS_LIMIT:


### PR DESCRIPTION
This is a hotfix to #264 

`key` seems to be what we want. ~~I'm not sure how this worked in the mainline PR :thinking: https://github.com/matrix-org/sydent/pull/251~~ oh because we don't use `cmp`.

```
>>> a = [(3, None), (2, None), (1, None)]
>>> sorted(a)
[(1, None), (2, None), (3, None)]
>>> sorted(a, cmp=lambda k: k[0])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: <lambda>() takes exactly 1 argument (2 given)
```

I also removed `int()` calls on the keys, as python will convert str to int here anyways.