### PR TITLE
Fix 'obey_x_forwarded_for' options for access logging

### DIFF
--- a/changelog.d/300.bugfix
+++ b/changelog.d/300.bugfix
@@ -1,0 +1,1 @@
+Fix `obey_x_forwarded_for` config option for access logging.


### PR DESCRIPTION
There's a bit of a question about whether this should apply to all three HTTP servers (client, replication and internal api) or just a subset.

Fixes #299