### PR TITLE
Allow for a validation regex for the next_link query parameter

### DIFF
--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -69,7 +69,7 @@ class EmailRequestCodeServlet(Resource):
                 "Validation attempt rejected as provided 'next_link' value is not "
                 "approved by the configured general.next_link.valid_regex value"
             )
-            return {'errcode': 'M_UNKNOWN', 'error': 'Invalid next_link'}
+            return {'errcode': 'M_INVALID_PARAM', 'error': 'Invalid next_link'}
 
         resp = None
 

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -20,6 +20,7 @@ import ConfigParser
 import logging
 import logging.handlers
 import os
+import re
 
 import twisted.internet.reactor
 from twisted.python import log
@@ -86,6 +87,9 @@ CONFIG_DEFAULTS = {
         # Path to file detailing the configuration of the /info and /internal-info servlets.
         # More information can be found in docs/info.md.
         'info_path': 'info.yaml',
+        # A regex used to validate the next_link query parameter provided by the
+        # client to the /requestToken and /submitToken endpoints
+        'next_link.valid_regex': '.*'
     },
     'db': {
         'db.file': 'sydent.db',
@@ -183,6 +187,10 @@ class Sydent:
         self.user_dir_allowed_hses = set(list_from_comma_sep_string(
             self.cfg.get('userdir', 'userdir.allowed_homeservers', '')
         ))
+
+        self.next_link_valid_regex = re.compile(
+            self.cfg.get('general', 'next_link.valid_regex')
+        )
 
         self.invites_validity_period = parse_duration(
             self.cfg.get('general', 'invites.validity_period'),

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -66,10 +66,11 @@ from replication.pusher import Pusher
 
 logger = logging.getLogger(__name__)
 
-def list_from_comma_sep_string(rawstr):
+
+def set_from_comma_sep_string(rawstr):
     if rawstr == '':
-        return []
-    return [x.strip() for x in rawstr.split(',')]
+        return set()
+    return {x.strip() for x in rawstr.split(',')}
 
 
 CONFIG_DEFAULTS = {
@@ -185,13 +186,15 @@ class Sydent:
         self.shadow_hs_master = self.cfg.get('general', 'shadow.hs.master')
         self.shadow_hs_slave  = self.cfg.get('general', 'shadow.hs.slave')
 
-        self.user_dir_allowed_hses = set(list_from_comma_sep_string(
+        self.user_dir_allowed_hses = set_from_comma_sep_string(
             self.cfg.get('userdir', 'userdir.allowed_homeservers', '')
-        ))
+        )
 
-        self.next_link_domain_whitelist = set(list_from_comma_sep_string(
-            self.cfg.get('general', 'next_link.domain_whitelist')
-        ))
+        next_link_whitelist = self.cfg.get('general', 'next_link.domain_whitelist')
+        if next_link_whitelist == '':
+            self.next_link_domain_whitelist = None
+        else:
+            self.next_link_domain_whitelist = set_from_comma_sep_string(next_link_whitelist)
 
         self.invites_validity_period = parse_duration(
             self.cfg.get('general', 'invites.validity_period'),

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -87,9 +87,10 @@ CONFIG_DEFAULTS = {
         # Path to file detailing the configuration of the /info and /internal-info servlets.
         # More information can be found in docs/info.md.
         'info_path': 'info.yaml',
-        # A regex used to validate the next_link query parameter provided by the
-        # client to the /requestToken and /submitToken endpoints
-        'next_link.valid_regex': '.*'
+        # A comma-separated domain whitelist used to validate the next_link query parameter
+        # provided by the client to the /requestToken and /submitToken endpoints
+        # If empty, no whitelist is applied
+        'next_link.domain_whitelist': ''
     },
     'db': {
         'db.file': 'sydent.db',
@@ -188,9 +189,9 @@ class Sydent:
             self.cfg.get('userdir', 'userdir.allowed_homeservers', '')
         ))
 
-        self.next_link_valid_regex = re.compile(
-            self.cfg.get('general', 'next_link.valid_regex')
-        )
+        self.next_link_domain_whitelist = set(list_from_comma_sep_string(
+            self.cfg.get('general', 'next_link.domain_whitelist')
+        ))
 
         self.invites_validity_period = parse_duration(
             self.cfg.get('general', 'invites.validity_period'),

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -61,10 +61,18 @@ def validateSessionWithToken(sydent, sid, clientSecret, token, next_link=None):
     # If so, and the next_link this time around is different, then the
     # user may be getting phished. Reject the validation attempt.
     if next_link and valSessionStore.next_link_differs(sid, token, next_link):
-        logger.info(
+        logger.warn(
             "Validation attempt rejected as provided 'next_link' is different "
             "from that in a previous, successful validation attempt with this "
             "session id"
+        )
+        raise NextLinkValidationException()
+
+    # Validate the value of next_link against the configured regex
+    if next_link and sydent.next_link_valid_regex.match(next_link) is None:
+        logger.warn(
+            "Validation attempt rejected as provided 'next_link' value is not "
+            "approved by the configured general.next_link.valid_regex value"
         )
         raise NextLinkValidationException()
 

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -70,7 +70,7 @@ def validateSessionWithToken(sydent, sid, clientSecret, token, next_link=None):
         raise NextLinkValidationException()
 
     # Validate the value of next_link
-    if next_link and validate_next_link(sydent, next_link):
+    if next_link and not validate_next_link(sydent, next_link):
         logger.warning(
             "Validation attempt rejected as provided 'next_link' value is not "
             "http(s) or domain does not match "
@@ -152,8 +152,8 @@ def validate_next_link(sydent, next_link):
 
     # If the domain whitelist is set, the domain must be in it
     if (
-            sydent.next_link_domain_whitelist
-            and next_link_parsed.hostname not in sydent.next_link_domain_whitelist
+        sydent.next_link_domain_whitelist is not None
+        and next_link_parsed.hostname not in sydent.next_link_domain_whitelist
     ):
         return False
 


### PR DESCRIPTION
Allows setting a regex to validate the `next_link` query parameter on creating and validating 3pid validation sessions.

CI is expected to fail :/