### PR TITLE
Allow store-invite servlet to handle args via query param or json body

### DIFF
--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from six import string_types
 import nacl.signing
 import random
 import string
@@ -76,9 +77,9 @@ class StoreInviteServlet(Resource):
         tokenStore.storeToken(medium, address, roomId, sender, token)
 
         substitutions = {}
-        for key, values in request.args.items():
-            if len(values) == 1 and type(values[0]) == str:
-                substitutions[key] = values[0]
+        for key, value in args.items():
+            if value and isinstance(value, string_types):
+                substitutions[key] = value
         substitutions["token"] = token
 
         required = [


### PR DESCRIPTION
Since at least [IS spec r0.1.0](https://matrix.org/docs/spec/identity_service/r0.1.0#post-matrix-identity-api-v1-store-invite), `POST /_matrix/identity/api/v1/store-invite` has sent invite parameters via JSON body.

Thus the code currently in the dinsic branch pulls from `request.args` which is an empty dict.

Things have been updated in the master branch to parse requests from both query parameter and json body using the `get_args` function, but the dinsic branch is still using query parameters only.

This PR ports the fix over from mainline.

CI is expected to fail on the dinsic branch.