### PR TITLE
Fix checking for access_token query parameter

### DIFF
--- a/changelog.d/294.bugfix
+++ b/changelog.d/294.bugfix
@@ -1,0 +1,1 @@
+Fix a bug that prevented Sydent from checking for OpenID auth tokens in request parameters when running on Python3.

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -17,11 +17,9 @@ from __future__ import absolute_import
 
 import logging
 
-import twisted.internet.ssl
-
 from sydent.db.accounts import AccountStore
 from sydent.terms.terms import get_terms
-from sydent.http.servlets import MatrixRestError
+from sydent.http.servlets import MatrixRestError, get_args
 
 
 logger = logging.getLogger(__name__)
@@ -43,8 +41,9 @@ def tokenFromRequest(request):
         token = authHeader[len("Bearer "):]
 
     # no? try access_token query param
-    if token is None and 'access_token' in request.args:
-        token = request.args['access_token'][0]
+    if token is None:
+        args = get_args(request, ('access_token',), required=False)
+        token = args.get('access_token')
 
     # Ensure we're dealing with unicode.
     if token and isinstance(token, bytes):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from twisted.trial import unittest
+
+from sydent.http.auth import tokenFromRequest
+from tests.utils import make_request, make_sydent
+
+
+class AuthTestCase(unittest.TestCase):
+    """Tests Sydent's auth code"""
+
+    def setUp(self):
+        # Create a new sydent
+        self.sydent = make_sydent()
+        self.test_token = "testingtoken"
+
+        # Inject a fake OpenID token into the database
+        cur = self.sydent.db.cursor()
+        cur.execute(
+            "INSERT INTO accounts (user_id, created_ts, consent_version)"
+            "VALUES (?, ?, ?)",
+            ("@bob:localhost", 101010101, "asd")
+        )
+        cur.execute(
+            "INSERT INTO tokens (user_id, token)"
+            "VALUES (?, ?)",
+            ("@bob:localhost", self.test_token)
+        )
+
+        self.sydent.db.commit()
+
+    def test_can_read_token_from_headers(self):
+        """Tests that Sydent correct extracts an auth token from request headers"""
+        self.sydent.run()
+
+        request, _ = make_request(
+            self.sydent.reactor, "GET", "/_matrix/identity/v2/hash_details"
+        )
+        request.requestHeaders.addRawHeader(
+            b"Authorization", b"Bearer " + self.test_token.encode("ascii")
+        )
+
+        token = tokenFromRequest(request)
+
+        self.assertEqual(token, self.test_token)
+
+    def test_can_read_token_from_query_parameters(self):
+        """Tests that Sydent correct extracts an auth token from query parameters"""
+        self.sydent.run()
+
+        request, _ = make_request(
+            self.sydent.reactor, "GET",
+            "/_matrix/identity/v2/hash_details?access_token=" + self.test_token
+        )
+
+        token = tokenFromRequest(request)
+
+        self.assertEqual(token, self.test_token)


### PR DESCRIPTION
It seems that in python3, Twisted's `request.args` is a dictionary with keys of type `bytes`, whereas in python2 the keys are of type `str`.

So, for now, since we're supporting both python2 and 3, check for both.