### PR TITLE
.gitignore: Only ignore sydent.conf and sydent.db if they occur in th…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ _trial_temp
 .python-version
 
 # Runtime files
-sydent.conf
-sydent.db
+/sydent.conf
+/sydent.db
 /matrix_is_test/sydent.stderr

--- a/changelog.d/354.misc
+++ b/changelog.d/354.misc
@@ -1,0 +1,1 @@
+.gitignore: Only ignore sydent.conf and sydent.db if they occur in the project's base folder.


### PR DESCRIPTION
…e project's base folder.

Reasoning: In Debian, we provide a debian/sydent.conf file as the
 initial config template file to be installed to /etc/matrix-sydent/.
 This file is stored in the Debian packaging Git (available on
 https://salsa.debian.org/matrix-team/matrix-sydent/).

 With this change in upstream's .gitignore file, we make sure that
 changes in debian/sydent.conf get properly tracked via the packaging
 Git, whereas changes to sydent.conf (in the project's basedir) are hidden
 from Git (which is relevant for software testing by upstream).

 The same logic quasi applies to the sydent.db file, although the Debian
 package, of course, does not ship such a file.

Signed-off-by: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>

### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fix a bug that prevented receiving messages from other servers." instead of "Move X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
