### PR TITLE
Extract the first 3 chars during 3pid obfuscation, not just the 3rd char

### DIFF
--- a/changelog.d/317.bugfix
+++ b/changelog.d/317.bugfix
@@ -1,0 +1,1 @@
+Fix a regression in v2.2.0 where the wrong characters would be obfuscated in a 3pid invite.

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -169,7 +169,7 @@ class StoreInviteServlet(Resource):
         # If the string is shorter than the defined threshold, redact based on length
         if len(s) <= characters_to_reveal:
             if len(s) > 5:
-                return s[3] + u"..."
+                return s[:3] + u"..."
             if len(s) > 1:
                 return s[0] + u"..."
             return u"..."


### PR DESCRIPTION
This is a duplicate of #316 for mainline which fixed the same bug on `dinsic`. The bug originally stemmed from https://github.com/matrix-org/sydent/pull/311.