### PR TITLE
Add an option, always_obfuscate, to control whether parts of email addresses should always be redacted

### DIFF
--- a/changelog.d/322.feature
+++ b/changelog.d/322.feature
@@ -1,1 +1,1 @@
-Add an option, always_obfuscate, to allow disabling Sydent's functionality of always trying to obfuscate at least some portion of an email address while generating third-party invites.
+Add an option, `always_obfuscate`, to allow disabling Sydent's functionality of always trying to obfuscate at least some portion of an email address while generating third-party invites.

--- a/changelog.d/322.feature
+++ b/changelog.d/322.feature
@@ -1,0 +1,1 @@
+Add an option, always_obfuscate, to allow disabling Sydent's functionality of always trying to obfuscate at least some portion of an email address while generating third-party invites.

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -156,7 +156,8 @@ class StoreInviteServlet(Resource):
     def _redact(self, s, characters_to_reveal):
         """
         Redacts the content of a string, using a given amount of characters to reveal.
-        If the string is shorter than the given threshold, redact it based on length.
+        If the always_obfuscate config option is set, and the string is shorter than the
+        given threshold, redact it based on length.
 
         :param s: The string to redact.
         :type s: unicode
@@ -168,15 +169,23 @@ class StoreInviteServlet(Resource):
         :return: The redacted string.
         :rtype: unicode
         """
-        # If the string is shorter than the defined threshold, redact based on length
         if len(s) <= characters_to_reveal:
-            if len(s) > 5:
-                return s[:3] + u"..."
-            if len(s) > 1:
-                return s[0] + u"..."
-            return u"..."
+            if self.sydent.always_obfuscate:
+                # Always try to obfuscate *some* part of the string
 
-        # Otherwise truncate it and add an ellipses
+                # If the string is shorter than the defined threshold,
+                # redact based on length
+                if len(s) > 5:
+                    return s[:3] + u"..."
+                if len(s) > 1:
+                    return s[0] + u"..."
+                return u"..."
+
+            # Otherwise just return the original address
+            return s
+
+        # Truncate to the desired length. Note that this may not obfuscate the string
+        # if it already shorter than `characters_to_reveal`. Add an ellipses.
         return s[:characters_to_reveal] + u"..."
 
     def _randomString(self, length):

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -156,7 +156,7 @@ class StoreInviteServlet(Resource):
     def _redact(self, s, characters_to_reveal):
         """
         Redacts the content of a string, using a given amount of characters to reveal.
-        If the always_obfuscate config option is set, and the string is shorter than the
+        If the always_obfuscate config option is true, and the string is shorter than the
         given threshold, redact it based on length.
 
         :param s: The string to redact.
@@ -170,22 +170,21 @@ class StoreInviteServlet(Resource):
         :rtype: unicode
         """
         if len(s) <= characters_to_reveal:
+            # The string is shorter than the configured amount of characters to show.
             if self.sydent.always_obfuscate:
-                # Always try to obfuscate *some* part of the string
-
-                # If the string is shorter than the defined threshold,
-                # redact based on length
+                # If the string is shorter than the defined threshold, then we'll
+                # redact based on size instead. This ensures that at least *some*
+                # part of the string is obfuscated, regardless of its total length.
                 if len(s) > 5:
                     return s[:3] + u"..."
                 if len(s) > 1:
                     return s[0] + u"..."
                 return u"..."
 
-            # Otherwise just return the original address
+            # Otherwise just return the original string.
             return s
 
-        # Truncate to the desired length. Note that this may not obfuscate the string
-        # if it already shorter than `characters_to_reveal`. Add an ellipses.
+        # Truncate to the configured length and add an ellipses.
         return s[:characters_to_reveal] + u"..."
 
     def _randomString(self, length):

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -153,6 +153,7 @@ CONFIG_DEFAULTS = {
         'email.smtppassword': '',
         'email.hostname': '',
         'email.tlsmode': '0',
+
         # When a user is invited to a room via their email address, that invite is
         # displayed in the room list using an obfuscated version of the user's email
         # address. These config options determine how much of the email address to
@@ -174,6 +175,18 @@ CONFIG_DEFAULTS = {
         # The number of characters from the beginning to reveal of the email's domain
         # portion (right of the '@' sign)
         'email.third_party_invite_domain_obfuscate_characters': '3',
+
+        # Adds an extra layer of obfuscation, ensuring that even in the case of a username, domain
+        # or component containing very few characters - the entire string will not be shown.
+        #
+        # The algorithm works like so:
+        #   * If the string's length is greater than the cutoff value specified
+        #     by the above options, stop. Otherwise,
+        #   * If the string's length > 5, obfuscate to 3 characters.
+        #   * If the string's length > 1, obfuscate to 1 character
+        #
+        # The default value is "true".
+        'email.always_obfuscate': 'true',
     },
     'sms': {
         'bodyTemplate': 'Your code is {token}',
@@ -266,6 +279,10 @@ class Sydent:
         self.domain_obfuscate_characters = int(self.cfg.get(
             "email", "email.third_party_invite_domain_obfuscate_characters"
         ))
+
+        self.always_obfuscate = parse_cfg_bool(
+            self.cfg.get("email", "email.always_obfuscate")
+        )
 
         # See if a pepper already exists in the database
         # Note: This MUST be run before we start serving requests, otherwise lookups for

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -183,7 +183,7 @@ CONFIG_DEFAULTS = {
         #   * If the string's length is greater than the cutoff value specified
         #     by the above options, stop. Otherwise,
         #   * If the string's length > 5, obfuscate to 3 characters.
-        #   * If the string's length > 1, obfuscate to 1 character
+        #   * If the string's length > 1, obfuscate to 1 character.
         #
         # The default value is "true".
         'email.always_obfuscate': 'true',

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -17,6 +17,7 @@ class ThreepidInvitesTestCase(unittest.TestCase):
                 # Used by test_invited_email_address_obfuscation
                 "email.third_party_invite_username_obfuscate_characters": "6",
                 "email.third_party_invite_domain_obfuscate_characters": "8",
+                "email.always_obfuscate": "false",
             },
         }
         self.sydent = make_sydent(test_config=config)
@@ -84,10 +85,15 @@ class ThreepidInvitesTestCase(unittest.TestCase):
 
         self.assertEqual(redacted_address, "123456...@12345678...")
 
-        # Even short addresses are redacted
+        # Addresses that are shorter than the configured reveal length are not redacted if
+        # always_obfuscate is false
         short_email_address = "1@1.com"
         redacted_address = store_invite_servlet.redact_email_address(short_email_address)
+        self.assertEqual(redacted_address, "1@1.com")
 
+        # Set always_obfuscate to true
+        self.sydent.always_obfuscate = True
+        redacted_address = store_invite_servlet.redact_email_address(short_email_address)
         self.assertEqual(redacted_address, "...@1...")
 
 


### PR DESCRIPTION
When generating a third-party invite, Sydent tries to obfuscate part of the invited email address before creating and sending off an event that will eventually be inserted into the relevant room. This address is obfuscated so that it can both:

* Be recognised by whomever created it and additionally distinguished from other third-party invites by all users.
* Hide the full address in order to prevent leaking private information.

A question arises when a user has an extremely short email address, such as `abc@ex.org`. Sydent operators can configure the minimum amount of characters that should be shown, but what if that value is relatively high? The full address would be shown.

To combat this, Sydent has some code that will fire if the username or domain of the email address is shorter in length than that configured amount of characters. It's some simply logic, that says if the string is less than 5 characters, only reveal 3... if it's shorter than 3 characters, only reveal 1 etc.

https://github.com/matrix-org/sydent/blob/5a874b1951fb09fb8bacc05cc50ce509c2f4e362/sydent/http/servlets/store_invite_servlet.py#L170-L175

DINUM don't want this functionality however, and would rather have the whole address be shown. Thus, a config option is being added here to forgo this functionality if the operator would like.