### PR TITLE
Return proper HTTP error codes for more error situations

### DIFF
--- a/changelog.d/305.bugfix
+++ b/changelog.d/305.bugfix
@@ -1,1 +1,1 @@
-Fix the status code returned during an error response when binding a 3PID.
+Fix the HTTP status code returned during some error responses.

--- a/changelog.d/305.bugfix
+++ b/changelog.d/305.bugfix
@@ -1,0 +1,1 @@
+Fix the status code returned during an error response when binding a 3PID.

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -161,6 +161,7 @@ class MsisdnValidateCodeServlet(Resource):
         clientSecret = args['client_secret']
 
         if not is_valid_client_secret(clientSecret):
+            request.setResponseCode(400)
             return {
                 'errcode': 'M_INVALID_PARAM',
                 'error': 'Invalid client_secret provided'
@@ -169,15 +170,19 @@ class MsisdnValidateCodeServlet(Resource):
         try:
             return self.sydent.validators.msisdn.validateSessionWithToken(sid, clientSecret, tokenString)
         except IncorrectClientSecretException:
+            request.setResponseCode(400)
             return {'success': False, 'errcode': 'M_INVALID_PARAM',
                     'error': "Client secret does not match the one given when requesting the token"}
         except SessionExpiredException:
+            request.setResponseCode(400)
             return {'success': False, 'errcode': 'M_SESSION_EXPIRED',
                     'error': "This validation session has expired: call requestToken again"}
         except InvalidSessionIdException:
+            request.setResponseCode(400)
             return {'success': False, 'errcode': 'M_INVALID_PARAM',
                     'error': "The token doesn't match"}
         except IncorrectSessionTokenException:
+            request.setResponseCode(404)
             return {'success': False, 'errcode': 'M_NO_VALID_SESSION',
                     'error': "No session could be found with this sid"}
 

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -57,6 +57,7 @@ class ReplicationPushServlet(Resource):
                 request.requestHeaders.getRawHeaders('Content-Type')[0] != 'application/json':
             logger.warn("Peer %s made push connection with non-JSON content (type: %s)",
                         peer.servername, request.requestHeaders.getRawHeaders('Content-Type')[0])
+            request.setResponseCode(400)
             return {'errcode': 'M_NOT_JSON', 'error': 'This endpoint expects JSON'}
 
         try:
@@ -64,10 +65,12 @@ class ReplicationPushServlet(Resource):
             inJson = json.loads(request.content.read().decode("UTF-8"))
         except ValueError:
             logger.warn("Peer %s made push connection with malformed JSON", peer.servername)
+            request.setResponseCode(400)
             return {'errcode': 'M_BAD_JSON', 'error': 'Malformed JSON'}
 
         if 'sgAssocs' not in inJson:
             logger.warn("Peer %s made push connection with no 'sgAssocs' key in JSON", peer.servername)
+            request.setResponseCode(400)
             return {'errcode': 'M_BAD_JSON', 'error': 'No "sgAssocs" key in JSON'}
 
         failedIds = []

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 
 import twisted.python.log
 from twisted.web.resource import Resource
-from sydent.http.servlets import jsonwrap
+from sydent.http.servlets import jsonwrap, MatrixRestError
 from sydent.threepid import threePidAssocFromDict
 
 from sydent.util.hash import sha256_and_url_safe_base64
@@ -48,8 +48,7 @@ class ReplicationPushServlet(Resource):
 
         if not peer:
             logger.warn("Got connection from %s but no peer found by that name", peerCertCn)
-            request.setResponseCode(403)
-            return {'errcode': 'M_UNKNOWN_PEER', 'error': 'This peer is not known to this server'}
+            raise MatrixRestError(403, 'M_UNKNOWN_PEER', 'This peer is not known to this server')
 
         logger.info("Push connection made from peer %s", peer.servername)
 
@@ -57,21 +56,18 @@ class ReplicationPushServlet(Resource):
                 request.requestHeaders.getRawHeaders('Content-Type')[0] != 'application/json':
             logger.warn("Peer %s made push connection with non-JSON content (type: %s)",
                         peer.servername, request.requestHeaders.getRawHeaders('Content-Type')[0])
-            request.setResponseCode(400)
-            return {'errcode': 'M_NOT_JSON', 'error': 'This endpoint expects JSON'}
+            raise MatrixRestError(400, 'M_NOT_JSON', 'This endpoint expects JSON')
 
         try:
             # json.loads doesn't allow bytes in Python 3.5
             inJson = json.loads(request.content.read().decode("UTF-8"))
         except ValueError:
             logger.warn("Peer %s made push connection with malformed JSON", peer.servername)
-            request.setResponseCode(400)
-            return {'errcode': 'M_BAD_JSON', 'error': 'Malformed JSON'}
+            raise MatrixRestError(400, 'M_BAD_JSON', 'Malformed JSON')
 
         if 'sgAssocs' not in inJson:
             logger.warn("Peer %s made push connection with no 'sgAssocs' key in JSON", peer.servername)
-            request.setResponseCode(400)
-            return {'errcode': 'M_BAD_JSON', 'error': 'No "sgAssocs" key in JSON'}
+            raise MatrixRestError(400, 'M_BAD_JSON', 'No "sgAssocs" key in JSON')
 
         failedIds = []
 

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -19,7 +19,7 @@ from twisted.web.resource import Resource
 
 import logging
 
-from sydent.http.servlets import get_args, jsonwrap, send_cors
+from sydent.http.servlets import get_args, jsonwrap, send_cors, MatrixRestError
 from sydent.terms.terms import get_terms
 from sydent.http.auth import authIfV2
 from sydent.db.terms import TermsStore
@@ -63,11 +63,8 @@ class TermsServlet(Resource):
         terms = get_terms(self.sydent)
         unknown_urls = list(set(user_accepts) - terms.getUrlSet())
         if len(unknown_urls) > 0:
-            request.setResponseCode(400)
-            return {
-                "errcode": "M_UNKNOWN",
-                "error": "Unrecognised URLs: %s" % (', '.join(unknown_urls),),
-            }
+            raise MatrixRestError(
+                400, "M_UNKNOWN", "Unrecognised URLs: %s" % (', '.join(unknown_urls),))
 
         termsStore = TermsStore(self.sydent)
         termsStore.addAgreedUrls(account.userId, user_accepts)

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -63,6 +63,7 @@ class TermsServlet(Resource):
         terms = get_terms(self.sydent)
         unknown_urls = list(set(user_accepts) - terms.getUrlSet())
         if len(unknown_urls) > 0:
+            request.setResponseCode(400)
             return {
                 "errcode": "M_UNKNOWN",
                 "error": "Unrecognised URLs: %s" % (', '.join(unknown_urls),),

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -71,7 +71,7 @@ class ThreePidBindServlet(Resource):
         except InvalidSessionIdException:
             raise noMatchError
         except SessionNotValidatedException:
-            return MatrixRestError(
+            raise MatrixRestError(
                 400,
                 'M_SESSION_NOT_VALIDATED',
                 "This validation session has not yet been completed")

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -43,16 +43,15 @@ class ThreePidBindServlet(Resource):
         clientSecret = args['client_secret']
 
         if not is_valid_client_secret(clientSecret):
-            request.setResponseCode(400)
-            return {
-                'errcode': 'M_INVALID_PARAM',
-                'error': 'Invalid client_secret provided'
-            }
+            raise MatrixRestError(
+                400, 'M_INVALID_PARAM', 'Invalid client_secret provided')
 
         # Return the same error for not found / bad client secret otherwise people can get information about
         # sessions without knowing the secret
-        noMatchError = {'errcode': 'M_NO_VALID_SESSION',
-                        'error': "No valid session was found matching that sid and client secret"}
+        noMatchError = MatrixRestError(
+            404,
+            'M_NO_VALID_SESSION',
+            "No valid session was found matching that sid and client secret")
 
         if account:
             # This is a v2 API so only allow binding to the logged in user id
@@ -63,15 +62,19 @@ class ThreePidBindServlet(Resource):
             valSessionStore = ThreePidValSessionStore(self.sydent)
             s = valSessionStore.getValidatedSession(sid, clientSecret)
         except IncorrectClientSecretException:
-            return noMatchError
+            raise noMatchError
         except SessionExpiredException:
-            return {'errcode': 'M_SESSION_EXPIRED',
-                    'error': "This validation session has expired: call requestToken again"}
+            raise MatrixRestError(
+                400,
+                'M_SESSION_EXPIRED',
+                "This validation session has expired: call requestToken again")
         except InvalidSessionIdException:
-            return noMatchError
+            raise noMatchError
         except SessionNotValidatedException:
-            return {'errcode': 'M_SESSION_NOT_VALIDATED',
-                    'error': "This validation session has not yet been completed"}
+            return MatrixRestError(
+                400,
+                'M_SESSION_NOT_VALIDATED',
+                "This validation session has not yet been completed")
 
         res = self.sydent.threepidBinder.addBinding(s.medium, s.address, mxid)
         return res


### PR DESCRIPTION
Fixes #304 by properly returning an error status code when an error occurs for `ThreePidBindServlet`.

## To Do

* [x] Check if other servlets have the same issue.
* [x] Fix matrix-is-tester errors.
* [ ] Figure out why this started happening recently.