### PR TITLE
Add type hints for checking by mypy 

### DIFF
--- a/changelog.d/355.misc
+++ b/changelog.d/355.misc
@@ -1,0 +1,1 @@
+Added type hints to support mypy checks. 

--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -50,7 +50,7 @@ class AccountStore(object):
         return Account(*row)
 
     def storeAccount(
-        self, user_id: str, creation_ts: int, consent_version: Optional[bytes]
+        self, user_id: str, creation_ts: int, consent_version: Optional[str]
     ) -> None:
         """
         Stores an account for the given user ID.
@@ -72,7 +72,7 @@ class AccountStore(object):
         self.sydent.db.commit()
 
     def setConsentVersion(
-        self, user_id: bytes, consent_version: Optional[str]
+        self, user_id: str, consent_version: Optional[str]
     ) -> None:
         """
         Saves that the given user has agreed to all of the terms in the document of the

--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -15,15 +15,16 @@
 # limitations under the License.
 from __future__ import absolute_import
 
-from sydent.users.accounts import Account
+from typing import TYPE_CHECKING, Optional
 
-from typing import Optional, TYPE_CHECKING
+from sydent.users.accounts import Account
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
 
+
 class AccountStore(object):
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
     def getAccountByToken(self, token: str) -> Optional[Account]:
@@ -71,9 +72,7 @@ class AccountStore(object):
         )
         self.sydent.db.commit()
 
-    def setConsentVersion(
-        self, user_id: str, consent_version: Optional[str]
-    ) -> None:
+    def setConsentVersion(self, user_id: str, consent_version: Optional[str]) -> None:
         """
         Saves that the given user has agreed to all of the terms in the document of the
         given version.

--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -17,14 +17,16 @@ from __future__ import absolute_import
 
 from sydent.users.accounts import Account
 
-from typing import Union
+from typing import Optional, TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
 
 class AccountStore(object):
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
-    def getAccountByToken(self, token: str) -> Union[Account, None]:
+    def getAccountByToken(self, token: str) -> Optional[Account]:
         """
         Select the account matching the given token, if any.
 
@@ -48,7 +50,7 @@ class AccountStore(object):
         return Account(*row)
 
     def storeAccount(
-        self, user_id: str, creation_ts: int, consent_version: Union[bytes, None]
+        self, user_id: str, creation_ts: int, consent_version: Optional[bytes]
     ) -> None:
         """
         Stores an account for the given user ID.
@@ -70,7 +72,7 @@ class AccountStore(object):
         self.sydent.db.commit()
 
     def setConsentVersion(
-        self, user_id: bytes, consent_version: Union[str, None]
+        self, user_id: bytes, consent_version: Optional[str]
     ) -> None:
         """
         Saves that the given user has agreed to all of the terms in the document of the

--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -17,12 +17,14 @@ from __future__ import absolute_import
 
 from sydent.users.accounts import Account
 
+from typing import Union
+
 
 class AccountStore(object):
     def __init__(self, sydent):
         self.sydent = sydent
 
-    def getAccountByToken(self, token):
+    def getAccountByToken(self, token: str) -> Union[Account, None]:
         """
         Select the account matching the given token, if any.
 
@@ -45,7 +47,9 @@ class AccountStore(object):
 
         return Account(*row)
 
-    def storeAccount(self, user_id, creation_ts, consent_version):
+    def storeAccount(
+        self, user_id: str, creation_ts: int, consent_version: Union[bytes, None]
+    ) -> None:
         """
         Stores an account for the given user ID.
 
@@ -65,7 +69,9 @@ class AccountStore(object):
         )
         self.sydent.db.commit()
 
-    def setConsentVersion(self, user_id, consent_version):
+    def setConsentVersion(
+        self, user_id: bytes, consent_version: Union[str, None]
+    ) -> None:
         """
         Saves that the given user has agreed to all of the terms in the document of the
         given version.
@@ -82,7 +88,7 @@ class AccountStore(object):
         )
         self.sydent.db.commit()
 
-    def addToken(self, user_id, token):
+    def addToken(self, user_id: str, token: str) -> None:
         """
         Stores the authentication token for a given user.
 
@@ -98,7 +104,7 @@ class AccountStore(object):
         )
         self.sydent.db.commit()
 
-    def delToken(self, token):
+    def delToken(self, token: str) -> int:
         """
         Deletes an authentication token from the database.
 

--- a/sydent/db/hashing_metadata.py
+++ b/sydent/db/hashing_metadata.py
@@ -17,7 +17,7 @@
 # Actions on the hashing_metadata table which is defined in the migration process in
 # sqlitedb.py
 from sqlite3 import Cursor
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable, Optional
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/db/hashing_metadata.py
+++ b/sydent/db/hashing_metadata.py
@@ -17,12 +17,14 @@
 # Actions on the hashing_metadata table which is defined in the migration process in
 # sqlitedb.py
 
+from typing import Union, Callable
+
 
 class HashingMetadataStore:
     def __init__(self, sydent):
         self.sydent = sydent
 
-    def get_lookup_pepper(self):
+    def get_lookup_pepper(self) -> Union[str, None]:
         """Return the value of the current lookup pepper from the db
 
         :return: A pepper if it exists in the database, or None if one does
@@ -44,7 +46,9 @@ class HashingMetadataStore:
 
         return pepper
 
-    def store_lookup_pepper(self, hashing_function, pepper):
+    def store_lookup_pepper(
+        self, hashing_function: Callable[[str], str], pepper: str
+    ) -> None:
         """Stores a new lookup pepper in the hashing_metadata db table and rehashes all 3PIDs
 
         :param hashing_function: A function with single input and output strings
@@ -74,7 +78,13 @@ class HashingMetadataStore:
         # Commit the queued db transactions so that adding a new pepper and hashing is atomic
         self.sydent.db.commit()
 
-    def _rehash_threepids(self, cur, hashing_function, pepper, table):
+    def _rehash_threepids(
+        self,
+        cur: object,
+        hashing_function: Callable[[str], str],
+        pepper: str,
+        table: str,
+    ) -> None:
         """Rehash 3PIDs of a given table using a given hashing_function and pepper
 
         A database cursor `cur` must be passed to this function. After this function completes,

--- a/sydent/db/hashing_metadata.py
+++ b/sydent/db/hashing_metadata.py
@@ -16,15 +16,16 @@
 
 # Actions on the hashing_metadata table which is defined in the migration process in
 # sqlitedb.py
+from sqlite3 import Cursor
 
 from typing import Union, Callable, TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
-    import sqlite3
+    from sydent.sydent import Sydent
 
 
 class HashingMetadataStore:
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
     def get_lookup_pepper(self) -> Optional[str]:
@@ -83,7 +84,7 @@ class HashingMetadataStore:
 
     def _rehash_threepids(
         self,
-        cur: "sqlite3.Cursor",
+        cur: "Cursor",
         hashing_function: Callable[[str], str],
         pepper: str,
         table: str,

--- a/sydent/db/hashing_metadata.py
+++ b/sydent/db/hashing_metadata.py
@@ -17,7 +17,7 @@
 # Actions on the hashing_metadata table which is defined in the migration process in
 # sqlitedb.py
 
-from typing import Union, Callable, TYPE_CHECKING
+from typing import Union, Callable, TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     import sqlite3
@@ -27,7 +27,7 @@ class HashingMetadataStore:
     def __init__(self, sydent):
         self.sydent = sydent
 
-    def get_lookup_pepper(self) -> Union[str, None]:
+    def get_lookup_pepper(self) -> Optional[str]:
         """Return the value of the current lookup pepper from the db
 
         :return: A pepper if it exists in the database, or None if one does

--- a/sydent/db/hashing_metadata.py
+++ b/sydent/db/hashing_metadata.py
@@ -17,15 +17,14 @@
 # Actions on the hashing_metadata table which is defined in the migration process in
 # sqlitedb.py
 from sqlite3 import Cursor
-
-from typing import Union, Callable, TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Callable, Optional, Union
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
 
 
 class HashingMetadataStore:
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
     def get_lookup_pepper(self) -> Optional[str]:

--- a/sydent/db/hashing_metadata.py
+++ b/sydent/db/hashing_metadata.py
@@ -17,7 +17,10 @@
 # Actions on the hashing_metadata table which is defined in the migration process in
 # sqlitedb.py
 
-from typing import Union, Callable
+from typing import Union, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import sqlite3
 
 
 class HashingMetadataStore:
@@ -80,7 +83,7 @@ class HashingMetadataStore:
 
     def _rehash_threepids(
         self,
-        cur: object,
+        cur: "sqlite3.Cursor",
         hashing_function: Callable[[str], str],
         pepper: str,
         table: str,

--- a/sydent/db/hashing_metadata.py
+++ b/sydent/db/hashing_metadata.py
@@ -84,7 +84,7 @@ class HashingMetadataStore:
 
     def _rehash_threepids(
         self,
-        cur: "Cursor",
+        cur: Cursor,
         hashing_function: Callable[[str], str],
         pepper: str,
         table: str,

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -14,15 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import time
-
-from typing import Optional, List, Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
 
 
 class JoinTokenStore(object):
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
     def storeToken(

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -15,11 +15,14 @@
 # limitations under the License.
 import time
 
-from typing import Union, List, Dict
+from typing import Optional, List, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
 
 
 class JoinTokenStore(object):
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
     def storeToken(
@@ -163,7 +166,7 @@ class JoinTokenStore(object):
         self.sydent.db.commit()
         return cur.rowcount > 0
 
-    def getSenderForToken(self, token: str) -> Union[str, None]:
+    def getSenderForToken(self, token: str) -> Optional[str]:
         """
         Retrieves the MXID of the user that sent the invite the provided token is for.
 

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -15,12 +15,16 @@
 # limitations under the License.
 import time
 
+from typing import Union, List, Dict
+
 
 class JoinTokenStore(object):
     def __init__(self, sydent):
         self.sydent = sydent
 
-    def storeToken(self, medium, address, roomId, sender, token):
+    def storeToken(
+        self, medium: str, address: str, roomId: str, sender: str, token: str
+    ) -> None:
         """
         Store a new invite token and its metadata.
 
@@ -45,7 +49,7 @@ class JoinTokenStore(object):
         )
         self.sydent.db.commit()
 
-    def getTokens(self, medium, address):
+    def getTokens(self, medium: str, address: str) -> List[Dict[str, str]]:
         """
         Retrieves the pending invites tokens for this 3PID that haven't been delivered
         yet.
@@ -100,7 +104,7 @@ class JoinTokenStore(object):
 
         return ret
 
-    def markTokensAsSent(self, medium, address):
+    def markTokensAsSent(self, medium: str, address: str) -> None:
         """
         Updates the invite tokens associated with a given 3PID to mark them as
         delivered to a homeserver so they're not delivered again in the future.
@@ -122,7 +126,7 @@ class JoinTokenStore(object):
         )
         self.sydent.db.commit()
 
-    def storeEphemeralPublicKey(self, publicKey):
+    def storeEphemeralPublicKey(self, publicKey: str) -> None:
         """
         Saves the provided ephemeral public key.
 
@@ -138,7 +142,7 @@ class JoinTokenStore(object):
         )
         self.sydent.db.commit()
 
-    def validateEphemeralPublicKey(self, publicKey):
+    def validateEphemeralPublicKey(self, publicKey: str) -> bool:
         """
         Checks if an ephemeral public key is valid, and, if it is, updates its
         verification count.
@@ -159,7 +163,7 @@ class JoinTokenStore(object):
         self.sydent.db.commit()
         return cur.rowcount > 0
 
-    def getSenderForToken(self, token):
+    def getSenderForToken(self, token: str) -> Union[str, None]:
         """
         Retrieves the MXID of the user that sent the invite the provided token is for.
 
@@ -177,7 +181,7 @@ class JoinTokenStore(object):
             return rows[0][0]
         return None
 
-    def deleteTokens(self, medium, address):
+    def deleteTokens(self, medium: str, address: str) -> None:
         """
         Deletes every token for a given 3PID.
 

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -15,16 +15,16 @@
 # limitations under the License.
 from __future__ import absolute_import
 
-from sydent.replication.peer import RemotePeer
+from typing import TYPE_CHECKING, Dict, List, Optional
 
-from typing import Optional, List, Dict, TYPE_CHECKING
+from sydent.replication.peer import RemotePeer
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
 
 
 class PeerStore:
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
     def getPeerByName(self, name: str) -> Optional[RemotePeer]:

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -17,12 +17,14 @@ from __future__ import absolute_import
 
 from sydent.replication.peer import RemotePeer
 
+from typing import Union, List, Dict
+
 
 class PeerStore:
     def __init__(self, sydent):
         self.sydent = sydent
 
-    def getPeerByName(self, name):
+    def getPeerByName(self, name: str) -> Union[RemotePeer, None]:
         """
         Retrieves a remote peer using it's server name.
 
@@ -57,7 +59,7 @@ class PeerStore:
 
         return p
 
-    def getAllPeers(self):
+    def getAllPeers(self) -> List[RemotePeer]:
         """
         Retrieve all of the remote peers from the database.
 
@@ -75,7 +77,7 @@ class PeerStore:
         peername = None
         port = None
         lastSentVer = None
-        pubkeys = {}
+        pubkeys: Dict[str, str] = {}
 
         for row in res.fetchall():
             if row[0] != peername:
@@ -95,8 +97,8 @@ class PeerStore:
         return peers
 
     def setLastSentVersionAndPokeSucceeded(
-        self, peerName, lastSentVersion, lastPokeSucceeded
-    ):
+        self, peerName: str, lastSentVersion: int, lastPokeSucceeded: int
+    ) -> None:
         """
         Sets the ID of the last association sent to a given peer and the time of the
         last successful request sent to that peer.

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -17,14 +17,17 @@ from __future__ import absolute_import
 
 from sydent.replication.peer import RemotePeer
 
-from typing import Union, List, Dict
+from typing import Optional, List, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
 
 
 class PeerStore:
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
-    def getPeerByName(self, name: str) -> Union[RemotePeer, None]:
+    def getPeerByName(self, name: str) -> Optional[RemotePeer]:
         """
         Retrieves a remote peer using it's server name.
 

--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -19,11 +19,16 @@ import logging
 import os
 import sqlite3
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
 class SqliteDatabase:
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         self.sydent = syd
 
         dbFilePath = self.sydent.cfg.get("db", "db.file")

--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -18,7 +18,6 @@
 import logging
 import os
 import sqlite3
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -28,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class SqliteDatabase:
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         self.sydent = syd
 
         dbFilePath = self.sydent.cfg.get("db", "db.file")

--- a/sydent/db/terms.py
+++ b/sydent/db/terms.py
@@ -14,11 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
 
 
 class TermsStore(object):
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
     def getAgreedUrls(self, user_id: str) -> List[str]:

--- a/sydent/db/terms.py
+++ b/sydent/db/terms.py
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
 
 
 class TermsStore(object):
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
     def getAgreedUrls(self, user_id: str) -> List[str]:

--- a/sydent/db/terms.py
+++ b/sydent/db/terms.py
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
+
 
 class TermsStore(object):
     def __init__(self, sydent):
         self.sydent = sydent
 
-    def getAgreedUrls(self, user_id):
+    def getAgreedUrls(self, user_id: str) -> List[str]:
         """
         Retrieves the URLs of the terms the given user has agreed to.
 
@@ -45,7 +47,7 @@ class TermsStore(object):
 
         return urls
 
-    def addAgreedUrls(self, user_id, urls):
+    def addAgreedUrls(self, user_id: str, urls: List[str]) -> None:
         """
         Saves that the given user has accepted the terms at the given URLs.
 

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -403,7 +403,7 @@ class GlobalAssociationStore:
         )
         self.sydent.db.commit()
 
-    def retrieveMxidsForHashes(self, addresses: List[str]) -> Dict[str, str]:
+    def retrieveMxidsForHashes(self, addresses: List[Any]) -> Dict[str, str]:
         """Returns a mapping from hash: mxid from a list of given lookup_hash values
 
         :param addresses: An array of lookup_hash values to check against the db

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -18,9 +18,9 @@ from __future__ import absolute_import
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from sydent.util import time_msec
 from sydent.threepid import ThreepidAssociation
 from sydent.threepid.signer import Signer
+from sydent.util import time_msec
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -61,7 +61,7 @@ class LocalAssociationStore:
         self.sydent.db.commit()
 
     def getAssociationsAfterId(
-        self, afterId: int, limit: Optional[int] = None
+        self, afterId: Optional[int], limit: Optional[int] = None
     ) -> Tuple[Dict[int, ThreepidAssociation], Optional[int]]:
         """
         Retrieves every association after the given ID.
@@ -106,7 +106,7 @@ class LocalAssociationStore:
         return assocs, maxId
 
     def getSignedAssociationsAfterId(
-        self, afterId: int, limit: Optional[int] = None
+        self, afterId: Optional[int], limit: Optional[int] = None
     ) -> Tuple[Dict[int, Dict[str, Any]], Optional[int]]:
         """Get associations after a given ID, and sign them before returning
 
@@ -254,7 +254,7 @@ class GlobalAssociationStore:
         return row[0]
 
     def getMxids(
-        self, threepid_tuples: List[Tuple[str, str, str]]
+        self, threepid_tuples: List[Tuple[str, str]]
     ) -> List[Tuple[str, str, str]]:
         """Given a list of threepid_tuples, return the same list but with
         mxids appended to each tuple for which a match was found in the
@@ -295,7 +295,7 @@ class GlobalAssociationStore:
             )
 
             results = []
-            current = (Any, Any)
+            current = None
             for row in res.fetchall():
                 # only use the most recent entry for each
                 # threepid (they're sorted by ts)
@@ -401,7 +401,7 @@ class GlobalAssociationStore:
         )
         self.sydent.db.commit()
 
-    def retrieveMxidsForHashes(self, addresses: List[Any]) -> Dict[str, str]:
+    def retrieveMxidsForHashes(self, addresses: List[str]) -> Dict[str, str]:
         """Returns a mapping from hash: mxid from a list of given lookup_hash values
 
         :param addresses: An array of lookup_hash values to check against the db

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -16,8 +16,9 @@
 from __future__ import absolute_import
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
+from sydent.util import time_msec
 from sydent.threepid import ThreepidAssociation
 from sydent.threepid.signer import Signer
 

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -19,7 +19,15 @@ import logging
 
 from sydent.threepid import ThreepidAssociation
 from sydent.threepid.signer import Signer
+<<<<<<< HEAD
 from sydent.util import time_msec
+=======
+
+import logging
+
+from typing import Tuple, Union, List, Dict, Any, Sequence
+
+>>>>>>> reset author
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +36,7 @@ class LocalAssociationStore:
     def __init__(self, sydent):
         self.sydent = sydent
 
-    def addOrUpdateAssociation(self, assoc):
+    def addOrUpdateAssociation(self, assoc: ThreepidAssociation) -> None:
         """
         Updates an association, or creates one if none exists with these parameters.
 
@@ -54,7 +62,9 @@ class LocalAssociationStore:
         )
         self.sydent.db.commit()
 
-    def getAssociationsAfterId(self, afterId, limit=None):
+    def getAssociationsAfterId(
+        self, afterId: int, limit: Union[int, None] = None
+    ) -> Tuple[Dict[int, ThreepidAssociation], Union[int, None]]:
         """
         Retrieves every association after the given ID.
 
@@ -97,7 +107,9 @@ class LocalAssociationStore:
 
         return assocs, maxId
 
-    def getSignedAssociationsAfterId(self, afterId, limit=None):
+    def getSignedAssociationsAfterId(
+        self, afterId: int, limit: Union[int, None] = None
+    ) -> Tuple[Dict[int, Dict[str, Any]], Union[int, None]]:
         """Get associations after a given ID, and sign them before returning
 
         :param afterId: The ID to return results after (not inclusive)
@@ -124,7 +136,7 @@ class LocalAssociationStore:
 
         return assocs, maxId
 
-    def removeAssociation(self, threepid, mxid):
+    def removeAssociation(self, threepid: Dict[str, str], mxid: str) -> None:
         """
         Delete the association between a 3PID and a MXID, if it exists. If the
         association doesn't exist, log and do nothing.
@@ -179,7 +191,9 @@ class GlobalAssociationStore:
     def __init__(self, sydent):
         self.sydent = sydent
 
-    def signedAssociationStringForThreepid(self, medium, address):
+    def signedAssociationStringForThreepid(
+        self, medium: str, address: str
+    ) -> Union[str, None]:
         """
         Retrieve the JSON for the signed association matching the provided 3PID,
         if one exists.
@@ -214,7 +228,7 @@ class GlobalAssociationStore:
 
         return sgAssocStr
 
-    def getMxid(self, medium, address):
+    def getMxid(self, medium: str, address: str) -> Union[str, None]:
         """
         Retrieves the MXID associated with a 3PID.
 
@@ -241,7 +255,9 @@ class GlobalAssociationStore:
 
         return row[0]
 
-    def getMxids(self, threepid_tuples):
+    def getMxids(
+        self, threepid_tuples: List[Tuple[str, str, str]]
+    ) -> List[Tuple[str, str, str]]:
         """Given a list of threepid_tuples, return the same list but with
         mxids appended to each tuple for which a match was found in the
         database for. Output is ordered by medium, address, timestamp DESC
@@ -281,7 +297,7 @@ class GlobalAssociationStore:
             )
 
             results = []
-            current = ()
+            current = (Any, Any)
             for row in res.fetchall():
                 # only use the most recent entry for each
                 # threepid (they're sorted by ts)
@@ -295,7 +311,14 @@ class GlobalAssociationStore:
 
         return results
 
-    def addAssociation(self, assoc, rawSgAssoc, originServer, originId, commit=True):
+    def addAssociation(
+        self,
+        assoc: ThreepidAssociation,
+        rawSgAssoc: Dict[str, Any],
+        originServer: str,
+        originId: int,
+        commit: bool = True,
+    ) -> None:
         """
         Saves an association received through either a replication push or a local push.
 
@@ -333,7 +356,7 @@ class GlobalAssociationStore:
         if commit:
             self.sydent.db.commit()
 
-    def lastIdFromServer(self, server):
+    def lastIdFromServer(self, server: str) -> Union[int, None]:
         """
         Retrieves the ID of the last association received from the given peer.
 
@@ -357,7 +380,7 @@ class GlobalAssociationStore:
 
         return row[0]
 
-    def removeAssociation(self, medium, address):
+    def removeAssociation(self, medium: str, address: str) -> None:
         """
         Removes any association stored for the provided 3PID.
 
@@ -380,7 +403,7 @@ class GlobalAssociationStore:
         )
         self.sydent.db.commit()
 
-    def retrieveMxidsForHashes(self, addresses):
+    def retrieveMxidsForHashes(self, addresses: List[str]) -> Dict[str, str]:
         """Returns a mapping from hash: mxid from a list of given lookup_hash values
 
         :param addresses: An array of lookup_hash values to check against the db

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -424,14 +424,14 @@ class GlobalAssociationStore:
         results = {}
         try:
             # Convert list of addresses to list of tuples of addresses
-            addresses = [(x,) for x in addresses]
+            tuplized_addresses = [(x,) for x in addresses]
 
             inserted_cap = 0
-            while inserted_cap < len(addresses):
+            while inserted_cap < len(tuplized_addresses):
                 cur.executemany(
                     "INSERT INTO tmp_retrieve_mxids_for_hashes(lookup_hash) "
                     "VALUES (?)",
-                    addresses[inserted_cap : inserted_cap + 500],
+                    tuplized_addresses[inserted_cap : inserted_cap + 500],
                 )
                 inserted_cap += 500
 

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -16,13 +16,10 @@
 from __future__ import absolute_import
 
 import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
 from sydent.threepid import ThreepidAssociation
 from sydent.threepid.signer import Signer
-
-import logging
-
-from typing import Tuple, Optional, List, Dict, Any, Sequence, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
@@ -31,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class LocalAssociationStore:
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
     def addOrUpdateAssociation(self, assoc: ThreepidAssociation) -> None:
@@ -186,7 +183,7 @@ class LocalAssociationStore:
 
 
 class GlobalAssociationStore:
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
     def signedAssociationStringForThreepid(

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -19,21 +19,19 @@ import logging
 
 from sydent.threepid import ThreepidAssociation
 from sydent.threepid.signer import Signer
-<<<<<<< HEAD
-from sydent.util import time_msec
-=======
 
 import logging
 
-from typing import Tuple, Union, List, Dict, Any, Sequence
+from typing import Tuple, Optional, List, Dict, Any, Sequence, TYPE_CHECKING
 
->>>>>>> reset author
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
 
 
 class LocalAssociationStore:
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
     def addOrUpdateAssociation(self, assoc: ThreepidAssociation) -> None:
@@ -63,8 +61,8 @@ class LocalAssociationStore:
         self.sydent.db.commit()
 
     def getAssociationsAfterId(
-        self, afterId: int, limit: Union[int, None] = None
-    ) -> Tuple[Dict[int, ThreepidAssociation], Union[int, None]]:
+        self, afterId: int, limit: Optional[int] = None
+    ) -> Tuple[Dict[int, ThreepidAssociation], Optional[int]]:
         """
         Retrieves every association after the given ID.
 
@@ -108,8 +106,8 @@ class LocalAssociationStore:
         return assocs, maxId
 
     def getSignedAssociationsAfterId(
-        self, afterId: int, limit: Union[int, None] = None
-    ) -> Tuple[Dict[int, Dict[str, Any]], Union[int, None]]:
+        self, afterId: int, limit: Optional[int] = None
+    ) -> Tuple[Dict[int, Dict[str, Any]], Optional[int]]:
         """Get associations after a given ID, and sign them before returning
 
         :param afterId: The ID to return results after (not inclusive)
@@ -188,12 +186,12 @@ class LocalAssociationStore:
 
 
 class GlobalAssociationStore:
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
     def signedAssociationStringForThreepid(
         self, medium: str, address: str
-    ) -> Union[str, None]:
+    ) -> Optional[str]:
         """
         Retrieve the JSON for the signed association matching the provided 3PID,
         if one exists.
@@ -228,7 +226,7 @@ class GlobalAssociationStore:
 
         return sgAssocStr
 
-    def getMxid(self, medium: str, address: str) -> Union[str, None]:
+    def getMxid(self, medium: str, address: str) -> Optional[str]:
         """
         Retrieves the MXID associated with a 3PID.
 
@@ -356,7 +354,7 @@ class GlobalAssociationStore:
         if commit:
             self.sydent.db.commit()
 
-    def lastIdFromServer(self, server: str) -> Union[int, None]:
+    def lastIdFromServer(self, server: str) -> Optional[int]:
         """
         Retrieves the ID of the last association received from the given peer.
 

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 
 from random import SystemRandom
+from typing import TYPE_CHECKING, Optional
 
 import sydent.util.tokenutils
 from sydent.util import time_msec
@@ -27,14 +28,12 @@ from sydent.validators import (
     ValidationSession,
 )
 
-from typing import TYPE_CHECKING, Optional
-
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
 
 
 class ThreePidValSessionStore:
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         self.sydent = syd
         self.random = SystemRandom()
 

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -27,13 +27,17 @@ from sydent.validators import (
     ValidationSession,
 )
 
+from typing import Union
+
 
 class ThreePidValSessionStore:
     def __init__(self, syd):
         self.sydent = syd
         self.random = SystemRandom()
 
-    def getOrCreateTokenSession(self, medium, address, clientSecret):
+    def getOrCreateTokenSession(
+        self, medium: str, address: str, clientSecret: str
+    ) -> ValidationSession:
         """
         Retrieves the validation session for a given medium, address and client secret,
         or creates one if none was found.
@@ -82,7 +86,14 @@ class ThreePidValSessionStore:
         )
         return s
 
-    def addValSession(self, medium, address, clientSecret, mtime, commit=True):
+    def addValSession(
+        self,
+        medium: str,
+        address: str,
+        clientSecret: str,
+        mtime: int,
+        commit: bool = True,
+    ) -> int:
         """
         Creates a validation session with the given parameters.
 
@@ -117,7 +128,7 @@ class ThreePidValSessionStore:
             self.sydent.db.commit()
         return sid
 
-    def setSendAttemptNumber(self, sid, attemptNo):
+    def setSendAttemptNumber(self, sid: str, attemptNo: int) -> None:
         """
         Updates the send attempt number for the session with the given ID.
 
@@ -134,7 +145,7 @@ class ThreePidValSessionStore:
         )
         self.sydent.db.commit()
 
-    def setValidated(self, sid, validated):
+    def setValidated(self, sid: str, validated: bool) -> None:
         """
         Updates a session to set the validated flag to the given value.
 
@@ -151,7 +162,7 @@ class ThreePidValSessionStore:
         )
         self.sydent.db.commit()
 
-    def setMtime(self, sid, mtime):
+    def setMtime(self, sid: str, mtime: int) -> None:
         """
         Set the time of the last send attempt for the session with the given ID
 
@@ -168,7 +179,7 @@ class ThreePidValSessionStore:
         )
         self.sydent.db.commit()
 
-    def getSessionById(self, sid):
+    def getSessionById(self, sid: str) -> Union[ValidationSession, None]:
         """
         Retrieves the session matching the given sid.
 
@@ -195,7 +206,7 @@ class ThreePidValSessionStore:
             row[0], row[1], row[2], row[3], row[4], row[5], None, None
         )
 
-    def getTokenSessionById(self, sid):
+    def getTokenSessionById(self, sid: str) -> Union[ValidationSession, None]:
         """
         Retrieves a validation session using the session's ID.
 
@@ -223,7 +234,7 @@ class ThreePidValSessionStore:
 
         return None
 
-    def getValidatedSession(self, sid, clientSecret):
+    def getValidatedSession(self, sid: str, clientSecret: str) -> ValidationSession:
         """
         Retrieve a validated and still-valid session whose client secret matches the
         one passed in.
@@ -260,7 +271,7 @@ class ThreePidValSessionStore:
 
         return s
 
-    def deleteOldSessions(self):
+    def deleteOldSessions(self) -> None:
         """Delete old threepid validation sessions that are long expired."""
 
         cur = self.sydent.db.cursor()

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -27,11 +27,14 @@ from sydent.validators import (
     ValidationSession,
 )
 
-from typing import Union
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
 
 
 class ThreePidValSessionStore:
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         self.sydent = syd
         self.random = SystemRandom()
 
@@ -179,7 +182,7 @@ class ThreePidValSessionStore:
         )
         self.sydent.db.commit()
 
-    def getSessionById(self, sid: str) -> Union[ValidationSession, None]:
+    def getSessionById(self, sid: str) -> Optional[ValidationSession]:
         """
         Retrieves the session matching the given sid.
 
@@ -206,7 +209,7 @@ class ThreePidValSessionStore:
             row[0], row[1], row[2], row[3], row[4], row[5], None, None
         )
 
-    def getTokenSessionById(self, sid: str) -> Union[ValidationSession, None]:
+    def getTokenSessionById(self, sid: str) -> Optional[ValidationSession]:
         """
         Retrieves a validation session using the session's ID.
 

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -131,7 +131,7 @@ class ThreePidValSessionStore:
             self.sydent.db.commit()
         return sid
 
-    def setSendAttemptNumber(self, sid: str, attemptNo: int) -> None:
+    def setSendAttemptNumber(self, sid: int, attemptNo: int) -> None:
         """
         Updates the send attempt number for the session with the given ID.
 
@@ -148,7 +148,7 @@ class ThreePidValSessionStore:
         )
         self.sydent.db.commit()
 
-    def setValidated(self, sid: str, validated: bool) -> None:
+    def setValidated(self, sid: int, validated: bool) -> None:
         """
         Updates a session to set the validated flag to the given value.
 
@@ -165,7 +165,7 @@ class ThreePidValSessionStore:
         )
         self.sydent.db.commit()
 
-    def setMtime(self, sid: str, mtime: int) -> None:
+    def setMtime(self, sid: int, mtime: int) -> None:
         """
         Set the time of the last send attempt for the session with the given ID
 
@@ -182,7 +182,7 @@ class ThreePidValSessionStore:
         )
         self.sydent.db.commit()
 
-    def getSessionById(self, sid: str) -> Optional[ValidationSession]:
+    def getSessionById(self, sid: int) -> Optional[ValidationSession]:
         """
         Retrieves the session matching the given sid.
 
@@ -209,7 +209,7 @@ class ThreePidValSessionStore:
             row[0], row[1], row[2], row[3], row[4], row[5], None, None
         )
 
-    def getTokenSessionById(self, sid: str) -> Optional[ValidationSession]:
+    def getTokenSessionById(self, sid: int) -> Optional[ValidationSession]:
         """
         Retrieves a validation session using the session's ID.
 
@@ -237,7 +237,7 @@ class ThreePidValSessionStore:
 
         return None
 
-    def getValidatedSession(self, sid: str, clientSecret: str) -> ValidationSession:
+    def getValidatedSession(self, sid: int, clientSecret: str) -> ValidationSession:
         """
         Retrieve a validated and still-valid session whose client secret matches the
         one passed in.

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -68,7 +68,7 @@ class Verifier(object):
         self.sydent = sydent
         # Cache of server keys. These are cached until the 'valid_until_ts' time
         # in the result.
-        self.cache: Dict = {
+        self.cache: Dict[str, Any] = {
             # server_name: <result from keys query>,
         }
 

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -17,23 +17,17 @@ from __future__ import absolute_import
 
 import logging
 import time
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple
 
-
-import signedjson.key
-import signedjson.sign
+import signedjson.key  # type: ignore
+import signedjson.sign  # type: ignore
+from signedjson.sign import SignatureVerifyException
 from twisted.internet import defer
 from twisted.web.server import Request
 from unpaddedbase64 import decode_base64  # type: ignore
-import signedjson.sign  # type: ignore
-import signedjson.key  # type: ignore
-from signedjson.sign import SignatureVerifyException
-from twisted.internet import defer
-from unpaddedbase64 import decode_base64
 
 from sydent.http.httpclient import FederationHttpClient
 from sydent.util.stringutils import is_valid_matrix_server_name
-
-from typing import Dict, Optional, TYPE_CHECKING, Any, List, Tuple, Generator
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
@@ -64,7 +58,7 @@ class Verifier(object):
     verifying that the signature on the json blob matches.
     """
 
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
         # Cache of server keys. These are cached until the 'valid_until_ts' time
         # in the result.
@@ -178,7 +172,7 @@ class Verifier(object):
 
     @defer.inlineCallbacks
     def authenticate_request(
-        self, request: 'Request', content: Optional[bytes]
+        self, request: "Request", content: Optional[bytes]
     ) -> Generator:
         """Authenticates a Matrix federation request based on the X-Matrix header
         XXX: Copied largely from synapse

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -22,18 +22,18 @@ from sydent.http.servlets import MatrixRestError, get_args
 from sydent.terms.terms import get_terms
 from sydent.sydent import Sydent
 
+from twisted.web.server import Request
+
 from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sydent.db.accounts import Account
-    import twisted
     from sydent.sydent import Sydent
-
 
 logger = logging.getLogger(__name__)
 
 
-def tokenFromRequest(request: twisted.web.server.Request) -> Optional[str]:
+def tokenFromRequest(request: 'Request') -> Optional[str]:
     """Extract token from header of query parameter.
 
     :param request: The request to look for an access token in.
@@ -61,10 +61,10 @@ def tokenFromRequest(request: twisted.web.server.Request) -> Optional[str]:
 
 
 def authV2(
-    sydent: 'Sydent',
-    request: twisted.web.server.Request,
+    sydent: "Sydent",
+    request: 'Request',
     requireTermsAgreed: bool = True,
-) -> Optional[Account]:
+) -> Optional['Account']:
     """For v2 APIs check that the request has a valid access token associated with it
 
     :param sydent: The Sydent instance to use.

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -20,7 +20,6 @@ import logging
 from sydent.db.accounts import AccountStore
 from sydent.http.servlets import MatrixRestError, get_args
 from sydent.terms.terms import get_terms
-from sydent.sydent import Sydent
 
 from twisted.web.server import Request
 

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -63,7 +63,7 @@ def authV2(
     sydent: "Sydent",
     request: 'Request',
     requireTermsAgreed: bool = True,
-) -> Optional['Account']:
+) -> 'Account':
     """For v2 APIs check that the request has a valid access token associated with it
 
     :param sydent: The Sydent instance to use.

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -16,14 +16,13 @@
 from __future__ import absolute_import
 
 import logging
+from typing import TYPE_CHECKING, Optional
+
+from twisted.web.server import Request
 
 from sydent.db.accounts import AccountStore
 from sydent.http.servlets import MatrixRestError, get_args
 from sydent.terms.terms import get_terms
-
-from twisted.web.server import Request
-
-from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sydent.db.accounts import Account
@@ -32,7 +31,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def tokenFromRequest(request: 'Request') -> Optional[str]:
+def tokenFromRequest(request: "Request") -> Optional[str]:
     """Extract token from header of query parameter.
 
     :param request: The request to look for an access token in.
@@ -61,9 +60,9 @@ def tokenFromRequest(request: 'Request') -> Optional[str]:
 
 def authV2(
     sydent: "Sydent",
-    request: 'Request',
+    request: "Request",
     requireTermsAgreed: bool = True,
-) -> 'Account':
+) -> "Account":
     """For v2 APIs check that the request has a valid access token associated with it
 
     :param sydent: The Sydent instance to use.

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -21,10 +21,18 @@ from sydent.db.accounts import AccountStore
 from sydent.http.servlets import MatrixRestError, get_args
 from sydent.terms.terms import get_terms
 
+from typing import Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sydent.db.accounts import Account
+    import twisted
+    from sydent.sydent import Sydent
+
+
 logger = logging.getLogger(__name__)
 
 
-def tokenFromRequest(request):
+def tokenFromRequest(request: twisted.web.server.Request) -> Optional[str]:
     """Extract token from header of query parameter.
 
     :param request: The request to look for an access token in.
@@ -51,7 +59,11 @@ def tokenFromRequest(request):
     return token
 
 
-def authV2(sydent, request, requireTermsAgreed=True):
+def authV2(
+    sydent: sydent.sydent.Sydent,
+    request: twisted.web.server.Request,
+    requireTermsAgreed: bool = True,
+) -> Union[Account, None]:
     """For v2 APIs check that the request has a valid access token associated with it
 
     :param sydent: The Sydent instance to use.

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -20,8 +20,9 @@ import logging
 from sydent.db.accounts import AccountStore
 from sydent.http.servlets import MatrixRestError, get_args
 from sydent.terms.terms import get_terms
+from sydent.sydent import Sydent
 
-from typing import Union, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sydent.db.accounts import Account
@@ -60,10 +61,10 @@ def tokenFromRequest(request: twisted.web.server.Request) -> Optional[str]:
 
 
 def authV2(
-    sydent: sydent.sydent.Sydent,
+    sydent: 'Sydent',
     request: twisted.web.server.Request,
     requireTermsAgreed: bool = True,
-) -> Union[Account, None]:
+) -> Optional[Account]:
     """For v2 APIs check that the request has a valid access token associated with it
 
     :param sydent: The Sydent instance to use.

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -73,8 +73,7 @@ def authV2(
     :param requireTermsAgreed: Whether to deny authentication if the user hasn't accepted
         the terms of service.
 
-    :returns Account|None: The account object if there is correct auth, or None for v1
-        APIs.
+    :returns Account: The account object if there is correct auth
     :raises MatrixRestError: If the request is v2 but could not be authed or the user has
         not accepted terms.
     """

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import json
 import logging
 from io import BytesIO
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional
 
 from twisted.internet import defer
 from twisted.web.client import Agent, FileBodyProducer
@@ -29,8 +30,6 @@ from sydent.http.federation_tls_options import ClientTLSOptionsFactory
 from sydent.http.httpcommon import BodyExceededMaxSize, read_body_with_max_size
 from sydent.http.matrixfederationagent import MatrixFederationAgent
 from sydent.util import json_decoder
-
-from typing import Optional, Dict, Any, TYPE_CHECKING, Generator
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
@@ -46,9 +45,7 @@ class HTTPClient(object):
     agent: IAgent
 
     @defer.inlineCallbacks
-    def get_json(
-        self, uri: str, max_size: Optional[int] = None
-    ) -> Generator:
+    def get_json(self, uri: str, max_size: Optional[int] = None) -> Generator:
         """Make a GET request to an endpoint returning JSON and parse result
 
         :param uri: The URI to make a GET request to.
@@ -132,7 +129,7 @@ class SimpleHttpClient(HTTPClient):
     from Synapse.
     """
 
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
         # The default endpoint factory in Twisted 14.0.0 (which we require) uses the
         # BrowserLikePolicyForHTTPS context factory which will do regular cert validation
@@ -152,7 +149,7 @@ class FederationHttpClient(HTTPClient):
     MatrixFederationAgent.
     """
 
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
         self.agent = MatrixFederationAgent(
             BlacklistingReactorWrapper(

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -29,6 +29,11 @@ from sydent.http.httpcommon import BodyExceededMaxSize, read_body_with_max_size
 from sydent.http.matrixfederationagent import MatrixFederationAgent
 from sydent.util import json_decoder
 
+from typing import Union, Dict, Any, TYPE_CHECKING, Generator
+
+if TYPE_CHECKING:
+    import twisted
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,9 +41,13 @@ class HTTPClient(object):
     """A base HTTP class that contains methods for making GET and POST HTTP
     requests.
     """
+    agent: Any # TODO: find actual type of twisted.web.iweb.IAgent
+
 
     @defer.inlineCallbacks
-    def get_json(self, uri, max_size=None):
+    def get_json(
+        self, uri: str, max_size: Union[int, None] = None
+    ) -> Generator[Dict[Any, Any], Any, Any]:
         """Make a GET request to an endpoint returning JSON and parse result
 
         :param uri: The URI to make a GET request to.
@@ -66,7 +75,9 @@ class HTTPClient(object):
         defer.returnValue(json_body)
 
     @defer.inlineCallbacks
-    def post_json_get_nothing(self, uri, post_json, opts):
+    def post_json_get_nothing(
+        self, uri: str, post_json: Dict[Any, Any], opts: Dict[str, Any]
+    ) -> Generator[Any, Any, Any]:
         """Make a POST request to an endpoint returning JSON and parse result
 
         :param uri: The URI to make a POST request to.

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -43,7 +43,7 @@ class HTTPClient(object):
     requests.
     """
 
-    agent: Any  # TODO: find type that will work with both Agent() and MatrixFederationAgent()
+    agent: IAgent  # TODO: find type that will work with both Agent() and MatrixFederationAgent()
 
     @defer.inlineCallbacks
     def get_json(

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -43,7 +43,7 @@ class HTTPClient(object):
     requests.
     """
 
-    agent: IAgent  # TODO: find type that will work with both Agent() and MatrixFederationAgent()
+    agent: IAgent
 
     @defer.inlineCallbacks
     def get_json(

--- a/sydent/http/httpcommon.py
+++ b/sydent/http/httpcommon.py
@@ -24,6 +24,13 @@ from twisted.web import server
 from twisted.web._newclient import ResponseDone
 from twisted.web.http import PotentialDataLoss
 from twisted.web.iweb import UNKNOWN_LENGTH
+from twisted.web import server
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +39,7 @@ MAX_REQUEST_SIZE = 512 * 1024
 
 
 class SslComponents:
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
         self.myPrivateCertificate = self.makeMyCertificate()

--- a/sydent/http/httpcommon.py
+++ b/sydent/http/httpcommon.py
@@ -16,6 +16,7 @@
 
 import logging
 from io import BytesIO
+from typing import TYPE_CHECKING
 
 import twisted.internet.ssl
 from twisted.internet import defer, protocol
@@ -24,9 +25,6 @@ from twisted.web import server
 from twisted.web._newclient import ResponseDone
 from twisted.web.http import PotentialDataLoss
 from twisted.web.iweb import UNKNOWN_LENGTH
-from twisted.web import server
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
@@ -39,7 +37,7 @@ MAX_REQUEST_SIZE = 512 * 1024
 
 
 class SslComponents:
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
         self.myPrivateCertificate = self.makeMyCertificate()

--- a/sydent/http/httpsclient.py
+++ b/sydent/http/httpsclient.py
@@ -20,9 +20,10 @@ import logging
 from io import BytesIO
 
 from twisted.internet.ssl import optionsForClientTLS
+from twisted.internet.defer import Deferred
 from twisted.web.client import Agent, FileBodyProducer
 from twisted.web.http_headers import Headers
-from twisted.web.iweb import IPolicyForHTTPS
+from twisted.web.iweb import IPolicyForHTTPS, IResponse
 from zope.interface import implementer
 
 from typing import TYPE_CHECKING, Dict, Any, Generator, Optional
@@ -52,7 +53,7 @@ class ReplicationHttpsClient:
             #                                                      trustRoot=self.sydent.sslComponents.trustRoot)
             self.agent = Agent(self.sydent.reactor, SydentPolicyForHTTPS(self.sydent))
 
-    def postJson(self, uri: str, jsonObject: Dict[Any, Any]) -> Optional[Generator]:
+    def postJson(self, uri: str, jsonObject: Dict[Any, Any]) -> Optional[Deferred]:
         """
         Sends an POST request over HTTPS.
 

--- a/sydent/http/httpsclient.py
+++ b/sydent/http/httpsclient.py
@@ -18,13 +18,13 @@ from __future__ import absolute_import
 import json
 import logging
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Dict, Generator, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from twisted.internet.defer import Deferred
 from twisted.internet.ssl import optionsForClientTLS
 from twisted.web.client import Agent, FileBodyProducer
 from twisted.web.http_headers import Headers
-from twisted.web.iweb import IPolicyForHTTPS, IResponse
+from twisted.web.iweb import IPolicyForHTTPS
 from zope.interface import implementer
 
 if TYPE_CHECKING:

--- a/sydent/http/httpsclient.py
+++ b/sydent/http/httpsclient.py
@@ -18,15 +18,14 @@ from __future__ import absolute_import
 import json
 import logging
 from io import BytesIO
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional
 
-from twisted.internet.ssl import optionsForClientTLS
 from twisted.internet.defer import Deferred
+from twisted.internet.ssl import optionsForClientTLS
 from twisted.web.client import Agent, FileBodyProducer
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IPolicyForHTTPS, IResponse
 from zope.interface import implementer
-
-from typing import TYPE_CHECKING, Dict, Any, Generator, Optional
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
@@ -41,7 +40,7 @@ class ReplicationHttpsClient:
     replication HTTPS server)
     """
 
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
         self.agent = None
 
@@ -84,7 +83,7 @@ class ReplicationHttpsClient:
 
 @implementer(IPolicyForHTTPS)
 class SydentPolicyForHTTPS(object):
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
     def creatorForNetloc(self, hostname, port):

--- a/sydent/http/httpsclient.py
+++ b/sydent/http/httpsclient.py
@@ -25,6 +25,11 @@ from twisted.web.http_headers import Headers
 from twisted.web.iweb import IPolicyForHTTPS
 from zope.interface import implementer
 
+from typing import TYPE_CHECKING, Dict, Any, Generator, Optional
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,7 +40,7 @@ class ReplicationHttpsClient:
     replication HTTPS server)
     """
 
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
         self.agent = None
 
@@ -47,7 +52,7 @@ class ReplicationHttpsClient:
             #                                                      trustRoot=self.sydent.sslComponents.trustRoot)
             self.agent = Agent(self.sydent.reactor, SydentPolicyForHTTPS(self.sydent))
 
-    def postJson(self, uri, jsonObject):
+    def postJson(self, uri: str, jsonObject: Dict[Any, Any]) -> Optional[Generator]:
         """
         Sends an POST request over HTTPS.
 
@@ -62,7 +67,7 @@ class ReplicationHttpsClient:
         logger.debug("POSTing request to %s", uri)
         if not self.agent:
             logger.error("HTTPS post attempted but HTTPS is not configured")
-            return
+            return None
 
         headers = Headers(
             {"Content-Type": ["application/json"], "User-Agent": ["Sydent"]}
@@ -78,7 +83,7 @@ class ReplicationHttpsClient:
 
 @implementer(IPolicyForHTTPS)
 class SydentPolicyForHTTPS(object):
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
     def creatorForNetloc(self, hostname, port):

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import
 
 import logging
+from typing import TYPE_CHECKING
 
 import twisted.internet.ssl
 from twisted.web.resource import Resource
@@ -31,8 +32,6 @@ from sydent.http.servlets.authenticated_unbind_threepid_servlet import (
     AuthenticatedUnbindThreePidServlet,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
 
@@ -40,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 class ClientApiHttpServer:
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
         root = Resource()
@@ -154,7 +153,7 @@ class ClientApiHttpServer:
 
 
 class InternalApiHttpServer(object):
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
     def setup(self, interface, port):
@@ -182,7 +181,7 @@ class InternalApiHttpServer(object):
 
 
 class ReplicationHttpsServer:
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
         root = Resource()

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -31,11 +31,16 @@ from sydent.http.servlets.authenticated_unbind_threepid_servlet import (
     AuthenticatedUnbindThreePidServlet,
 )
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
 class ClientApiHttpServer:
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
         root = Resource()
@@ -149,7 +154,7 @@ class ClientApiHttpServer:
 
 
 class InternalApiHttpServer(object):
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
     def setup(self, interface, port):
@@ -177,7 +182,7 @@ class InternalApiHttpServer(object):
 
 
 class ReplicationHttpsServer:
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
         root = Resource()

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -17,11 +17,10 @@ from __future__ import absolute_import
 import logging
 import random
 import time
+from typing import Generator, Optional
 
 import attr
-from netaddr import IPAddress # type: ignore
-from zope.interface import implementer
-
+from netaddr import IPAddress  # type: ignore
 from twisted.internet import defer
 from twisted.internet.defer import Deferred
 from twisted.internet.endpoints import HostnameEndpoint, wrapClientTLS
@@ -30,14 +29,12 @@ from twisted.web.client import URI, Agent, HTTPConnectionPool, RedirectAgent
 from twisted.web.http import stringToDatetime
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IAgent, IBodyProducer
-
+from zope.interface import implementer
 
 from sydent.http.httpcommon import read_body_with_max_size
 from sydent.http.srvresolver import SrvResolver, pick_server_from_list
 from sydent.util import json_decoder
 from sydent.util.ttlcache import TTLCache
-
-from typing import Generator, Optional
 
 # period to cache .well-known results for by default
 WELL_KNOWN_DEFAULT_CACHE_PERIOD = 24 * 3600
@@ -89,8 +86,8 @@ class MatrixFederationAgent(object):
         reactor,
         tls_client_options_factory,
         _well_known_tls_policy=None,
-        _srv_resolver: Optional['SrvResolver']=None,
-        _well_known_cache: Optional['TTLCache']=well_known_cache,
+        _srv_resolver: Optional["SrvResolver"] = None,
+        _well_known_cache: Optional["TTLCache"] = well_known_cache,
     ) -> None:
         self._reactor = reactor
 
@@ -125,8 +122,9 @@ class MatrixFederationAgent(object):
         self,
         method: bytes,
         uri: bytes,
-        headers: Optional['Headers']=None,
-        bodyProducer: Optional['IBodyProducer']=None) -> Generator:
+        headers: Optional["Headers"] = None,
+        bodyProducer: Optional["IBodyProducer"] = None,
+    ) -> Generator:
         """
         :param method: HTTP method (GET/POST/etc).
         :type method: bytes
@@ -191,7 +189,9 @@ class MatrixFederationAgent(object):
         defer.returnValue(res)
 
     @defer.inlineCallbacks
-    def _route_matrix_uri(self, parsed_uri: 'URI', lookup_well_known: bool=True) -> 'Deferred':
+    def _route_matrix_uri(
+        self, parsed_uri: "URI", lookup_well_known: bool = True
+    ) -> "Deferred":
         """Helper for `request`: determine the routing for a Matrix URI
 
         :param parsed_uri: uri to route. Note that it should be parsed with

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -126,7 +126,7 @@ class MatrixFederationAgent(object):
         method: bytes,
         uri: bytes,
         headers: Optional['Headers']=None,
-        bodyProducer: Optional['IBodyProducer']=None) -> 'Deferred':
+        bodyProducer: Optional['IBodyProducer']=None) -> Generator:
         """
         :param method: HTTP method (GET/POST/etc).
         :type method: bytes
@@ -304,7 +304,7 @@ class MatrixFederationAgent(object):
         )
 
     @defer.inlineCallbacks
-    def _get_well_known(self, server_name: bytes) -> 'Deferred':
+    def _get_well_known(self, server_name: bytes) -> Generator:
         """Attempt to fetch and parse a .well-known file for the given server
 
         :param server_name: Name of the server, from the requested url.
@@ -327,7 +327,7 @@ class MatrixFederationAgent(object):
         defer.returnValue(result)
 
     @defer.inlineCallbacks
-    def _do_get_well_known(self, server_name: bytes) -> 'Deferred':
+    def _do_get_well_known(self, server_name: bytes) -> Generator:
         """Actually fetch and parse a .well-known, without checking the cache
 
         :param server_name: Name of the server, from the requested url

--- a/sydent/http/srvresolver.py
+++ b/sydent/http/srvresolver.py
@@ -21,7 +21,6 @@ from typing import Callable, Dict, Generator, List, SupportsInt, Tuple
 
 import attr
 from twisted.internet import defer
-from twisted.internet.defer import Deferred
 from twisted.internet.error import ConnectError
 from twisted.internet.interfaces import IResolver
 from twisted.names import client, dns

--- a/sydent/http/srvresolver.py
+++ b/sydent/http/srvresolver.py
@@ -17,6 +17,7 @@
 import logging
 import random
 import time
+from typing import Callable, Dict, Generator, List, SupportsInt, Tuple
 
 import attr
 from twisted.internet import defer
@@ -25,8 +26,6 @@ from twisted.internet.error import ConnectError
 from twisted.internet.interfaces import IResolver
 from twisted.names import client, dns
 from twisted.names.error import DNSNameError, DomainError
-
-from typing import Callable, Dict, Tuple, List, SupportsInt, Generator
 
 logger = logging.getLogger(__name__)
 
@@ -100,13 +99,18 @@ class SrvResolver(object):
     :type get_time: callable
     """
 
-    def __init__(self, dns_client: 'IResolver'=client, cache: Dict[bytes, List[Server]]=SERVER_CACHE, get_time: Callable[[], SupportsInt]=time.time) -> None:
+    def __init__(
+        self,
+        dns_client: "IResolver" = client,
+        cache: Dict[bytes, List[Server]] = SERVER_CACHE,
+        get_time: Callable[[], SupportsInt] = time.time,
+    ) -> None:
         self._dns_client = dns_client
         self._cache = cache
         self._get_time = get_time
 
     @defer.inlineCallbacks
-    def resolve_service(self, service_name: bytes) -> 'Generator':
+    def resolve_service(self, service_name: bytes) -> "Generator":
         """Look up a SRV record
 
         :param service_name: The record to look up.

--- a/sydent/http/srvresolver.py
+++ b/sydent/http/srvresolver.py
@@ -20,9 +20,13 @@ import time
 
 import attr
 from twisted.internet import defer
+from twisted.internet.defer import Deferred
 from twisted.internet.error import ConnectError
+from twisted.internet.interfaces import IResolver
 from twisted.names import client, dns
 from twisted.names.error import DNSNameError, DomainError
+
+from typing import Callable, Dict, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +53,7 @@ class Server(object):
     expires = attr.ib(default=0)
 
 
-def pick_server_from_list(server_list):
+def pick_server_from_list(server_list: list[Server]) -> Tuple[bytes, int]:
     """Randomly choose a server from the server list.
 
     :param server_list: List of candidate servers.
@@ -96,13 +100,13 @@ class SrvResolver(object):
     :type get_time: callable
     """
 
-    def __init__(self, dns_client=client, cache=SERVER_CACHE, get_time=time.time):
+    def __init__(self, dns_client: 'IResolver'=client, cache: Dict=SERVER_CACHE, get_time: Callable=time.time) -> None:
         self._dns_client = dns_client
         self._cache = cache
         self._get_time = get_time
 
     @defer.inlineCallbacks
-    def resolve_service(self, service_name):
+    def resolve_service(self, service_name: bytes) -> 'Deferred':
         """Look up a SRV record
 
         :param service_name: The record to look up.

--- a/sydent/http/srvresolver.py
+++ b/sydent/http/srvresolver.py
@@ -26,7 +26,7 @@ from twisted.internet.interfaces import IResolver
 from twisted.names import client, dns
 from twisted.names.error import DNSNameError, DomainError
 
-from typing import Callable, Dict, Tuple, List, SupportsInt
+from typing import Callable, Dict, Tuple, List, SupportsInt, Generator
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +106,7 @@ class SrvResolver(object):
         self._get_time = get_time
 
     @defer.inlineCallbacks
-    def resolve_service(self, service_name: bytes) -> Generator:
+    def resolve_service(self, service_name: bytes) -> 'Generator':
         """Look up a SRV record
 
         :param service_name: The record to look up.

--- a/sydent/http/srvresolver.py
+++ b/sydent/http/srvresolver.py
@@ -26,7 +26,7 @@ from twisted.internet.interfaces import IResolver
 from twisted.names import client, dns
 from twisted.names.error import DNSNameError, DomainError
 
-from typing import Callable, Dict, Tuple, List
+from typing import Callable, Dict, Tuple, List, SupportsInt
 
 logger = logging.getLogger(__name__)
 
@@ -100,13 +100,13 @@ class SrvResolver(object):
     :type get_time: callable
     """
 
-    def __init__(self, dns_client: 'IResolver'=client, cache: Dict=SERVER_CACHE, get_time: Callable=time.time) -> None:
+    def __init__(self, dns_client: 'IResolver'=client, cache: Dict[bytes, List[Server]]=SERVER_CACHE, get_time: Callable[[], SupportsInt]=time.time) -> None:
         self._dns_client = dns_client
         self._cache = cache
         self._get_time = get_time
 
     @defer.inlineCallbacks
-    def resolve_service(self, service_name: bytes) -> 'Deferred':
+    def resolve_service(self, service_name: bytes) -> Generator:
         """Look up a SRV record
 
         :param service_name: The record to look up.

--- a/sydent/http/srvresolver.py
+++ b/sydent/http/srvresolver.py
@@ -26,7 +26,7 @@ from twisted.internet.interfaces import IResolver
 from twisted.names import client, dns
 from twisted.names.error import DNSNameError, DomainError
 
-from typing import Callable, Dict, Tuple
+from typing import Callable, Dict, Tuple, List
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class Server(object):
     expires = attr.ib(default=0)
 
 
-def pick_server_from_list(server_list: list[Server]) -> Tuple[bytes, int]:
+def pick_server_from_list(server_list: List[Server]) -> Tuple[bytes, int]:
     """Randomly choose a server from the server list.
 
     :param server_list: List of candidate servers.

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -19,13 +19,16 @@ from __future__ import absolute_import
 import binascii
 import json
 import logging
+from typing import TYPE_CHECKING, Any, Dict, Generator
 
-import signedjson.key
-import signedjson.sign
+import signedjson.key  # type: ignore
+import signedjson.sign  # type: ignore
 from six.moves import configparser
 from twisted.internet import defer
+from twisted.internet.defer import Deferred
 from twisted.web.client import readBody
-from unpaddedbase64 import decode_base64
+from twisted.web.iweb import IResponse
+from unpaddedbase64 import decode_base64  # type: ignore
 
 from sydent.config import ConfigError
 from sydent.db.hashing_metadata import HashingMetadataStore
@@ -33,21 +36,6 @@ from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.threepid import threePidAssocFromDict
 from sydent.util import json_decoder
 from sydent.util.hash import sha256_and_url_safe_base64
-from unpaddedbase64 import decode_base64  # type: ignore
-
-import signedjson.sign  # type: ignore
-import signedjson.key  # type: ignore
-
-import logging
-import json
-import binascii
-
-from twisted.internet import defer
-from twisted.internet.defer import Deferred
-from twisted.web.client import readBody
-from twisted.web.iweb import IResponse
-
-from typing import Generator, Dict, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
@@ -63,7 +51,7 @@ class Peer(object):
         self.pubkeys = pubkeys
         self.is_being_pushed_to = False
 
-    def pushUpdates(self, sgAssocs) -> 'Deferred':
+    def pushUpdates(self, sgAssocs) -> "Deferred":
         """
         :param sgAssocs: Sequence of (originId, sgAssoc) tuples where originId is the id on the creating server and
                         sgAssoc is the json object of the signed association
@@ -77,7 +65,7 @@ class LocalPeer(Peer):
     The local peer (ourselves: essentially copying from the local associations table to the global one)
     """
 
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         super(LocalPeer, self).__init__(sydent.server_name, {})
         self.sydent = sydent
         self.hashing_store = HashingMetadataStore(sydent)
@@ -87,7 +75,7 @@ class LocalPeer(Peer):
         if self.lastId is None:
             self.lastId = -1
 
-    def pushUpdates(self, sgAssocs: Dict[int, Dict[str, Any]]) -> 'Deferred':
+    def pushUpdates(self, sgAssocs: Dict[int, Dict[str, Any]]) -> "Deferred":
         """
         Saves the given associations in the global associations store. Only stores an
         association if its ID is greater than the last seen ID.
@@ -132,7 +120,14 @@ class LocalPeer(Peer):
 
 
 class RemotePeer(Peer):
-    def __init__(self, sydent: 'Sydent', server_name: str, port: int, pubkeys: Dict[str, str], lastSentVersion: int) -> None:
+    def __init__(
+        self,
+        sydent: "Sydent",
+        server_name: str,
+        port: int,
+        pubkeys: Dict[str, str],
+        lastSentVersion: int,
+    ) -> None:
         """
         :param sydent: The current Sydent instance.
         :type sydent: sydent.sydent.Sydent
@@ -223,7 +218,7 @@ class RemotePeer(Peer):
         # Verify the JSON
         signedjson.sign.verify_signed_json(assoc, self.servername, self.verify_key)
 
-    def pushUpdates(self, sgAssocs: Dict[int, Dict[str, Any]]) -> 'Deferred':
+    def pushUpdates(self, sgAssocs: Dict[int, Dict[str, Any]]) -> "Deferred":
         """
         Pushes the given associations to the peer.
 
@@ -253,8 +248,8 @@ class RemotePeer(Peer):
 
     def _pushSuccess(
         self,
-        result: 'IResponse',
-        updateDeferred: 'Deferred',
+        result: "IResponse",
+        updateDeferred: "Deferred",
     ) -> None:
         """
         Processes a successful push request. If the request resulted in a status code
@@ -273,9 +268,7 @@ class RemotePeer(Peer):
             d.addCallback(self._failedPushBodyRead, updateDeferred=updateDeferred)
             d.addErrback(self._pushFailed, updateDeferred=updateDeferred)
 
-    def _failedPushBodyRead(
-        self, body: bytes, updateDeferred: 'Deferred'
-    ) -> None:
+    def _failedPushBodyRead(self, body: bytes, updateDeferred: "Deferred") -> None:
         """
         Processes a response body from a failed push request, then calls the error
         callback of the provided deferred.
@@ -293,7 +286,7 @@ class RemotePeer(Peer):
     def _pushFailed(
         self,
         failure,
-        updateDeferred: 'Deferred',
+        updateDeferred: "Deferred",
     ) -> None:
         """
         Processes a failed push request, by calling the error callback of the given

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 import binascii
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Generator
+from typing import TYPE_CHECKING, Any, Dict
 
 import signedjson.key  # type: ignore
 import signedjson.sign  # type: ignore

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -22,10 +22,15 @@ import twisted.internet.reactor
 import twisted.internet.task
 from twisted.internet import defer
 
-from sydent.db.peers import PeerStore
-from sydent.db.threepid_associations import LocalAssociationStore
-from sydent.replication.peer import LocalPeer
 from sydent.util import time_msec
+from sydent.replication.peer import LocalPeer, RemotePeer
+from sydent.db.threepid_associations import LocalAssociationStore
+from sydent.db.peers import PeerStore
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +39,7 @@ ASSOCIATIONS_PUSH_LIMIT = 100
 
 
 class Pusher:
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
         self.pushing = False
         self.peerStore = PeerStore(self.sydent)
@@ -45,7 +50,7 @@ class Pusher:
         cb.clock = self.sydent.reactor
         cb.start(10.0)
 
-    def doLocalPush(self):
+    def doLocalPush(self) -> None:
         """
         Synchronously push local associations to this server (ie. copy them to globals table)
         The local server is essentially treated the same as any other peer except we don't do
@@ -74,7 +79,7 @@ class Pusher:
         return defer.DeferredList([self._push_to_peer(p) for p in peers])
 
     @defer.inlineCallbacks
-    def _push_to_peer(self, p):
+    def _push_to_peer(self, p: 'RemotePeer') -> None:
         """
         For a given peer, retrieves the list of associations that were created since
         the last successful push to this peer (limited to ASSOCIATIONS_PUSH_LIMIT) and

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -27,7 +27,7 @@ from sydent.replication.peer import LocalPeer, RemotePeer
 from sydent.db.threepid_associations import LocalAssociationStore
 from sydent.db.peers import PeerStore
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generator
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
@@ -79,7 +79,7 @@ class Pusher:
         return defer.DeferredList([self._push_to_peer(p) for p in peers])
 
     @defer.inlineCallbacks
-    def _push_to_peer(self, p: 'RemotePeer') -> None:
+    def _push_to_peer(self, p: 'RemotePeer') -> Generator:
         """
         For a given peer, retrieves the list of associations that were created since
         the last successful push to this peer (limited to ASSOCIATIONS_PUSH_LIMIT) and

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -17,17 +17,16 @@
 from __future__ import absolute_import
 
 import logging
+from typing import TYPE_CHECKING, Generator
 
 import twisted.internet.reactor
 import twisted.internet.task
 from twisted.internet import defer
 
-from sydent.util import time_msec
-from sydent.replication.peer import LocalPeer, RemotePeer
-from sydent.db.threepid_associations import LocalAssociationStore
 from sydent.db.peers import PeerStore
-
-from typing import TYPE_CHECKING, Generator
+from sydent.db.threepid_associations import LocalAssociationStore
+from sydent.replication.peer import LocalPeer, RemotePeer
+from sydent.util import time_msec
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
@@ -39,7 +38,7 @@ ASSOCIATIONS_PUSH_LIMIT = 100
 
 
 class Pusher:
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
         self.pushing = False
         self.peerStore = PeerStore(self.sydent)
@@ -79,7 +78,7 @@ class Pusher:
         return defer.DeferredList([self._push_to_peer(p) for p in peers])
 
     @defer.inlineCallbacks
-    def _push_to_peer(self, p: 'RemotePeer') -> Generator:
+    def _push_to_peer(self, p: "RemotePeer") -> Generator:
         """
         For a given peer, retrieves the list of associations that were created since
         the last successful push to this peer (limited to ASSOCIATIONS_PUSH_LIMIT) and

--- a/sydent/sms/openmarket.py
+++ b/sydent/sms/openmarket.py
@@ -21,9 +21,13 @@ from base64 import b64encode
 from twisted.internet import defer
 from twisted.web.http_headers import Headers
 
+
 from sydent.http.httpclient import SimpleHttpClient
 
-from typing import Union, Dict, Generator, Any
+from typing import Dict, Any, TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +46,7 @@ TONS = {
 }
 
 
-def tonFromType(t):
+def tonFromType(t: str) -> int:
     """
     Get the type of number from the originator's type.
 
@@ -58,12 +62,14 @@ def tonFromType(t):
 
 
 class OpenMarketSMS:
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
         self.http_cli = SimpleHttpClient(sydent)
 
     @defer.inlineCallbacks
-    def sendTextSMS(self, body: Dict, dest: str, source: Union[None, Dict[str, str]]=None) -> Generator:
+    def sendTextSMS(
+        self, body: Dict, dest: str, source: Optional[Dict[str, str]] = None
+    ) -> None:
         """
         Sends a text message with the given body to the given MSISDN.
 

--- a/sydent/sms/openmarket.py
+++ b/sydent/sms/openmarket.py
@@ -17,14 +17,12 @@ from __future__ import absolute_import
 
 import logging
 from base64 import b64encode
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from twisted.internet import defer
 from twisted.web.http_headers import Headers
 
-
 from sydent.http.httpclient import SimpleHttpClient
-
-from typing import Dict, Any, TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
@@ -62,7 +60,7 @@ def tonFromType(t: str) -> int:
 
 
 class OpenMarketSMS:
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
         self.http_cli = SimpleHttpClient(sydent)
 

--- a/sydent/sms/openmarket.py
+++ b/sydent/sms/openmarket.py
@@ -99,7 +99,7 @@ class OpenMarketSMS:
         password = self.sydent.cfg.get("sms", "password").encode("UTF-8")
 
         b64creds = b64encode(b"%s:%s" % (username, password))
-        headers: Any = Headers(
+        req_headers = Headers(
             {
                 b"Authorization": [b"Basic " + b64creds],
                 b"Content-Type": [b"application/json"],
@@ -107,7 +107,7 @@ class OpenMarketSMS:
         )
 
         resp = yield self.http_cli.post_json_get_nothing(
-            API_BASE_URL, body, {"headers": headers}
+            API_BASE_URL, body, {"headers": req_headers}
         )
         headers = dict(resp.headers.getAllRawHeaders())
 

--- a/sydent/sms/openmarket.py
+++ b/sydent/sms/openmarket.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 
 import logging
 from base64 import b64encode
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 from twisted.internet import defer
 from twisted.web.http_headers import Headers

--- a/sydent/sms/openmarket.py
+++ b/sydent/sms/openmarket.py
@@ -23,6 +23,8 @@ from twisted.web.http_headers import Headers
 
 from sydent.http.httpclient import SimpleHttpClient
 
+from typing import Union, Dict, Generator, Any
+
 logger = logging.getLogger(__name__)
 
 
@@ -61,7 +63,7 @@ class OpenMarketSMS:
         self.http_cli = SimpleHttpClient(sydent)
 
     @defer.inlineCallbacks
-    def sendTextSMS(self, body, dest, source=None):
+    def sendTextSMS(self, body: Dict, dest: str, source: Union[None, Dict[str, str]]=None) -> Generator:
         """
         Sends a text message with the given body to the given MSISDN.
 
@@ -91,7 +93,7 @@ class OpenMarketSMS:
         password = self.sydent.cfg.get("sms", "password").encode("UTF-8")
 
         b64creds = b64encode(b"%s:%s" % (username, password))
-        headers = Headers(
+        headers: Any = Headers(
             {
                 b"Authorization": [b"Basic " + b64creds],
                 b"Content-Type": [b"application/json"],

--- a/sydent/terms/terms.py
+++ b/sydent/terms/terms.py
@@ -17,19 +17,20 @@
 import logging
 
 import yaml
+from typing import Union, Set, List, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
 
 class Terms(object):
-    def __init__(self, yamlObj):
+    def __init__(self, yamlObj) -> None:
         """
         :param yamlObj: The parsed YAML.
         :type yamlObj: dict[str, any] or None
         """
         self._rawTerms = yamlObj
 
-    def getMasterVersion(self):
+    def getMasterVersion(self) -> Union[str, None]:
         """
         :return: The global (master) version of the terms, or None if there
             are no terms of service for this server.
@@ -43,7 +44,7 @@ class Terms(object):
 
         return version
 
-    def getForClient(self):
+    def getForClient(self) -> Dict:
         """
         :return: A dict which value for the "policies" key is a dict which contains the
             "docs" part of the terms' YAML. That nested dict is empty if no terms.
@@ -58,7 +59,7 @@ class Terms(object):
                 policies[docName].update(doc["langs"])
         return {"policies": policies}
 
-    def getUrlSet(self):
+    def getUrlSet(self) -> Set[str]:
         """
         :return: All the URLs for the terms in a set. Empty set if no terms.
         :rtype: set[unicode]
@@ -76,7 +77,7 @@ class Terms(object):
                     urls.add(url)
         return urls
 
-    def urlListIsSufficient(self, urls):
+    def urlListIsSufficient(self, urls: List[str]) -> bool:
         """
         Checks whether the provided list of URLs (which represents the list of terms
         accepted by the user) is enough to allow the creation of the user's account.
@@ -102,7 +103,7 @@ class Terms(object):
         return agreed == required
 
 
-def get_terms(sydent):
+def get_terms(sydent) -> Optional[Terms]:
     """Read and parse terms as specified in the config.
 
     :returns Terms
@@ -139,3 +140,4 @@ def get_terms(sydent):
         logger.exception(
             "Couldn't read terms file '%s'", sydent.cfg.get("general", "terms.path")
         )
+        return None # added per this: https://github.com/python/mypy/issues/3974

--- a/sydent/terms/terms.py
+++ b/sydent/terms/terms.py
@@ -140,4 +140,4 @@ def get_terms(sydent) -> Optional[Terms]:
         logger.exception(
             "Couldn't read terms file '%s'", sydent.cfg.get("general", "terms.path")
         )
-        return None  # added per this: https://github.com/python/mypy/issues/3974
+        return None

--- a/sydent/terms/terms.py
+++ b/sydent/terms/terms.py
@@ -17,20 +17,20 @@
 import logging
 
 import yaml
-from typing import Union, Set, List, Dict, Optional
+from typing import Any, Set, List, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
 
 class Terms(object):
-    def __init__(self, yamlObj) -> None:
+    def __init__(self, yamlObj: Optional[Dict[str, Any]]) -> None:
         """
         :param yamlObj: The parsed YAML.
         :type yamlObj: dict[str, any] or None
         """
         self._rawTerms = yamlObj
 
-    def getMasterVersion(self) -> Union[str, None]:
+    def getMasterVersion(self) -> Optional[str]:
         """
         :return: The global (master) version of the terms, or None if there
             are no terms of service for this server.
@@ -44,7 +44,7 @@ class Terms(object):
 
         return version
 
-    def getForClient(self) -> Dict:
+    def getForClient(self) -> Dict[str, dict]:
         """
         :return: A dict which value for the "policies" key is a dict which contains the
             "docs" part of the terms' YAML. That nested dict is empty if no terms.
@@ -140,4 +140,4 @@ def get_terms(sydent) -> Optional[Terms]:
         logger.exception(
             "Couldn't read terms file '%s'", sydent.cfg.get("general", "terms.path")
         )
-        return None # added per this: https://github.com/python/mypy/issues/3974
+        return None  # added per this: https://github.com/python/mypy/issues/3974

--- a/sydent/terms/terms.py
+++ b/sydent/terms/terms.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import logging
+from typing import Any, Dict, List, Optional, Set
 
 import yaml
-from typing import Any, Set, List, Dict, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 import collections
 import logging
 import math
-import signedjson.sign # type: ignore
+import signedjson.sign  # type: ignore
 from sydent.db.invite_tokens import JoinTokenStore
 
 import signedjson.sign
@@ -49,7 +49,7 @@ class ThreepidBinder:
     # the lifetime of a 3pid association
     THREEPID_ASSOCIATION_LIFETIME_MS = 100 * 365 * 24 * 60 * 60 * 1000
 
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
         self.hashing_store = HashingMetadataStore(sydent)
 
@@ -121,7 +121,7 @@ class ThreepidBinder:
 
         return sgassoc
 
-    def removeBinding(self, threepid: Dict, mxid: str) -> None:
+    def removeBinding(self, threepid: Dict[str, str], mxid: str) -> None:
         """
         Removes the binding between a given 3PID and a given MXID.
 
@@ -135,7 +135,7 @@ class ThreepidBinder:
         self.sydent.pusher.doLocalPush()
 
     @defer.inlineCallbacks
-    def _notify(self, assoc: Dict[str, Any], attempt: int) -> Generator:
+    def _notify(self, assoc: Dict[str, Any], attempt: int) -> None:
         """
         Sends data about a new association (and, if necessary, the associated invites)
         to the associated MXID's homeserver.
@@ -202,7 +202,9 @@ class ThreepidBinder:
                     assoc["address"],
                 )
 
-    def _notifyErrback(self, assoc: Dict[str, Any], attempt: int, error: Union[Exception, str]) -> None:
+    def _notifyErrback(
+        self, assoc: Dict[str, Any], attempt: int, error: Union[Exception, str]
+    ) -> None:
         """
         Handles errors when trying to send an association down to a homeserver by
         logging the error and scheduling a new attempt.

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -40,7 +40,7 @@ class ThreepidBinder:
     # the lifetime of a 3pid association
     THREEPID_ASSOCIATION_LIFETIME_MS = 100 * 365 * 24 * 60 * 60 * 1000
 
-    def __init__(self, sydent):
+    def __init__(self, sydent: sydent.Sydent) -> None:
         self.sydent = sydent
         self.hashing_store = HashingMetadataStore(sydent)
 

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 import collections
 import logging
 import math
-from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 import signedjson.sign  # type: ignore
 from twisted.internet import defer

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -19,10 +19,9 @@ from __future__ import absolute_import
 import collections
 import logging
 import math
-import signedjson.sign  # type: ignore
-from sydent.db.invite_tokens import JoinTokenStore
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Union
 
-import signedjson.sign
+import signedjson.sign  # type: ignore
 from twisted.internet import defer
 
 from sydent.db.hashing_metadata import HashingMetadataStore
@@ -34,10 +33,6 @@ from sydent.threepid.signer import Signer
 from sydent.util import time_msec
 from sydent.util.hash import sha256_and_url_safe_base64
 from sydent.util.stringutils import is_valid_matrix_server_name
-
-from twisted.internet import defer
-
-from typing import TYPE_CHECKING, Dict, Any, Generator, Union, Optional
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/threepid/signer.py
+++ b/sydent/threepid/signer.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import signedjson.sign # type: ignore
+import signedjson.sign  # type: ignore
 
 from typing import TYPE_CHECKING, Dict, Any
 
@@ -22,11 +22,12 @@ if TYPE_CHECKING:
     from sydent.sydent import Sydent
     from sydent.threepid import ThreepidAssociation
 
+
 class Signer:
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
-    def signedThreePidAssociation(self, assoc: 'ThreepidAssociation') -> Dict[str, Any]:
+    def signedThreePidAssociation(self, assoc: "ThreepidAssociation") -> Dict[str, Any]:
         """
         Signs a 3PID association.
 

--- a/sydent/threepid/signer.py
+++ b/sydent/threepid/signer.py
@@ -14,14 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import signedjson.sign
+import signedjson.sign # type: ignore
 
+from typing import TYPE_CHECKING, Dict, Any
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+    from sydent.threepid import ThreepidAssociation
 
 class Signer:
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
-    def signedThreePidAssociation(self, assoc):
+    def signedThreePidAssociation(self, assoc: 'ThreepidAssociation') -> Dict[str, Any]:
         """
         Signs a 3PID association.
 

--- a/sydent/threepid/signer.py
+++ b/sydent/threepid/signer.py
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import signedjson.sign  # type: ignore
+from typing import TYPE_CHECKING, Any, Dict
 
-from typing import TYPE_CHECKING, Dict, Any
+import signedjson.sign  # type: ignore
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/users/accounts.py
+++ b/sydent/users/accounts.py
@@ -15,7 +15,7 @@
 
 
 class Account(object):
-    def __init__(self, user_id, creation_ts, consent_version):
+    def __init__(self, user_id: str, creation_ts: int, consent_version: str) -> None:
         """
         :param user_id: The Matrix user ID for the account.
         :type user_id: str

--- a/sydent/users/tokens.py
+++ b/sydent/users/tokens.py
@@ -16,11 +16,10 @@ from __future__ import absolute_import
 
 import logging
 import time
+from typing import TYPE_CHECKING
 
 from sydent.db.accounts import AccountStore
 from sydent.util.tokenutils import generateAlphanumericTokenOfLength
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/users/tokens.py
+++ b/sydent/users/tokens.py
@@ -20,10 +20,16 @@ import time
 from sydent.db.accounts import AccountStore
 from sydent.util.tokenutils import generateAlphanumericTokenOfLength
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+
+
 logger = logging.getLogger(__name__)
 
 
-def issueToken(sydent, user_id):
+def issueToken(sydent: "Sydent", user_id: str) -> str:
     """
     Creates an account for the given Matrix user ID, then generates, saves and returns
     an access token for that account.

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -34,10 +34,17 @@ else:
 from sydent.util import time_msec
 from sydent.util.tokenutils import generateAlphanumericTokenOfLength
 
+from typing import TYPE_CHECKING, Dict, Any
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
-def sendEmail(sydent, templateFile, mailTo, substitutions):
+def sendEmail(
+    sydent: "Sydent", templateFile: str, mailTo: str, substitutions: Dict[str, str]
+) -> None:
     """
     Sends an email with the given parameters.
 
@@ -131,4 +138,5 @@ class EmailAddressException(Exception):
 
 
 class EmailSendException(Exception):
+    cause: Any  # type hint added to prevent ""EmailSendException" has no attribute "cause"" error in Mypy
     pass

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -31,10 +31,10 @@ if six.PY2:
 else:
     from html import escape
 
+from typing import TYPE_CHECKING, Any, Dict
+
 from sydent.util import time_msec
 from sydent.util.tokenutils import generateAlphanumericTokenOfLength
-
-from typing import TYPE_CHECKING, Dict, Any
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/util/hash.py
+++ b/sydent/util/hash.py
@@ -19,7 +19,7 @@ import hashlib
 import unpaddedbase64  # type: ignore
 
 
-def sha256_and_url_safe_base64(input_text: str) -> bytes:
+def sha256_and_url_safe_base64(input_text: str) -> str:
     """SHA256 hash an input string, encode the digest as url-safe base64, and
     return
 

--- a/sydent/util/hash.py
+++ b/sydent/util/hash.py
@@ -16,10 +16,10 @@
 
 import hashlib
 
-import unpaddedbase64
+import unpaddedbase64  # type: ignore
 
 
-def sha256_and_url_safe_base64(input_text):
+def sha256_and_url_safe_base64(input_text: str) -> bytes:
     """SHA256 hash an input string, encode the digest as url-safe base64, and
     return
 

--- a/sydent/util/ip_range.py
+++ b/sydent/util/ip_range.py
@@ -15,7 +15,7 @@
 import itertools
 from typing import Iterable, Optional
 
-from netaddr import AddrFormatError, IPNetwork, IPSet
+from netaddr import AddrFormatError, IPNetwork, IPSet  # type: ignore
 
 # IP ranges that are considered private / unroutable / don't make sense.
 DEFAULT_IP_RANGE_BLACKLIST = [

--- a/sydent/util/stringutils.py
+++ b/sydent/util/stringutils.py
@@ -37,7 +37,7 @@ hostname_regex = re.compile(
 MAX_EMAIL_ADDRESS_LENGTH = 500
 
 
-def is_valid_client_secret(client_secret):
+def is_valid_client_secret(client_secret: str) -> bool:
     """Validate that a given string matches the client_secret regex defined by the spec
 
     :param client_secret: The client_secret to validate

--- a/sydent/util/tokenutils.py
+++ b/sydent/util/tokenutils.py
@@ -20,7 +20,7 @@ import string
 r = random.SystemRandom()
 
 
-def generateTokenForMedium(medium):
+def generateTokenForMedium(medium: str) -> str:
     """
     Generates a token of a different format depending on the medium, a 32 characters
     alphanumeric one if the medium is email, a 6 characters numeric one otherwise.
@@ -37,7 +37,7 @@ def generateTokenForMedium(medium):
         return generateNumericTokenOfLength(6)
 
 
-def generateNumericTokenOfLength(length):
+def generateNumericTokenOfLength(length: int) -> str:
     """
     Generates a token of the given length with the character set [0-9].
 
@@ -50,7 +50,7 @@ def generateNumericTokenOfLength(length):
     return u"".join([r.choice(string.digits) for _ in range(length)])
 
 
-def generateAlphanumericTokenOfLength(length):
+def generateAlphanumericTokenOfLength(length: int) -> str:
     """
     Generates a token of the given length with the character set [a-zA-Z0-9].
 

--- a/sydent/util/ttlcache.py
+++ b/sydent/util/ttlcache.py
@@ -15,11 +15,10 @@
 
 import logging
 import time
+from typing import Any, Dict, Tuple
 
 import attr
 from sortedcontainers import SortedList  # type: ignore
-
-from typing import Any, Dict, Tuple
 
 logger = logging.getLogger(__name__)
 

--- a/sydent/util/ttlcache.py
+++ b/sydent/util/ttlcache.py
@@ -15,7 +15,7 @@
 
 import logging
 import time
-from typing import Any, Dict, Tuple
+from typing import Any, Tuple
 
 import attr
 from sortedcontainers import SortedList  # type: ignore

--- a/sydent/util/ttlcache.py
+++ b/sydent/util/ttlcache.py
@@ -17,7 +17,9 @@ import logging
 import time
 
 import attr
-from sortedcontainers import SortedList
+from sortedcontainers import SortedList  # type: ignore
+
+from typing import Any, Dict, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +38,7 @@ class TTLCache(object):
 
         self._timer = timer
 
-    def set(self, key, value, ttl):
+    def set(self, key, value, ttl: float) -> None:
         """Add/update an entry in the cache
 
         :param key: Key for this entry.
@@ -74,7 +76,7 @@ class TTLCache(object):
             return default
         return e.value
 
-    def get_with_expiry(self, key):
+    def get_with_expiry(self, key) -> Tuple[Any, float]:
         """Get a value, and its expiry time, from the cache
 
         :param key: key to look up

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+from typing import TYPE_CHECKING, Dict
 
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.util import time_msec
@@ -11,8 +12,6 @@ from sydent.validators import (
     SessionExpiredException,
     ValidationSession,
 )
-
-from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -12,10 +12,17 @@ from sydent.validators import (
     ValidationSession,
 )
 
+from typing import TYPE_CHECKING, Dict
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
-def validateSessionWithToken(sydent, sid, clientSecret, token):
+def validateSessionWithToken(
+    sydent: "Sydent", sid: str, clientSecret: str, token: str
+) -> Dict[str, bool]:
     """
     Attempt to validate a session, identified by the sid, using
     the token from out-of-band. The client secret is given to

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -24,22 +24,30 @@ from sydent.util import time_msec
 from sydent.util.emailutils import sendEmail
 from sydent.validators import common
 
+from sydent.util import time_msec
+
+from typing import TYPE_CHECKING, Optional, Dict
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+    from sydent.validators import ValidationSession
+
 logger = logging.getLogger(__name__)
 
 
 class EmailValidator:
-    def __init__(self, sydent):
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
     def requestToken(
         self,
-        emailAddress,
-        clientSecret,
-        sendAttempt,
-        nextLink,
-        ipaddress=None,
-        brand=None,
-    ):
+        emailAddress: str,
+        clientSecret: str,
+        sendAttempt: int,
+        nextLink: str,
+        ipaddress: Optional[str] = None,
+        brand: Optional[str] = None,
+    ) -> int:
         """
         Creates or retrieves a validation session and sends an email to the corresponding
         email address with a token to use to verify the association.
@@ -102,7 +110,9 @@ class EmailValidator:
 
         return valSession.id
 
-    def makeValidateLink(self, valSession, clientSecret, nextLink):
+    def makeValidateLink(
+        self, valSession: "ValidationSession", clientSecret: str, nextLink: str
+    ) -> str:
         """
         Creates a validation link that can be sent via email to the user.
 
@@ -137,7 +147,9 @@ class EmailValidator:
             link += "&nextLink=%s" % (urllib.parse.quote(nextLink))
         return link
 
-    def validateSessionWithToken(self, sid, clientSecret, token):
+    def validateSessionWithToken(
+        self, sid: str, clientSecret: str, token: str
+    ) -> Dict[str, bool]:
         """
         Validates the session with the given ID.
 

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 
 import logging
+from typing import TYPE_CHECKING, Dict, Optional
 
 from six.moves import urllib
 
@@ -23,10 +24,6 @@ from sydent.db.valsession import ThreePidValSessionStore
 from sydent.util import time_msec
 from sydent.util.emailutils import sendEmail
 from sydent.validators import common
-
-from sydent.util import time_msec
-
-from typing import TYPE_CHECKING, Optional, Dict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/validators/msisdnvalidator.py
+++ b/sydent/validators/msisdnvalidator.py
@@ -17,7 +17,7 @@
 from __future__ import absolute_import
 
 import logging
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional, List
 
 import phonenumbers  # type: ignore
 
@@ -38,7 +38,7 @@ class MsisdnValidator:
         self.omSms = OpenMarketSMS(sydent)
 
         # cache originators & sms rules from config file
-        self.originators = {}
+        self.originators: Dict[str, List[Dict[str, str]]] = {}
         self.smsRules = {}
         for opt in self.sydent.cfg.options("sms"):
             if opt.startswith("originators."):

--- a/sydent/validators/msisdnvalidator.py
+++ b/sydent/validators/msisdnvalidator.py
@@ -17,7 +17,7 @@
 from __future__ import absolute_import
 
 import logging
-from typing import TYPE_CHECKING, Dict, Optional, List
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import phonenumbers  # type: ignore
 

--- a/sydent/validators/msisdnvalidator.py
+++ b/sydent/validators/msisdnvalidator.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 
 import logging
+from typing import TYPE_CHECKING, Dict, Optional
 
 import phonenumbers  # type: ignore
 
@@ -24,8 +25,6 @@ from sydent.db.valsession import ThreePidValSessionStore
 from sydent.sms.openmarket import OpenMarketSMS
 from sydent.util import time_msec
 from sydent.validators import DestinationRejectedException, common
-
-from typing import TYPE_CHECKING, Optional, Dict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/validators/msisdnvalidator.py
+++ b/sydent/validators/msisdnvalidator.py
@@ -39,7 +39,7 @@ class MsisdnValidator:
         self.omSms = OpenMarketSMS(sydent)
 
         # cache originators & sms rules from config file
-        self.originators: Dict = {}
+        self.originators = {}
         self.smsRules = {}
         for opt in self.sydent.cfg.options("sms"):
             if opt.startswith("originators."):

--- a/sydent/validators/msisdnvalidator.py
+++ b/sydent/validators/msisdnvalidator.py
@@ -18,23 +18,28 @@ from __future__ import absolute_import
 
 import logging
 
-import phonenumbers
+import phonenumbers  # type: ignore
 
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.sms.openmarket import OpenMarketSMS
 from sydent.util import time_msec
 from sydent.validators import DestinationRejectedException, common
 
+from typing import TYPE_CHECKING, Optional, Dict
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
 class MsisdnValidator:
-    def __init__(self, sydent):
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
         self.omSms = OpenMarketSMS(sydent)
 
         # cache originators & sms rules from config file
-        self.originators = {}
+        self.originators: Dict = {}
         self.smsRules = {}
         for opt in self.sydent.cfg.options("sms"):
             if opt.startswith("originators."):
@@ -71,7 +76,13 @@ class MsisdnValidator:
 
                 self.smsRules[country] = action
 
-    def requestToken(self, phoneNumber, clientSecret, sendAttempt, brand=None):
+    def requestToken(
+        self,
+        phoneNumber: phonenumbers.PhoneNumber,
+        clientSecret: str,
+        sendAttempt: int,
+        brand: Optional[str] = None,
+    ) -> int:
         """
         Creates or retrieves a validation session and sends an text message to the
         corresponding phone number address with a token to use to verify the association.
@@ -132,7 +143,9 @@ class MsisdnValidator:
 
         return valSession.id
 
-    def getOriginator(self, destPhoneNumber):
+    def getOriginator(
+        self, destPhoneNumber: phonenumbers.PhoneNumber
+    ) -> Dict[str, str]:
         """
         Gets an originator for a given phone number.
 
@@ -165,7 +178,9 @@ class MsisdnValidator:
         )[1:]
         return origs[sum([int(i) for i in msisdn]) % len(origs)]
 
-    def validateSessionWithToken(self, sid, clientSecret, token):
+    def validateSessionWithToken(
+        self, sid: str, clientSecret: str, token: str
+    ) -> Dict[str, bool]:
         """
         Validates the session with the given ID.
 


### PR DESCRIPTION
Here is the first round of adding support for mypy. A few things:

- This PR resulted from my adding all the type annotations in the comments to various function and getting mypy to recognize them
- I started trying to fix the errors that adding types produced but at some point realized it was too many changes at once/some of the changes were structural in ways I didn't feel confident about changing/etc. So I figured lets just get these baseline changes approved and merged and then go from there-i am sure there will be revisions 
- a lot of these changes were re-written as I learned more (using optional[whatever] instead of union[none, whatever], etc) so the final changes are in last committed version of each file  
- there are some files that already had annotations that I did not add, i did not change those 
- there is a directory http/servlets that I did not do, and i did not do sydent.py because it seemed like this PR was getting huge so i tried to stop somewhere that i could be clear on where to start again 

signed off by H-Shay: shaysquared@gmail.com