### PR TITLE
Allow configuration for disabling v1 bindings

### DIFF
--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -87,10 +87,12 @@ class ClientApiHttpServer:
         pubkey.putChild(b'ephemeral', ephemeralPubkey)
         ephemeralPubkey.putChild(b'isvalid', self.sydent.servlets.ephemeralPubkeyIsValid)
 
-        v1.putChild(b'3pid', threepid)
         threepid.putChild(b'bind', bind)
         threepid.putChild(b'unbind', unbind)
         threepid.putChild(b'getValidated3pid', getValidated3pid)
+
+        if self.sydent.enable_v1_associations:
+            v1.putChild(b'3pid', threepid)
 
         email.putChild(b'requestToken', emailReqCode)
         email.putChild(b'submitToken', emailValCode)

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -74,9 +74,11 @@ class ClientApiHttpServer:
         identity.putChild(b'v2', v2)
         api.putChild(b'v1', v1)
 
-        v1.putChild(b'validate', validate)
         validate.putChild(b'email', email)
         validate.putChild(b'msisdn', msisdn)
+
+        if self.sydent.enable_v1_associations:
+            v1.putChild(b'validate', validate)
 
         v1.putChild(b'lookup', lookup)
         v1.putChild(b'bulk_lookup', bulk_lookup)

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -89,6 +89,9 @@ CONFIG_DEFAULTS = {
 
         # The following can be added to your local config file to enable sentry support.
         # 'sentry_dsn': 'https://...'  # The DSN has configured in the sentry instance project.
+
+        # Whether clients and homeservers can register an association using v1 endpoints.
+        'enable_v1_associations': 'true',
     },
     'db': {
         'db.file': 'sydent.db',
@@ -168,6 +171,8 @@ class Sydent:
                 port=self.cfg.getint("general", "prometheus_port"),
                 addr=self.cfg.get("general", "prometheus_addr"),
             )
+
+        self.enable_v1_associations = self.cfg.get("general", "enable_v1_associations")
 
         # See if a pepper already exists in the database
         # Note: This MUST be run before we start serving requests, otherwise lookups for

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -172,7 +172,9 @@ class Sydent:
                 addr=self.cfg.get("general", "prometheus_addr"),
             )
 
-        self.enable_v1_associations = self.cfg.get("general", "enable_v1_associations")
+        self.enable_v1_associations = parse_cfg_bool(
+            self.cfg.get("general", "enable_v1_associations")
+        )
 
         # See if a pepper already exists in the database
         # Note: This MUST be run before we start serving requests, otherwise lookups for
@@ -363,6 +365,10 @@ def setup_logging(cfg):
 
 def get_config_file_path():
     return os.environ.get('SYDENT_CONF', "sydent.conf")
+
+
+def parse_cfg_bool(value):
+    return value.lower() == "true"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add the 'enable_v1_associations' configuration flag to determine whether to enable or disable the creation of associations via v1 endpoints.