### PR TITLE
Add an option, third_party_invite_username_separator_string, that allows redacting separate portions of a third party invite address

### DIFF
--- a/changelog.d/323.feature
+++ b/changelog.d/323.feature
@@ -1,0 +1,1 @@
+Add option `third_party_invite_username_separator_string` that allows redacting separate portions of a third party invite email address username.

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -148,7 +148,6 @@ class StoreInviteServlet(Resource):
         username, domain = address.split(u"@", 1)
 
         # Obfuscate the username portion
-
         separator = self.sydent.third_party_invite_username_separator_string
         if separator:
             # Redact each component individually, if it has content.

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -151,24 +151,14 @@ class StoreInviteServlet(Resource):
 
         separator = self.sydent.third_party_invite_username_separator_string
         if separator:
-            # If a separator string has been configured, we redact each component of the
-            # username individually.
-            redacted_username = ""
-
-            username_components = username.split(separator)
-            for index, component in enumerate(username_components):
-                if component:
-                    # Redact this component and append it to the final string
-                    redacted_username += (
-                        self._redact(component, self.sydent.username_obfuscate_characters)
-                    )
-
-                # Append the separator separately. This handles the case of multiple
-                # separators appearing sequentially in the username.
-                #
-                # The conditional here is to prevent a separator being appended to the end.
-                if index != len(username_components) - 1:
-                    redacted_username += separator
+            # Redact each component individually, if it has content.
+            # (No content implies multiple sequential separators.)
+            redacted_components = [
+                self._redact(component, self.sydent.username_obfuscate_characters)
+                if component else ""
+                for component in username.split(separator)
+            ]
+            redacted_username = separator.join(redacted_components)
         else:
             redacted_username = self._redact(
                 username, self.sydent.username_obfuscate_characters

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -147,8 +147,26 @@ class StoreInviteServlet(Resource):
         # Extract strings from the address
         username, domain = address.split(u"@", 1)
 
-        # Obfuscate strings
-        redacted_username = self._redact(username, self.sydent.username_obfuscate_characters)
+        # Obfuscate the username portion
+
+        # Break up the username by the configured separator string
+        separator = self.sydent.third_party_invite_username_separator_string
+        username_components = username.split(separator) if separator else [username]
+
+        # Obfuscate each individual component
+        redacted_components = [
+            self._redact(component, self.sydent.username_obfuscate_characters)
+            for component in username_components if component != ""
+        ]
+        if redacted_components:
+            # Join the components back together
+            redacted_username = separator.join(redacted_components)
+        else:
+            # We ended up with an empty username. This can happen if the username was
+            # only comprised of the separator character
+            redacted_username = username
+
+        # Obfuscate the domain portion
         redacted_domain = self._redact(domain, self.sydent.domain_obfuscate_characters)
 
         return redacted_username + u"@" + redacted_domain

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -174,6 +174,18 @@ CONFIG_DEFAULTS = {
         # The number of characters from the beginning to reveal of the email's domain
         # portion (right of the '@' sign)
         'email.third_party_invite_domain_obfuscate_characters': '3',
+
+        # A string to separate multiple components of the username portion of an email address.
+        # For instance, if "." is set, then "alice.smith@example.com" would result
+        # in both "alice" and "smith" being individually obfuscated. Resulting in
+        # "ali...smi...@example.com" for example.
+        #
+        # The obfuscation amount for each component is set via the
+        # `third_party_invite_username_reveal_characters` config option.
+        #
+        # The default value is an empty string, meaning this option is ignored. In that case,
+        # the username is considered a single component.
+        'email.third_party_invite_username_separator_string': '',
     },
     'sms': {
         'bodyTemplate': 'Your code is {token}',
@@ -266,6 +278,10 @@ class Sydent:
         self.domain_obfuscate_characters = int(self.cfg.get(
             "email", "email.third_party_invite_domain_obfuscate_characters"
         ))
+
+        self.third_party_invite_username_separator_string = self.cfg.get(
+            "email", "email.third_party_invite_username_separator_string"
+        )
 
         # See if a pepper already exists in the database
         # Note: This MUST be run before we start serving requests, otherwise lookups for

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -176,9 +176,9 @@ CONFIG_DEFAULTS = {
         'email.third_party_invite_domain_obfuscate_characters': '3',
 
         # A string to separate multiple components of the username portion of an email address.
-        # For instance, if "." is set, then "alice.smith@example.com" would result
+        # For instance, if "-" is set, then "alice-smith@example.com" would result
         # in both "alice" and "smith" being individually obfuscated. Resulting in
-        # "ali...smi...@example.com" for example.
+        # "ali...-smi...@example.com" for example.
         #
         # The obfuscation amount for each component is set via the
         # `third_party_invite_username_reveal_characters` config option.

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -90,6 +90,27 @@ class ThreepidInvitesTestCase(unittest.TestCase):
 
         self.assertEqual(redacted_address, "...@1...")
 
+        # Try using a username separator string
+        self.sydent.third_party_invite_username_separator_string = "-"
+
+        email_address = "johnathon-jingle-smithington@company-town.notarealtld"
+        redacted_address = store_invite_servlet.redact_email_address(email_address)
+        # Each individual component of the username should be obfuscated, but not the domain
+        self.assertEqual(redacted_address, "johnat...-jin...-smithi...@company-...")
+
+        # Try one with a separator at a word boundary
+        self.sydent.third_party_invite_username_separator_string = "."
+
+        email_address = "applejack.@someexample.com"
+        redacted_address = store_invite_servlet.redact_email_address(email_address)
+        self.assertEqual(redacted_address, "applej...@someexam...")
+
+        # Try one where a separator is the username
+        self.sydent.third_party_invite_username_separator_string = "."
+
+        email_address = ".@someexample.com"
+        redacted_address = store_invite_servlet.redact_email_address(email_address)
+        self.assertEqual(redacted_address, ".@someexam...")
 
 class ThreepidInvitesNoDeleteTestCase(unittest.TestCase):
     """Test that invite tokens are not deleted when that is disabled.

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -92,10 +92,10 @@ class ThreepidInvitesTestCase(unittest.TestCase):
 
         # Try using a username separator string
         self.sydent.third_party_invite_username_separator_string = "-"
-        email_address = "johnathon-jingle-smithington@smiths.notarealtld"
+        email_address = "johnathon-jingle-smithington@john-smith.notarealtld"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
         # Each individual component of the username should be obfuscated, but not the domain
-        self.assertEqual(redacted_address, "johnat...-jin...-smithi...@smiths.n...")
+        self.assertEqual(redacted_address, "johnat...-jin...-smithi...@john-smi...")
 
         # Try one with a separator at a word boundary
         email_address = "applejack-@someexample.com"

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -92,25 +92,28 @@ class ThreepidInvitesTestCase(unittest.TestCase):
 
         # Try using a username separator string
         self.sydent.third_party_invite_username_separator_string = "-"
-
-        email_address = "johnathon-jingle-smithington@company-town.notarealtld"
+        email_address = "johnathon-jingle-smithington@smiths.notarealtld"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
         # Each individual component of the username should be obfuscated, but not the domain
-        self.assertEqual(redacted_address, "johnat...-jin...-smithi...@company-...")
+        self.assertEqual(redacted_address, "johnat...-jin...-smithi...@smiths.n...")
 
         # Try one with a separator at a word boundary
-        self.sydent.third_party_invite_username_separator_string = "."
-
-        email_address = "applejack.@someexample.com"
+        email_address = "applejack-@someexample.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
-        self.assertEqual(redacted_address, "applej...@someexam...")
+        self.assertEqual(redacted_address, "applej...-@someexam...")
 
-        # Try one where a separator is the username
-        self.sydent.third_party_invite_username_separator_string = "."
-
-        email_address = ".@someexample.com"
+        # Try one where the username is just the separator.
+        email_address = "-@someexample.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
-        self.assertEqual(redacted_address, ".@someexam...")
+        self.assertEqual(redacted_address, "-@someexam...")
+
+        # Try multiple, sequential separators
+        self.sydent.username_obfuscate_characters = 3
+        self.sydent.domain_obfuscate_characters = 3
+
+        email_address = "donuld--fauntleboy--puck@disnie.com"
+        redacted_address = store_invite_servlet.redact_email_address(email_address)
+        self.assertEqual(redacted_address, "don...--fau...--puc...@dis...")
 
 class ThreepidInvitesNoDeleteTestCase(unittest.TestCase):
     """Test that invite tokens are not deleted when that is disabled.


### PR DESCRIPTION
When generating a third-party invite, Sydent tries to obfuscate part of the invited email address before creating and sending off an event that will eventually be inserted into the relevant room. This address is obfuscated so that it can both:

* Be recognised by whomever created it and additionally distinguished from other third-party invites by all users.
* Hide the full address in order to prevent leaking private information.

The username and domain in an email address are obfuscated separately. However, this can pose an issue when emails look something like "John.Smith@example.com". This could be obfuscated to "John.Sm...@exam...".

While this has hidden the user's last name, their first name is still visible!

This PR adds an option that lets you configure a separator for email address usernames. The resulting strings after splitting the username using this separator will be obfuscated individually. So, if this option were set to `.`, then "John.Smith@example.com" would become, say, "Jo...Sm...@exam...".

Note that there currently only exists an option for usernames, as that's all that was requested.