### PR TITLE
[DINSIC] Do not exponentially backoff /3pid/onbind calls after receiving 403

### DIFF
--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -207,31 +207,33 @@ class ThreepidBinder:
                 "Attempted to notify on bind for %s but received 403. Not retrying."
                 % (mxid,)
             )
+            return
         elif response.code != 200:
             # Otherwise, try again with exponential backoff
             self._notifyErrback(
                 assoc, attempt, "Non-OK error code received (%d)" % response.code
             )
-        else:
-            logger.info("Successfully notified on bind for %s" % (mxid,))
+            return
 
-            # Skip the deletion step if instructed so by the config.
-            if not self.sydent.delete_tokens_on_bind:
-                return
+        logger.info("Successfully notified on bind for %s" % (mxid,))
 
-            # Only remove sent tokens when they've been successfully sent.
-            try:
-                joinTokenStore = JoinTokenStore(self.sydent)
-                joinTokenStore.deleteTokens(assoc["medium"], assoc["address"])
-                logger.info(
-                    "Successfully deleted invite for %s from the store",
-                    assoc["address"],
-                )
-            except Exception as e:
-                logger.exception(
-                    "Couldn't remove invite for %s from the store",
-                    assoc["address"],
-                )
+        # Skip the deletion step if instructed so by the config.
+        if not self.sydent.delete_tokens_on_bind:
+            return
+
+        # Only remove sent tokens when they've been successfully sent.
+        try:
+            joinTokenStore = JoinTokenStore(self.sydent)
+            joinTokenStore.deleteTokens(assoc["medium"], assoc["address"])
+            logger.info(
+                "Successfully deleted invite for %s from the store",
+                assoc["address"],
+            )
+        except Exception as e:
+            logger.exception(
+                "Couldn't remove invite for %s from the store",
+                assoc["address"],
+            )
 
     def _notifyErrback(self, assoc, attempt, error):
         """

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -201,8 +201,14 @@ class ThreepidBinder:
             self._notifyErrback(assoc, attempt, e)
             return
 
-        # If the request failed, try again with exponential backoff
-        if response.code != 200:
+        if response.code == 403:
+            # If the request failed with a 403, then the token is not recognised
+            logger.warning(
+                "Attempted to notify on bind for %s but received 403. Not retrying."
+                % (mxid,)
+            )
+        elif response.code != 200:
+            # Otherwise, try again with exponential backoff
             self._notifyErrback(
                 assoc, attempt, "Non-OK error code received (%d)" % response.code
             )


### PR DESCRIPTION
Upon successfully receiving a response from the homeserver, if that response is non-200, we
exponentially backoff the request. This doesn't really make sense for 403 (or many other
codes for that matter), as trying again with the same arguments is likely to yield the
same result.

We special-case 403 here as this caused a bug with recurring invites appearing (see
https://github.com/matrix-org/matrix-dinsic/issues/614), though this could likely be
extended to all 4xx codes other than 429 (rate-limiting).

The slightly large diff is mostly due to me fixing up the if statement structure a bit -> switching everything in the `else:` to outside of the if statement and returning in the other blocks.

Most easily reviewable commit-by-commit.