### PR TITLE
Stop using deprecated logging.warn() method. Use logging.warning() in…

### DIFF
--- a/changelog.d/351.misc
+++ b/changelog.d/351.misc
@@ -1,0 +1,1 @@
+Stop using deprecated logging.warn() method. Use logging.warning() instead.

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -136,7 +136,7 @@ class Verifier(object):
             for key_name, sig in sigs.items():
                 if key_name in server_keys:
                     if "key" not in server_keys[key_name]:
-                        logger.warn("Ignoring key %s with no 'key'")
+                        logger.warning("Ignoring key %s with no 'key'")
                         continue
                     key_bytes = decode_base64(server_keys[key_name]["key"])
                     verify_key = signedjson.key.decode_verify_key_bytes(
@@ -150,12 +150,12 @@ class Verifier(object):
                         "Verified signature with key %s from %s", key_name, server_name
                     )
                     defer.returnValue((server_name, key_name))
-            logger.warn(
+            logger.warning(
                 "No matching key found for signature block %r in server keys %r",
                 signed_json["signatures"],
                 server_keys,
             )
-        logger.warn(
+        logger.warning(
             "Unable to verify any signatures from block %r. Acceptable server names: %r",
             signed_json["signatures"],
             acceptable_server_names,

--- a/sydent/http/httpcommon.py
+++ b/sydent/http/httpcommon.py
@@ -44,7 +44,7 @@ class SslComponents:
             "http", "replication.https.certfile"
         )
         if privKeyAndCertFilename == "":
-            logger.warn(
+            logger.warning(
                 "No HTTPS private key / cert found: not starting replication server "
                 "or doing replication pushes"
             )
@@ -53,7 +53,7 @@ class SslComponents:
         try:
             fp = open(privKeyAndCertFilename)
         except IOError:
-            logger.warn(
+            logger.warning(
                 "Unable to read private key / cert file from %s: not starting the replication HTTPS server "
                 "or doing replication pushes.",
                 privKeyAndCertFilename,
@@ -74,9 +74,9 @@ class SslComponents:
                 caCert = twisted.internet.ssl.Certificate.loadPEM(fp.read())
                 fp.close()
             except Exception:
-                logger.warn("Failed to open CA cert file %s", caCertFilename)
+                logger.warning("Failed to open CA cert file %s", caCertFilename)
                 raise
-            logger.warn("Using custom CA cert file: %s", caCertFilename)
+            logger.warning("Using custom CA cert file: %s", caCertFilename)
             return twisted.internet._sslverify.OpenSSLCertificateAuthorities(
                 [caCert.original]
             )

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -69,7 +69,7 @@ class MsisdnRequestCodeServlet(Resource):
         try:
             phone_number_object = phonenumbers.parse(raw_phone_number, country)
         except Exception as e:
-            logger.warn("Invalid phone number given: %r", e)
+            logger.warning("Invalid phone number given: %r", e)
             request.setResponseCode(400)
             return {
                 "errcode": "M_INVALID_PHONE_NUMBER",

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -48,7 +48,7 @@ class ReplicationPushServlet(Resource):
         peer = peerStore.getPeerByName(peerCertCn)
 
         if not peer:
-            logger.warn(
+            logger.warning(
                 "Got connection from %s but no peer found by that name", peerCertCn
             )
             raise MatrixRestError(
@@ -62,7 +62,7 @@ class ReplicationPushServlet(Resource):
             or request.requestHeaders.getRawHeaders("Content-Type")[0]
             != "application/json"
         ):
-            logger.warn(
+            logger.warning(
                 "Peer %s made push connection with non-JSON content (type: %s)",
                 peer.servername,
                 request.requestHeaders.getRawHeaders("Content-Type")[0],
@@ -73,13 +73,13 @@ class ReplicationPushServlet(Resource):
             # json.loads doesn't allow bytes in Python 3.5
             inJson = json_decoder.decode(request.content.read().decode("UTF-8"))
         except ValueError:
-            logger.warn(
+            logger.warning(
                 "Peer %s made push connection with malformed JSON", peer.servername
             )
             raise MatrixRestError(400, "M_BAD_JSON", "Malformed JSON")
 
         if "sgAssocs" not in inJson:
-            logger.warn(
+            logger.warning(
                 "Peer %s made push connection with no 'sgAssocs' key in JSON",
                 peer.servername,
             )
@@ -144,7 +144,7 @@ class ReplicationPushServlet(Resource):
                 )
             except:
                 failedIds.append(originId)
-                logger.warn(
+                logger.warning(
                     "Failed to verify signed association from %s with origin ID %s",
                     peer.servername,
                     originId,

--- a/sydent/http/srvresolver.py
+++ b/sydent/http/srvresolver.py
@@ -134,7 +134,7 @@ class SrvResolver(object):
             # Try something in the cache, else rereaise
             cache_entry = self._cache.get(service_name, None)
             if cache_entry:
-                logger.warn(
+                logger.warning(
                     "Failed to resolve %r, falling back to cache. %r", service_name, e
                 )
                 defer.returnValue(list(cache_entry))

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -162,7 +162,7 @@ class RemotePeer(Peer):
             # Decode hex into bytes
             pubkey_decoded = binascii.unhexlify(pubkey)
 
-            logger.warn(
+            logger.warning(
                 "Peer public key of %s is hex encoded. Please update to base64 encoding",
                 server_name,
             )

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -227,7 +227,7 @@ class Sydent:
         self.server_name = self.cfg.get("general", "server.name")
         if self.server_name == "":
             self.server_name = os.uname()[1]
-            logger.warn(
+            logger.warning(
                 (
                     "You had not specified a server name. I have guessed that this server is called '%s' "
                     + "and saved this in the config file. If this is incorrect, you should edit server.name in "


### PR DESCRIPTION
…stead.

Signed-off-by: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>

### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fix a bug that prevented receiving messages from other servers." instead of "Move X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
