### PR TITLE
Fix building docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ COPY --chown=sydent:sydent ["README.rst", "setup.cfg", "setup.py", "/sydent/"]
 # Install dependencies
 USER sydent
 WORKDIR /sydent
-RUN pip install --user --upgrade pip setuptools sentry-sdk prometheus_client
-RUN pip install --user .
-RUN rm -rf /sydent/.cache
-RUN find /sydent -name '*.pyc' -delete
+RUN pip install --user --upgrade pip setuptools sentry-sdk prometheus_client \
+    && pip install --user . \
+    && rm -rf /sydent/.cache \
+    && find /sydent -name '*.pyc' -delete
 
 #
 # Step 2: Reduce image size and layers

--- a/changelog.d/335.docker
+++ b/changelog.d/335.docker
@@ -1,0 +1,1 @@
+Base docker image on Debian rather than Alpine Linux.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,11 @@
         showcontent = true
 
     [[tool.towncrier.type]]
+        directory = "docker"
+        name = "Updates to the Docker image"
+        showcontent = true
+
+    [[tool.towncrier.type]]
         directory = "doc"
         name = "Improved Documentation"
         showcontent = true


### PR DESCRIPTION
Fixes #333 by using python-slim as the base image (instead of alpine). This is analogous to matrix-org/synapse#7839. I did some light testing and sydent seems to boot and host resources, so I think this is working.

I'm not super familiar with writing Dockerfiles so I might have done something silly, but it is pretty much just converting from alpine-isms to debian-isms.