### PR TITLE
Send bytes and not unicode when replicating

### DIFF
--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -47,7 +47,7 @@ class HTTPClient(object):
 
         response = yield self.agent.request(
             b"GET",
-            uri.encode("ascii"),
+            uri.encode("utf8"),
         )
         body = yield readBody(response)
         try:
@@ -76,7 +76,7 @@ class HTTPClient(object):
         :return: a response from the remote server.
         :rtype: twisted.internet.defer.Deferred[twisted.web.iweb.IResponse]
         """
-        json_bytes = json.dumps(post_json).encode("ascii")
+        json_bytes = json.dumps(post_json).encode("utf8")
 
         headers = opts.get('headers', Headers({
             b"Content-Type": [b"application/json"],
@@ -86,7 +86,7 @@ class HTTPClient(object):
 
         response = yield self.agent.request(
             b"POST",
-            uri.encode("ascii"),
+            uri.encode("utf8"),
             headers,
             bodyProducer=FileBodyProducer(BytesIO(json_bytes))
         )

--- a/sydent/http/httpsclient.py
+++ b/sydent/http/httpsclient.py
@@ -17,8 +17,7 @@ from __future__ import absolute_import
 
 import logging
 import json
-
-from six import StringIO
+from io import BytesIO
 
 from zope.interface import implementer
 
@@ -66,8 +65,10 @@ class ReplicationHttpsClient:
             return
 
         headers = Headers({'Content-Type': ['application/json'], 'User-Agent': ['Sydent']})
+
+        json_bytes = json.dumps(jsonObject).encode("utf8")
         reqDeferred = self.agent.request(b'POST', uri.encode('utf8'), headers,
-                                         FileBodyProducer(StringIO(json.dumps(jsonObject))))
+                                         FileBodyProducer(BytesIO(json_bytes)))
 
         return reqDeferred
 

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -149,7 +149,7 @@ class ReplicationTestCase(unittest.TestCase):
             :param headers: The headers of the request.
             :type headers: twisted.web.http_headers.Headers
             :param body: The body of the request.
-            :type body: twisted.web.client.FileBodyProducer[six.StringIO]
+            :type body: twisted.web.client.FileBodyProducer[io.BytesIO]
 
             :return: A deferred that resolves into a 200 OK response.
             :rtype: twisted.internet.defer.Deferred[Response]
@@ -158,9 +158,9 @@ class ReplicationTestCase(unittest.TestCase):
             assert method == b'POST'
             assert uri == b'https://fake.server:1234/_matrix/identity/replicate/v1/push'
 
-            # postJson calls the agent with a StringIO within a FileBodyProducer, so we
+            # postJson calls the agent with a BytesIO within a FileBodyProducer, so we
             # need to unpack the payload correctly.
-            payload = json.loads(body._inputFile.read())
+            payload = json.loads(body._inputFile.read().decode("utf8"))
             for assoc_id, assoc in payload['sgAssocs'].items():
                 sent_assocs[assoc_id] = assoc
 


### PR DESCRIPTION
That wasn't picked up by the CI because we mock the agent in the unit tests.

Also fixed the charset with which we encode in `httpclient.py` to avoid potential future breakage.