### PR TITLE
Update logging to be able to accept braces`

### DIFF
--- a/changelog.d/318.misc
+++ b/changelog.d/318.misc
@@ -1,0 +1,1 @@
+Fix test logging to allow braces in log output.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -240,8 +240,7 @@ class ToTwistedHandler(logging.Handler):
         log_entry = self.format(record)
         log_level = record.levelname.lower().replace("warning", "warn")
         self.tx_log.emit(
-            twisted.logger.LogLevel.levelWithName(log_level),
-            log_entry.replace("{", r"(").replace("}", r")"),
+            twisted.logger.LogLevel.levelWithName(log_level), "{entry}", entry=log_entry
         )
 
 


### PR DESCRIPTION
Fixes #315

### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fix a bug that prevented receiving messages from other servers." instead of "Move X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`