### PR TITLE
Add config options for how much to obfuscate email addresses in 3rd party invites

### DIFF
--- a/changelog.d/311.feature
+++ b/changelog.d/311.feature
@@ -1,0 +1,1 @@
+Add config options for controlling how email addresses are obfuscated in third party invites.

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -126,16 +126,15 @@ class StoreInviteServlet(Resource):
             "token": token,
             "public_key": pubKeyBase64,
             "public_keys": keysToReturn,
-            "display_name": self.redact(address),
+            "display_name": self.redact_email_address(address),
         }
 
         return resp
 
-    def redact(self, address):
+    def redact_email_address(self, address):
         """
-        Redacts the content of a 3PID address. If the address is an email address,
-        then redacts both the address's localpart and domain independently. Otherwise,
-        redacts the whole address.
+        Redacts the content of a 3PID address. Redacts both the email's username and
+        domain independently.
 
         :param address: The address to redact.
         :type address: unicode
@@ -143,26 +142,40 @@ class StoreInviteServlet(Resource):
         :return: The redacted address.
         :rtype: unicode
         """
-        return u"@".join(map(self._redact, address.split(u"@", 1)))
+        # Extract strings from the address
+        username, domain = address.split(u"@", 1)
 
-    def _redact(self, s):
+        # Obfuscate strings
+        redacted_username = self._redact(username, self.sydent.username_obfuscate_characters)
+        redacted_domain = self._redact(domain, self.sydent.domain_obfuscate_characters)
+
+        return redacted_username + u"@" + redacted_domain
+
+    def _redact(self, s, characters_to_reveal):
         """
-        Redacts the content of a 3PID address. If the address is an email address,
-        then redacts both the address's localpart and domain independently. Otherwise,
-        redacts the whole address.
+        Redacts the content of a string, using a given amount of characters to reveal.
+        If the string is shorter than the given threshold, redact it based on length.
 
-        :param s: The address to redact.
+        :param s: The string to redact.
         :type s: unicode
 
-        :return: The redacted address.
+        :param characters_to_reveal: How many characters of the string to leave before
+            the '...'
+        :type characters_to_reveal: int
+
+        :return: The redacted string.
         :rtype: unicode
         """
-        if len(s) > 5:
-            return s[:3] + u"..."
-        elif len(s) > 1:
-            return s[0] + u"..."
-        else:
+        # If the string is shorter than the defined threshold, redact based on length
+        if len(s) <= characters_to_reveal:
+            if len(s) > 5:
+                return s[3] + u"..."
+            if len(s) > 1:
+                return s[0] + u"..."
             return u"..."
+
+        # Otherwise truncate it and add an ellipses
+        return s[:characters_to_reveal] + u"..."
 
     def _randomString(self, length):
         """

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -124,6 +124,21 @@ CONFIG_DEFAULTS = {
         'email.smtppassword': '',
         'email.hostname': '',
         'email.tlsmode': '0',
+        # When a user is invited to a room via their email address, that invite is
+        # displayed in the room list using an obfuscated version of the user's email
+        # address. These config options determine how much of the email address to
+        # obfuscate. Note that the '@' sign is always included.
+        #
+        # If the given username or domain is shorter than the threshold defined here,
+        # the string is then redacted based on its length. This ensure that a full email
+        # address is never shown, even if it is extremely short.
+        #
+        # The number of characters from the beginning to reveal of the email's username
+        # portion (left of the '@' sign)
+        'email.third_party_invite_username_obfuscate_characters': '3',
+        # The number of characters from the beginning to reveal of the email's domain
+        # portion (right of the '@' sign)
+        'email.third_party_invite_domain_obfuscate_characters': '3',
     },
     'sms': {
         'bodyTemplate': 'Your code is {token}',
@@ -181,6 +196,13 @@ class Sydent:
         self.delete_tokens_on_bind = parse_cfg_bool(
             self.cfg.get("general", "delete_tokens_on_bind")
         )
+
+        self.username_obfuscate_characters = int(self.cfg.get(
+            "email", "email.third_party_invite_username_obfuscate_characters"
+        ))
+        self.domain_obfuscate_characters = int(self.cfg.get(
+            "email", "email.third_party_invite_domain_obfuscate_characters"
+        ))
 
         # See if a pepper already exists in the database
         # Note: This MUST be run before we start serving requests, otherwise lookups for

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -129,9 +129,6 @@ CONFIG_DEFAULTS = {
         # address. These config options determine how much of the email address to
         # obfuscate. Note that the '@' sign is always included.
         #
-        # If the given username or domain is shorter than the threshold defined here,
-        # the string is then redacted based on its length. The rules are as follows:
-        #
         # If the string is longer than a configured limit below, it is truncated to that limit
         # with '...' added. Otherwise:
         #

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -130,8 +130,17 @@ CONFIG_DEFAULTS = {
         # obfuscate. Note that the '@' sign is always included.
         #
         # If the given username or domain is shorter than the threshold defined here,
-        # the string is then redacted based on its length. This ensure that a full email
-        # address is never shown, even if it is extremely short.
+        # the string is then redacted based on its length. The rules are as follows:
+        #
+        # If the string is longer than a configured limit below, it is truncated to that limit
+        # with '...' added. Otherwise:
+        #
+        # * If the string is longer than 5 characters, it is truncated to 3 characters + '...'
+        # * If the string is longer than 1 character, it is truncated to 1 character + '...'
+        # * If the string is 1 character long, it is converted to '...'
+        #
+        # This ensures that a full email address is never shown, even if it is extremely
+        # short.
         #
         # The number of characters from the beginning to reveal of the email's username
         # portion (left of the '@' sign)


### PR DESCRIPTION
When inviting a user via their email address using Sydent, a third party invite event is injected into the room using an obfuscated version of the invitee's email address (to prevent This PR adds two new config options to sydent:

* `email.third_party_invite_username_obfuscate_characters` - for obfuscating the text before the `@` sign
* `email.third_party_invite_domain_obfuscate_characters - for obfuscating the text after the `@` sign

Instead of only truncating the string, I decided to keep the old behaviour of redacting based on string length (only if the string's length is <= the configured threshold). The old behaviour ensured that a full email address is never shown, even if it is very short (e.g. a@a.co), which is a property I believe we want to uphold.

Reviewable commit-by-commit.