### PR TITLE
Use get_args to get next link

### DIFF
--- a/changelog.d/303.bugfix
+++ b/changelog.d/303.bugfix
@@ -1,0 +1,1 @@
+Fix a bug causing Sydent to ignore `nextLink` parameters.

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -88,6 +88,8 @@ class EmailValidateCodeServlet(Resource):
         self.sydent = syd
 
     def render_GET(self, request):
+        args = get_args(request, ('nextLink',), required=False)
+
         resp = None
         try:
             resp = self.do_validate_request(request)
@@ -95,8 +97,8 @@ class EmailValidateCodeServlet(Resource):
             pass
         if resp and 'success' in resp and resp['success']:
             msg = "Verification successful! Please return to your Matrix client to continue."
-            if 'nextLink' in request.args:
-                next_link = request.args['nextLink'][0]
+            if 'nextLink' in args:
+                next_link = args['nextLink']
                 if not next_link.startswith("file:///"):
                     request.setResponseCode(302)
                     request.setHeader("Location", next_link)


### PR DESCRIPTION
Turns out setting a next link when validating a 3PID is broken since the Python 3 work. Briefly, `request.args` stores its keys as `bytes`, so `'nextLink' in request.args` works in Python 2 but not in Python 3.

The fix for this is to use `get_args`, which does the right thing in that regards, and has support for optional arguments since https://github.com/matrix-org/sydent/pull/294.

I assume I missed this when adding Python 3 compatibility because I was assuming `get_args` was the only way Sydent extracts arguments from a requests - turns out I missed that bit which was doing it another way. There doesn't seem to be other occurrences of that bug (looks like the only occurrence of `request.args` in the whole codebase is in `get_args`).