### PR TITLE
Add GitHub actions for unittests, matrix_is_tester tests, black and flake8

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -8,9 +8,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: ${{github.event.pull_request.head.sha}}
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-python@v2
         with:
           python-version: "3.7"
       - run: python -m pip install towncrier
-      - run: python -m towncrier.check --compare-with="origin/main"
+      - run: python -m towncrier.check --compare-with=${{ github.base_ref }}

--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -1,0 +1,16 @@
+name: Changelog
+on: [pull_request]
+
+jobs:
+  check-newsfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.sha}}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - run: python -m pip install towncrier
+      - run: python -m towncrier.check --compare-with="origin/main"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,21 +2,21 @@ name: Linting and tests
 on: [push]
 jobs: 
   run-unit-tests-python3-6:
-  runs-on: ubuntu-latest
-  steps: 
-    -uses: actions/checkout@v2
-    -uses: actions/setup-python@v2
-    with:
-       python-version: "3.6"
-    -run: python -m pip install -e .
-    -run: trial tests
+    runs-on: ubuntu-latest
+    steps: 
+      -uses: actions/checkout@v2
+      -uses: actions/setup-python@v2
+      with:
+        python-version: "3.6"
+      -run: python -m pip install -e .
+      -run: trial tests
 
   run-unit-tests-python3-9:
-  runs-on: ubuntu-latest
-  steps: 
-    -uses: actions/checkout@v2
-    -uses: actions/setup-python@v2
-    with:
-       python-version: "3.9"
-    -run: python -m pip install -e .
-    -run: trial tests
+    runs-on: ubuntu-latest
+    steps: 
+      -uses: actions/checkout@v2
+      -uses: actions/setup-python@v2
+      with:
+        python-version: "3.9"
+      -run: python -m pip install -e .
+      -run: trial tests

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,7 +6,7 @@ jobs:
   steps: 
     -uses: actions/checkout@v2
     -uses: actions/setup-python@v2
-     with:
+    with:
        python-version: "3.6"
     -run: python -m pip install -e .
     -run: trial tests
@@ -16,7 +16,7 @@ jobs:
   steps: 
     -uses: actions/checkout@v2
     -uses: actions/setup-python@v2
-     with:
+    with:
        python-version: "3.9"
     -run: python -m pip install -e .
     -run: trial tests

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,7 +7,7 @@ jobs:
     -uses: actions/checkout@v2
     -uses: actions/setup-python@v2
      with:
-      python-version: "3.6"
+       python-version: "3.6"
     -run: python -m pip install -e .
     -run: trial tests
 
@@ -17,6 +17,6 @@ jobs:
     -uses: actions/checkout@v2
     -uses: actions/setup-python@v2
      with:
-      python-version: "3.9"
+       python-version: "3.9"
     -run: python -m pip install -e .
     -run: trial tests

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,8 +10,10 @@ jobs:
           python-version: '3.6'
       - run: python -m pip install -e .
       - run: black --check --diff sydent/ tests/ matrix_is_test/ setup.py
+      - run: flake8 sydent/ tests/ matrix_is_test/ setup.py
 
   run-unit-tests-python3-6:
+    needs: [check-code-style]
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v2
@@ -22,6 +24,7 @@ jobs:
       - run: trial tests
 
   run-matrix-is-tests-python3-6:
+    needs: [check-code-style]
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v2
@@ -33,6 +36,7 @@ jobs:
       - run: trial matrix_is_tester
 
   run-unit-tests-python3-9:
+    needs: [check-code-style]
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v2
@@ -43,6 +47,7 @@ jobs:
       - run: trial tests
 
   run-matrix-is-tests-python3-9:
+    needs: [check-code-style]
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,6 +11,17 @@ jobs:
       - run: python -m pip install -e .
       - run: trial tests
 
+  run-matrix-is-tests-python3-6:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - run: python -m pip install -e .
+      - run: pip install git+https://github.com/matrix-org/matrix-is-tester.git
+      - run: trial matrix_is_tester
+
   run-unit-tests-python3-9:
     runs-on: ubuntu-latest
     steps: 
@@ -21,13 +32,13 @@ jobs:
       - run: python -m pip install -e .
       - run: trial tests
 
-  run-matrix-is-tests-python3-6:
+  run-matrix-is-tests-python3-9:
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.9'
       - run: python -m pip install -e .
       - run: pip install git+https://github.com/matrix-org/matrix-is-tester.git
       - run: trial matrix_is_tester

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,7 +6,7 @@ jobs:
     steps: 
       -uses: actions/checkout@v2
       -uses: actions/setup-python@v2
-      with:
+       with:
         python-version: "3.6"
       -run: python -m pip install -e .
       -run: trial tests
@@ -16,7 +16,7 @@ jobs:
     steps: 
       -uses: actions/checkout@v2
       -uses: actions/setup-python@v2
-      with:
+       with:
         python-version: "3.9"
       -run: python -m pip install -e .
       -run: trial tests

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,19 +4,19 @@ jobs:
   run-unit-tests-python3-6:
     runs-on: ubuntu-latest
     steps: 
-      -uses: actions/checkout@v2
-      -uses: actions/setup-python@v2
-       with:
-        python-version: "3.6"
-      -run: python -m pip install -e .
-      -run: trial tests
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+         python-version: '3.6'
+      - run: python -m pip install -e .
+      - run: trial tests
 
   run-unit-tests-python3-9:
     runs-on: ubuntu-latest
     steps: 
-      -uses: actions/checkout@v2
-      -uses: actions/setup-python@v2
-       with:
-        python-version: "3.9"
-      -run: python -m pip install -e .
-      -run: trial tests
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+         python-version: '3.9'
+      - run: python -m pip install -e .
+      - run: trial tests

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,22 @@
+name: Linting and tests
+on: [push]
+jobs: 
+  run-unit-tests-python3.6:
+  runs-on: ubuntu-latest
+  steps: 
+    -uses: actions/checkout@v2
+    -uses: actions/setup-python@v2
+     with:
+      python-version: "3.6"
+    -run: python -m pip install -e .
+    -run: trial tests
+
+  run-unit-tests-python3.9:
+  runs-on: ubuntu-latest
+  steps: 
+    -uses: actions/checkout@v2
+    -uses: actions/setup-python@v2
+     with:
+      python-version: "3.9"
+    -run: python -m pip install -e .
+    -run: trial tests

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,3 +20,14 @@ jobs:
          python-version: '3.9'
       - run: python -m pip install -e .
       - run: trial tests
+
+  run-matrix-is-tests-python3-6:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - run: python -m pip install -e .
+      - run: pip install git+https://github.com/matrix-org/matrix-is-tester.git
+      - run: trial matrix_is_tester

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,5 +1,8 @@
 name: Linting and tests
-on: [push]
+on: 
+  pull_request:
+  push:
+    branches: ["main"]
 jobs: 
   check-code-style:
     runs-on: ubuntu-latest
@@ -12,48 +15,35 @@ jobs:
       - run: black --check --diff sydent/ tests/ matrix_is_test/ setup.py
       - run: flake8 sydent/ tests/ matrix_is_test/ setup.py
 
-  run-unit-tests-python3-6:
+  run-unit-tests:
     needs: [check-code-style]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.x']
+    
     steps: 
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-         python-version: '3.6'
+         python-version: ${{ matrix.python-version }}
       - run: python -m pip install -e .
       - run: trial tests
 
-  run-matrix-is-tests-python3-6:
+  run-matrix-is-tests:
     needs: [check-code-style]
     runs-on: ubuntu-latest
+    strategy:
+    matrix:
+      python-version: ['3.6', '3.x'] 
+    
     steps: 
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: ${{ matrix.python-version }}
       - run: python -m pip install -e .
       - run: pip install git+https://github.com/matrix-org/matrix-is-tester.git
       - run: trial matrix_is_tester
 
-  run-unit-tests-python3-9:
-    needs: [check-code-style]
-    runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-         python-version: '3.9'
-      - run: python -m pip install -e .
-      - run: trial tests
-
-  run-matrix-is-tests-python3-9:
-    needs: [check-code-style]
-    runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-      - run: python -m pip install -e .
-      - run: pip install git+https://github.com/matrix-org/matrix-is-tester.git
-      - run: trial matrix_is_tester
+  

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,16 @@
 name: Linting and tests
 on: [push]
 jobs: 
+  check-code-style:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with: 
+          python-version: '3.6'
+      - run: python -m pip install -e .
+      - run: black --check --diff sydent/ tests/ matrix_is_test/ setup.py
+
   run-unit-tests-python3-6:
     runs-on: ubuntu-latest
     steps: 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,7 +1,7 @@
 name: Linting and tests
 on: [push]
 jobs: 
-  run-unit-tests-python3.6:
+  run-unit-tests-python3-6:
   runs-on: ubuntu-latest
   steps: 
     -uses: actions/checkout@v2
@@ -11,7 +11,7 @@ jobs:
     -run: python -m pip install -e .
     -run: trial tests
 
-  run-unit-tests-python3.9:
+  run-unit-tests-python3-9:
   runs-on: ubuntu-latest
   steps: 
     -uses: actions/checkout@v2

--- a/changelog.d/346.misc
+++ b/changelog.d/346.misc
@@ -1,1 +1,1 @@
-add github actions for unittests (python 3.6 and 3.9), matrix_is_tester tests (python 3.6 and 3.9), towncrier checks and black and flake8 codestyle checks
+Add github actions for unittests (python 3.6 and 3.9), matrix_is_tester tests (python 3.6 and 3.9), towncrier checks and black and flake8 codestyle checks.

--- a/changelog.d/346.misc
+++ b/changelog.d/346.misc
@@ -1,0 +1,1 @@
+add github actions for unittests (python 3.6 and 3.9), matrix_is_tester tests (python 3.6 and 3.9), towncrier checks and black and flake8 codestyle checks

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(
         "six>=1.10",
         "pyyaml>=3.11",
         "mock>=3.0.5",
-        "black==20.8b1"
+        "flake8==3.9.0",
+        "black==20.8b1",
     ],
     # make sure we package the sql files
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ setup(
         "six>=1.10",
         "pyyaml>=3.11",
         "mock>=3.0.5",
-        "flake8==3.9.0",
-        "black==20.8b1",
+        "flake8==3.9.2",
+        "black==21.5b1",
     ],
     # make sure we package the sql files
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "six>=1.10",
         "pyyaml>=3.11",
         "mock>=3.0.5",
+        "black==20.8b1"
     ],
     # make sure we package the sql files
     include_package_data=True,


### PR DESCRIPTION
This PR adds the unit tests, matrix_is_tester tests, towncrier checks, black code formatting checks and flake8 lint checks to github actions. Note that since the flake8 linting is failing (it runs but the code doesn't pass) and the unit tests and matrix_is_tests are run only after the codestyle checks pass, they are not running-I added those first and verified that they run before adding anything else. 

signed off by H.Shay, shaysquared@gmail.com
