### PR TITLE
Extract the first 3 chars during 3pid obfuscation, not just the 3rd char

### DIFF
--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -171,7 +171,7 @@ class StoreInviteServlet(Resource):
         # If the string is shorter than the defined threshold, redact based on length
         if len(s) <= characters_to_reveal:
             if len(s) > 5:
-                return s[3] + u"..."
+                return s[:3] + u"..."
             if len(s) > 1:
                 return s[0] + u"..."
             return u"..."


### PR DESCRIPTION
#311 had a typo in it which can be seen here: https://github.com/matrix-org/sydent/pull/311/files#diff-7d63b60d76737089d460f16b53428930d3b0dedbcf3e26a396155a5f22fee3b3L161-R172

This is the code that obfuscates email addresses when creating a 3PID invite for them in a room. `s[:3]` was changed to `s[3]`, which mean that if we were inviting `abcdef@example.com` and config options were set so that this codepath was run, we'd end up with `d...@example.com` instead of `abc...@example.com`, as we were returning the 4th character (`s[3]`), instead of returning everything in the string up to the 4th character (`s[:3]`).

This PR fixes that typo.