### PR TITLE
Rename third_party_invite_x_{obfuscate,reveal}_characters option

### DIFF
--- a/changelog.d/321.misc
+++ b/changelog.d/321.misc
@@ -1,0 +1,2 @@
+Rename the "obfuscate" portion of config options `third_party_invite_*` as they configure the number of characters to reveal, not obfuscate.
+

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -148,8 +148,8 @@ class StoreInviteServlet(Resource):
         username, domain = address.split(u"@", 1)
 
         # Obfuscate strings
-        redacted_username = self._redact(username, self.sydent.username_obfuscate_characters)
-        redacted_domain = self._redact(domain, self.sydent.domain_obfuscate_characters)
+        redacted_username = self._redact(username, self.sydent.username_reveal_characters)
+        redacted_domain = self._redact(domain, self.sydent.domain_reveal_characters)
 
         return redacted_username + u"@" + redacted_domain
 

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -275,7 +275,7 @@ class Sydent:
         # to rely on comparing with default values.
         if (
            self.username_reveal_characters ==
-           CONFIG_DEFAULTS["email"]["email.third_party_invite_username_reveal_characters"]
+           int(CONFIG_DEFAULTS["email"]["email.third_party_invite_username_reveal_characters"])
         ):
             # This value is no different from the default. Let's take the value of the
             # old option instead (which will also fall back to the default if not set)
@@ -290,7 +290,7 @@ class Sydent:
         # Do the same fallback dance for this option
         if (
             self.domain_reveal_characters ==
-            CONFIG_DEFAULTS["email"]["email.third_party_invite_domain_reveal_characters"]
+            int(CONFIG_DEFAULTS["email"]["email.third_party_invite_domain_reveal_characters"])
         ):
             self.domain_reveal_characters = int(self.cfg.get(
                 "email", "email.third_party_invite_domain_obfuscate_characters"

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -153,6 +153,7 @@ CONFIG_DEFAULTS = {
         'email.smtppassword': '',
         'email.hostname': '',
         'email.tlsmode': '0',
+
         # When a user is invited to a room via their email address, that invite is
         # displayed in the room list using an obfuscated version of the user's email
         # address. These config options determine how much of the email address to
@@ -170,9 +171,14 @@ CONFIG_DEFAULTS = {
         #
         # The number of characters from the beginning to reveal of the email's username
         # portion (left of the '@' sign)
+        'email.third_party_invite_username_reveal_characters': '3',
+        # Legacy name equivalent to the above option
         'email.third_party_invite_username_obfuscate_characters': '3',
+
         # The number of characters from the beginning to reveal of the email's domain
         # portion (right of the '@' sign)
+        'email.third_party_invite_domain_reveal_characters': '3',
+        # Legacy name equivalent to the above option
         'email.third_party_invite_domain_obfuscate_characters': '3',
     },
     'sms': {
@@ -260,12 +266,35 @@ class Sydent:
             self.cfg.get("general", "delete_tokens_on_bind")
         )
 
-        self.username_obfuscate_characters = int(self.cfg.get(
-            "email", "email.third_party_invite_username_obfuscate_characters"
+        self.username_reveal_characters = int(self.cfg.get(
+            "email", "email.third_party_invite_username_reveal_characters"
         ))
-        self.domain_obfuscate_characters = int(self.cfg.get(
-            "email", "email.third_party_invite_domain_obfuscate_characters"
+
+        # Fallback to the old config option name if the new one is not set.
+        # There isn't a clear way to check if a config option is set or not, so we have
+        # to rely on comparing with default values.
+        if (
+           self.username_reveal_characters ==
+           CONFIG_DEFAULTS["email"]["email.third_party_invite_username_reveal_characters"]
+        ):
+            # This value is no different from the default. Let's take the value of the
+            # old option instead (which will also fall back to the default if not set)
+            self.username_reveal_characters = int(self.cfg.get(
+                "email", "email.third_party_invite_username_obfuscate_characters"
+            ))
+
+        self.domain_reveal_characters = int(self.cfg.get(
+            "email", "email.third_party_invite_domain_reveal_characters"
         ))
+
+        # Do the same fallback dance for this option
+        if (
+            self.domain_reveal_characters ==
+            CONFIG_DEFAULTS["email"]["email.third_party_invite_domain_reveal_characters"]
+        ):
+            self.domain_reveal_characters = int(self.cfg.get(
+                "email", "email.third_party_invite_domain_obfuscate_characters"
+            ))
 
         # See if a pepper already exists in the database
         # Note: This MUST be run before we start serving requests, otherwise lookups for

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -15,8 +15,8 @@ class ThreepidInvitesTestCase(unittest.TestCase):
         config = {
             "email": {
                 # Used by test_invited_email_address_obfuscation
-                "email.third_party_invite_username_obfuscate_characters": "6",
-                "email.third_party_invite_domain_obfuscate_characters": "8",
+                "email.third_party_invite_username_reveal_characters": "6",
+                "email.third_party_invite_domain_reveal_characters": "8",
             },
         }
         self.sydent = make_sydent(test_config=config)

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -91,6 +91,34 @@ class ThreepidInvitesTestCase(unittest.TestCase):
         self.assertEqual(redacted_address, "...@1...")
 
 
+class ThreepidInvitesFallbackConfigTestCase(unittest.TestCase):
+    """Tests that any fallback config options work."""
+
+    def setUp(self):
+        # Create a new sydent
+        config = {
+            "email": {
+                # Test that the values of fallback config options are still used when their
+                # equivalent and new counterparts are not set
+
+                # Fallback of email.third_party_invite_username_reveal_characters
+                "email.third_party_invite_username_obfuscate_characters": "9",
+                # Fallback of email.third_party_invite_domain_reveal_characters
+                "email.third_party_invite_domain_obfuscate_characters": "4",
+            },
+        }
+        self.sydent = make_sydent(test_config=config)
+
+    def test_invited_email_address_obfuscation_fallback_config(self):
+        """Test fallback options relating to email address obfuscation"""
+        store_invite_servlet = StoreInviteServlet(self.sydent)
+
+        email_address = "1234567890@1234567890.com"
+        redacted_address = store_invite_servlet.redact_email_address(email_address)
+
+        self.assertEqual(redacted_address, "123456789...@1234...")
+
+
 class ThreepidInvitesNoDeleteTestCase(unittest.TestCase):
     """Test that invite tokens are not deleted when that is disabled.
     """


### PR DESCRIPTION
This option is for configuring the number of characters that *should be shown* to users, so this naming makes more sense.

Comes with a slightly annoying amount of backwards compatibility code.