### PR TITLE
Remove unspecified 'success' parameter from requestToken responses

### DIFF
--- a/changelog.d/302.bugfix
+++ b/changelog.d/302.bugfix
@@ -1,0 +1,1 @@
+Stop sending the unspecified `success` parameter in responses to `/requestToken` requests.

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -66,7 +66,7 @@ class EmailRequestCodeServlet(Resource):
             sid = self.sydent.validators.email.requestToken(
                 email, clientSecret, sendAttempt, nextLink, ipaddress=ipaddress
             )
-            resp = {'success': True, 'sid': str(sid)}
+            resp = {'sid': str(sid)}
         except EmailAddressException:
             request.setResponseCode(400)
             resp = {'errcode': 'M_INVALID_EMAIL', 'error': 'Invalid email address'}


### PR DESCRIPTION
It doesn't look like it's ever been a thing in the spec, and we don't seem to be checking this parameter in Synapse.

It can be an issue to have this parameter around for servers that have the setting from https://github.com/matrix-org/synapse/pull/7315 turned on and are delegating emails to an IS, because then you can figure out whether the server is lying to you just by checking on whether there's a `success` in the response.