### PR TITLE
Remove : from allowed client_secret chars

### DIFF
--- a/changelog.d/309.bugfix
+++ b/changelog.d/309.bugfix
@@ -1,0 +1,1 @@
+Sydent now correctly enforces the valid characters in the `client_secret` parameter used in various endpoints.

--- a/changelog.d/309.removal
+++ b/changelog.d/309.removal
@@ -1,1 +1,0 @@
-Disallow `:` characters from being included in `client_secret` parameters across all related endpoints to match the spec. This is a breaking change.

--- a/changelog.d/309.removal
+++ b/changelog.d/309.removal
@@ -1,0 +1,1 @@
+Disallow `:` characters from being included in `client_secret` parameters across all related endpoints to match the spec. This is a breaking change.

--- a/sydent/util/stringutils.py
+++ b/sydent/util/stringutils.py
@@ -15,9 +15,7 @@
 import re
 
 # https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-register-email-requesttoken
-# Note: The : character is allowed here for older clients, but will be removed in a
-# future release. Context: https://github.com/matrix-org/sydent/issues/247
-client_secret_regex = re.compile(r"^[0-9a-zA-Z\.\=\_\-\:]+$")
+client_secret_regex = re.compile(r"^[0-9a-zA-Z\.\=\_\-]+$")
 
 
 def is_valid_client_secret(client_secret):


### PR DESCRIPTION
Context: https://github.com/matrix-org/synapse/issues/6766

Equivalent Synapse PR: https://github.com/matrix-org/synapse/pull/8101

I believe it's now time to remove the extra allowed `:` from `client_secret` parameters.