### PR TITLE
Change out the triple-dot sequence in third-party invites to an ellipsis character

### DIFF
--- a/changelog.d/324.feature
+++ b/changelog.d/324.feature
@@ -1,0 +1,1 @@
+Switch out triple-period sequences in third-party invites for an ellipsis character.

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -178,12 +178,14 @@ class StoreInviteServlet(Resource):
         :type s: unicode
 
         :param characters_to_reveal: How many characters of the string to leave before
-            the '...'
+            the ellipsis
         :type characters_to_reveal: int
 
         :return: The redacted string.
         :rtype: unicode
         """
+        ellipsis_character = u"…"
+
         if len(s) <= characters_to_reveal:
             # The string is shorter than the configured amount of characters to show.
             if self.sydent.always_obfuscate:
@@ -191,16 +193,16 @@ class StoreInviteServlet(Resource):
                 # redact based on size instead. This ensures that at least *some*
                 # part of the string is obfuscated, regardless of its total length.
                 if len(s) > 5:
-                    return s[:3] + u"..."
+                    return s[:3] + ellipsis_character
                 if len(s) > 1:
-                    return s[0] + u"..."
-                return u"..."
+                    return s[0] + ellipsis_character
+                return ellipsis_character
 
             # Otherwise just return the original string.
             return s
 
         # Truncate to the configured length and add an ellipses.
-        return s[:characters_to_reveal] + u"..."
+        return s[:characters_to_reveal] + ellipsis_character
 
     def _randomString(self, length):
         """

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -184,8 +184,6 @@ class StoreInviteServlet(Resource):
         :return: The redacted string.
         :rtype: unicode
         """
-        ellipsis_character = u"…"
-
         if len(s) <= characters_to_reveal:
             # The string is shorter than the configured amount of characters to show.
             if self.sydent.always_obfuscate:
@@ -193,16 +191,16 @@ class StoreInviteServlet(Resource):
                 # redact based on size instead. This ensures that at least *some*
                 # part of the string is obfuscated, regardless of its total length.
                 if len(s) > 5:
-                    return s[:3] + ellipsis_character
+                    return s[:3] + u"…"
                 if len(s) > 1:
-                    return s[0] + ellipsis_character
-                return ellipsis_character
+                    return s[0] + u"…"
+                return u"…"
 
             # Otherwise just return the original string.
             return s
 
         # Truncate to the configured length and add an ellipses.
-        return s[:characters_to_reveal] + ellipsis_character
+        return s[:characters_to_reveal] + u"…"
 
     def _randomString(self, length):
         """

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from mock import Mock
 from sydent.http.httpclient import FederationHttpClient
 from sydent.db.invite_tokens import JoinTokenStore

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -85,35 +85,35 @@ class ThreepidInvitesTestCase(unittest.TestCase):
         email_address = "1234567890@1234567890.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
 
-        self.assertEqual(redacted_address, "123456…@12345678…")
+        self.assertEqual(redacted_address, u"123456…@12345678…")
 
         # Addresses that are shorter than the configured reveal length are not redacted if
         # always_obfuscate is false
         short_email_address = "1@1.com"
         redacted_address = store_invite_servlet.redact_email_address(short_email_address)
-        self.assertEqual(redacted_address, "1@1.com")
+        self.assertEqual(redacted_address, u"1@1.com")
 
         # Set always_obfuscate to true
         self.sydent.always_obfuscate = True
         redacted_address = store_invite_servlet.redact_email_address(short_email_address)
-        self.assertEqual(redacted_address, "…@1…")
+        self.assertEqual(redacted_address, u"…@1…")
 
         # Try using a username separator string
         self.sydent.third_party_invite_username_separator_string = "-"
         email_address = "johnathon-jingle-smithington@john-smith.notarealtld"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
         # Each individual component of the username should be obfuscated, but not the domain
-        self.assertEqual(redacted_address, "johnat…-jin…-smithi…@john-smi…")
+        self.assertEqual(redacted_address, u"johnat…-jin…-smithi…@john-smi…")
 
         # Try one with a separator at a word boundary
         email_address = "applejack-@someexample.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
-        self.assertEqual(redacted_address, "applej…-@someexam…")
+        self.assertEqual(redacted_address, u"applej…-@someexam…")
 
         # Try one where the username is just the separator.
         email_address = "-@someexample.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
-        self.assertEqual(redacted_address, "-@someexam…")
+        self.assertEqual(redacted_address, u"-@someexam…")
 
         # Try multiple, sequential separators
         self.sydent.username_reveal_characters = 3
@@ -121,7 +121,7 @@ class ThreepidInvitesTestCase(unittest.TestCase):
 
         email_address = "donuld--fauntleboy--puck@disnie.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
-        self.assertEqual(redacted_address, "don…--fau…--puc…@dis…")
+        self.assertEqual(redacted_address, u"don…--fau…--puc…@dis…")
 
 class ThreepidInvitesFallbackConfigTestCase(unittest.TestCase):
     """Tests that any fallback config options work."""
@@ -148,7 +148,7 @@ class ThreepidInvitesFallbackConfigTestCase(unittest.TestCase):
         email_address = "1234567890@1234567890.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
 
-        self.assertEqual(redacted_address, "123456789…@1234…")
+        self.assertEqual(redacted_address, u"123456789…@1234…")
 
 
 class ThreepidInvitesNoDeleteTestCase(unittest.TestCase):

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -83,7 +83,7 @@ class ThreepidInvitesTestCase(unittest.TestCase):
         email_address = "1234567890@1234567890.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
 
-        self.assertEqual(redacted_address, "123456...@12345678...")
+        self.assertEqual(redacted_address, "123456…@12345678…")
 
         # Addresses that are shorter than the configured reveal length are not redacted if
         # always_obfuscate is false
@@ -94,24 +94,24 @@ class ThreepidInvitesTestCase(unittest.TestCase):
         # Set always_obfuscate to true
         self.sydent.always_obfuscate = True
         redacted_address = store_invite_servlet.redact_email_address(short_email_address)
-        self.assertEqual(redacted_address, "...@1...")
+        self.assertEqual(redacted_address, "…@1…")
 
         # Try using a username separator string
         self.sydent.third_party_invite_username_separator_string = "-"
         email_address = "johnathon-jingle-smithington@john-smith.notarealtld"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
         # Each individual component of the username should be obfuscated, but not the domain
-        self.assertEqual(redacted_address, "johnat...-jin...-smithi...@john-smi...")
+        self.assertEqual(redacted_address, "johnat…-jin…-smithi…@john-smi…")
 
         # Try one with a separator at a word boundary
         email_address = "applejack-@someexample.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
-        self.assertEqual(redacted_address, "applej...-@someexam...")
+        self.assertEqual(redacted_address, "applej…-@someexam…")
 
         # Try one where the username is just the separator.
         email_address = "-@someexample.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
-        self.assertEqual(redacted_address, "-@someexam...")
+        self.assertEqual(redacted_address, "-@someexam…")
 
         # Try multiple, sequential separators
         self.sydent.username_reveal_characters = 3
@@ -119,7 +119,7 @@ class ThreepidInvitesTestCase(unittest.TestCase):
 
         email_address = "donuld--fauntleboy--puck@disnie.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
-        self.assertEqual(redacted_address, "don...--fau...--puc...@dis...")
+        self.assertEqual(redacted_address, "don…--fau…--puc…@dis…")
 
 class ThreepidInvitesFallbackConfigTestCase(unittest.TestCase):
     """Tests that any fallback config options work."""
@@ -146,7 +146,7 @@ class ThreepidInvitesFallbackConfigTestCase(unittest.TestCase):
         email_address = "1234567890@1234567890.com"
         redacted_address = store_invite_servlet.redact_email_address(email_address)
 
-        self.assertEqual(redacted_address, "123456789...@1234...")
+        self.assertEqual(redacted_address, "123456789…@1234…")
 
 
 class ThreepidInvitesNoDeleteTestCase(unittest.TestCase):


### PR DESCRIPTION
Besides a slightly nicer presentation, this can be useful when email addresses that contain period characters are obfuscated. Consider the address: `firstname.lastname@example.com`.

If this address is obfuscated to `firstname....@exa...`, we end up with a slightly odd-looking sequence of four periods on the left-hand side.

With an ellipsis character, we'd instead get `firstname.…@exa…`, which is still a little odd, but is clearer with regards to what exactly was obfuscated.

Applying this to the `dinsic` branch as it grew out of [a dinsic PR conversation](https://github.com/matrix-org/sydent/pull/323#discussion_r526854002), but will be ported to mainline with the rest of the obfuscated code it touches.

Not sponsored as this was not a paid-for request.