### PR TITLE
Issue 320

### DIFF
--- a/changelog.d/356.misc
+++ b/changelog.d/356.misc
@@ -1,0 +1,7 @@
+Remove support for Python < 3.6: 
+
+Update setup.py to state a minimum Python version of 3.6 (example from Sygnal). 
+Update pyproject.toml to state a target Python version for Black (example from Synapse).
+Remove all mention and use of six, as we no longer support Python 2.
+Remove all # -*- coding: utf-8 -*- lines from files; Python 3 is UTF-8 by default.
+Run pyupgrade on Sydent with arguments --py36-plus --keep-percent-format. 

--- a/matrix_is_test/launcher.py
+++ b/matrix_is_test/launcher.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/matrix_is_test/launcher.py
+++ b/matrix_is_test/launcher.py
@@ -47,7 +47,7 @@ email.subject = Your Validation Token
 """
 
 
-class MatrixIsTestLauncher(object):
+class MatrixIsTestLauncher:
     def __init__(self, with_terms):
         self.with_terms = with_terms
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@
 
 [tool.isort]
 profile = "black"
+
+[tool.black]
+target-version = ['py36']

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     version=read_version(),
     packages=find_packages(),
     description="Reference Matrix Identity Verification and Lookup Server",
+    python_requires=">=3.7",
     install_requires=[
         "signedjson==1.1.1",
         "unpaddedbase64==1.1.0",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         "attrs>=19.1.0",
         "netaddr>=0.7.0",
         "sortedcontainers>=2.1.0",
-        "six>=1.10",
         "pyyaml>=3.11",
         "mock>=3.0.5",
         "flake8==3.9.2",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd.
 # Copyright 2018 New Vector Ltd.
 #

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     version=read_version(),
     packages=find_packages(),
     description="Reference Matrix Identity Verification and Lookup Server",
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     install_requires=[
         "signedjson==1.1.1",
         "unpaddedbase64==1.1.0",

--- a/sydent/config/__init__.py
+++ b/sydent/config/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -11,12 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from sydent.users.accounts import Account
 
 
-class AccountStore(object):
+class AccountStore:
     def __init__(self, sydent):
         self.sydent = sydent
 

--- a/sydent/db/accounts.py
+++ b/sydent/db/accounts.py
@@ -18,8 +18,8 @@ from sydent.users.accounts import Account
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
-    
-    
+
+
 class AccountStore:
     def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent

--- a/sydent/db/hashing_metadata.py
+++ b/sydent/db/hashing_metadata.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2015 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/db/invite_tokens.py
+++ b/sydent/db/invite_tokens.py
@@ -14,7 +14,7 @@
 import time
 
 
-class JoinTokenStore(object):
+class JoinTokenStore:
     def __init__(self, sydent):
         self.sydent = sydent
 

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/db/peers.py
+++ b/sydent/db/peers.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from sydent.replication.peer import RemotePeer
 

--- a/sydent/db/sqlitedb.py
+++ b/sydent/db/sqlitedb.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 # Copyright 2018 New Vector Ltd
 #

--- a/sydent/db/terms.py
+++ b/sydent/db/terms.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/db/terms.py
+++ b/sydent/db/terms.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 class TermsStore:
-    def __init__(self, sydent: "Sydent:) -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
     def getAgreedUrls(self, user_id: str) -> List[str]:

--- a/sydent/db/terms.py
+++ b/sydent/db/terms.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-class TermsStore(object):
+class TermsStore:
     def __init__(self, sydent):
         self.sydent = sydent
 

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/db/threepid_associations.py
+++ b/sydent/db/threepid_associations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014,2017 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from random import SystemRandom
 

--- a/sydent/db/valsession.py
+++ b/sydent/db/valsession.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 import time
@@ -44,7 +43,7 @@ class InvalidServerName(Exception):
     pass
 
 
-class Verifier(object):
+class Verifier:
     """
     Verifies signed json blobs from Matrix Homeservers by finding the
     homeserver's address, contacting it, requesting its keys and
@@ -196,11 +195,11 @@ class Verifier(object):
             :rtype: tuple[unicode]
             """
             try:
-                params = header_str.split(u" ")[1].split(u",")
-                param_dict = dict(kv.split(u"=") for kv in params)
+                params = header_str.split(" ")[1].split(",")
+                param_dict = dict(kv.split("=") for kv in params)
 
                 def strip_quotes(value):
-                    if value.startswith(u'"'):
+                    if value.startswith('"'):
                         return value[1:-1]
                     else:
                         return value
@@ -212,13 +211,13 @@ class Verifier(object):
             except Exception:
                 raise SignatureVerifyException("Malformed Authorization header")
 
-        auth_headers = request.requestHeaders.getRawHeaders(u"Authorization")
+        auth_headers = request.requestHeaders.getRawHeaders("Authorization")
 
         if not auth_headers:
             raise NoAuthenticationError("Missing Authorization headers")
 
         for auth in auth_headers:
-            if auth.startswith(u"X-Matrix"):
+            if auth.startswith("X-Matrix"):
                 (origin, key, sig) = parse_auth_header(auth)
                 json_request["origin"] = origin
                 json_request["signatures"].setdefault(origin, {})[key] = sig

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2018 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/auth.py
+++ b/sydent/http/auth.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/blacklisting_reactor.py
+++ b/sydent/http/blacklisting_reactor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2021 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/federation_tls_options.py
+++ b/sydent/http/federation_tls_options.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/federation_tls_options.py
+++ b/sydent/http/federation_tls_options.py
@@ -53,7 +53,7 @@ def _idnaBytes(text):
 
 
 @implementer(IOpenSSLClientConnectionCreator)
-class ClientTLSOptions(object):
+class ClientTLSOptions:
     """
     Client creator for TLS without certificate identity verification. This is a
     copy of twisted.internet._sslverify.ClientTLSOptions with the identity
@@ -85,7 +85,7 @@ class ClientTLSOptions(object):
             connection.set_tlsext_host_name(self._hostnameBytes)
 
 
-class ClientTLSOptionsFactory(object):
+class ClientTLSOptionsFactory:
     """Factory for Twisted ClientTLSOptions that are used to make connections
     to remote servers for federation."""
 

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import json
 import logging
@@ -30,7 +29,7 @@ from sydent.util import json_decoder
 logger = logging.getLogger(__name__)
 
 
-class HTTPClient(object):
+class HTTPClient:
     """A base HTTP class that contains methods for making GET and POST HTTP
     requests.
     """

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/httpcommon.py
+++ b/sydent/http/httpcommon.py
@@ -49,7 +49,7 @@ class SslComponents:
 
         try:
             fp = open(privKeyAndCertFilename)
-        except IOError:
+        except OSError:
             logger.warning(
                 "Unable to read private key / cert file from %s: not starting the replication HTTPS server "
                 "or doing replication pushes.",

--- a/sydent/http/httpcommon.py
+++ b/sydent/http/httpcommon.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/httpsclient.py
+++ b/sydent/http/httpsclient.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import json
 import logging
@@ -75,7 +74,7 @@ class ReplicationHttpsClient:
 
 
 @implementer(IPolicyForHTTPS)
-class SydentPolicyForHTTPS(object):
+class SydentPolicyForHTTPS:
     def __init__(self, sydent):
         self.sydent = sydent
 

--- a/sydent/http/httpsclient.py
+++ b/sydent/http/httpsclient.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 # Copyright 2018 New Vector Ltd
 # Copyright 2019 The Matrix.org Foundation C.I.C.

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 
@@ -146,7 +145,7 @@ class ClientApiHttpServer:
         )
 
 
-class InternalApiHttpServer(object):
+class InternalApiHttpServer:
     def __init__(self, sydent):
         self.sydent = sydent
 

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 import random
@@ -53,7 +52,7 @@ well_known_cache = TTLCache("well-known")
 
 
 @implementer(IAgent)
-class MatrixFederationAgent(object):
+class MatrixFederationAgent:
     """An Agent-like thing which provides a `request` method which will look up a matrix
     server and send an HTTP request to it.
     Doesn't implement any retries. (Those are done in MatrixFederationHttpClient.)
@@ -163,7 +162,7 @@ class MatrixFederationAgent(object):
         if not headers.hasHeader(b"host"):
             headers.addRawHeader(b"host", res.host_header)
 
-        class EndpointFactory(object):
+        class EndpointFactory:
             @staticmethod
             def endpointForURI(_uri):
                 ep = LoggingHostnameEndpoint(
@@ -371,7 +370,7 @@ class MatrixFederationAgent(object):
 
 
 @implementer(IStreamClientEndpoint)
-class LoggingHostnameEndpoint(object):
+class LoggingHostnameEndpoint:
     """A wrapper for HostnameEndpint which logs when it connects"""
 
     def __init__(self, reactor, host, port, *args, **kwargs):
@@ -424,7 +423,7 @@ def _parse_cache_control(headers):
 
 
 @attr.s
-class _RoutingResult(object):
+class _RoutingResult:
     """The result returned by `_route_matrix_uri`.
     Contains the parameters needed to direct a federation connection to a particular
     server.

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -26,7 +26,7 @@ from twisted.internet.interfaces import IStreamClientEndpoint
 from twisted.web.client import URI, Agent, HTTPConnectionPool, RedirectAgent
 from twisted.web.http import stringToDatetime
 from twisted.web.http_headers import Headers
-from twisted.web.iweb import IAgent, IBodyProducer
+from twisted.web.iweb import IAgent
 from zope.interface import implementer
 
 from sydent.http.httpcommon import read_body_with_max_size

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/accountservlet.py
+++ b/sydent/http/servlets/accountservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/accountservlet.py
+++ b/sydent/http/servlets/accountservlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2018 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/authenticated_unbind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_unbind_threepid_servlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2020 Dirk Klimpel
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2017 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/hashdetailsservlet.py
+++ b/sydent/http/servlets/hashdetailsservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/hashdetailsservlet.py
+++ b/sydent/http/servlets/hashdetailsservlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014,2017 OpenMarket Ltd
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2016 OpenMarket Ltd
 # Copyright 2017 Vector Creations Ltd
 #

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 from unpaddedbase64 import encode_base64

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -14,7 +14,8 @@
 
 import logging
 
-from six.moves import urllib
+import urllib
+
 from twisted.internet import defer
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-
 import urllib
 
 from twisted.internet import defer

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import json
 import logging
@@ -110,7 +109,7 @@ class ReplicationPushServlet(Resource):
 
                 if assocObj.mxid is not None:
                     # Calculate the lookup hash with our own pepper for this association
-                    str_to_hash = u" ".join(
+                    str_to_hash = " ".join(
                         [
                             assocObj.address,
                             assocObj.medium,

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2015 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -17,7 +17,6 @@ import string
 from email.header import Header
 
 import nacl.signing
-from six import string_types
 from twisted.web.resource import Resource
 from unpaddedbase64 import encode_base64
 

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import random
 import string
@@ -99,7 +98,7 @@ class StoreInviteServlet(Resource):
         substitutions = {}
         # Include all arguments sent via the request.
         for k, v in args.items():
-            if isinstance(v, string_types):
+            if isinstance(v, str):
                 substitutions[k] = v
         substitutions["token"] = token
 
@@ -190,7 +189,7 @@ class StoreInviteServlet(Resource):
         :rtype: unicode
         """
         # Extract strings from the address
-        username, domain = address.split(u"@", 1)
+        username, domain = address.split("@", 1)
 
         # Obfuscate strings
         redacted_username = self._redact(
@@ -198,7 +197,7 @@ class StoreInviteServlet(Resource):
         )
         redacted_domain = self._redact(domain, self.sydent.domain_obfuscate_characters)
 
-        return redacted_username + u"@" + redacted_domain
+        return redacted_username + "@" + redacted_domain
 
     def _redact(self, s, characters_to_reveal):
         """
@@ -218,13 +217,13 @@ class StoreInviteServlet(Resource):
         # If the string is shorter than the defined threshold, redact based on length
         if len(s) <= characters_to_reveal:
             if len(s) > 5:
-                return s[:3] + u"..."
+                return s[:3] + "..."
             if len(s) > 1:
-                return s[0] + u"..."
-            return u"..."
+                return s[0] + "..."
+            return "..."
 
         # Otherwise truncate it and add an ellipses
-        return s[:characters_to_reveal] + u"..."
+        return s[:characters_to_reveal] + "..."
 
     def _randomString(self, length):
         """
@@ -236,4 +235,4 @@ class StoreInviteServlet(Resource):
         :return: The generated string.
         :rtype: unicode
         """
-        return u"".join(self.random.choice(string.ascii_letters) for _ in range(length))
+        return "".join(self.random.choice(string.ascii_letters) for _ in range(length))

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 # Copyright 2018 New Vector Ltd
 #

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/http/servlets/v1_servlet.py
+++ b/sydent/http/servlets/v1_servlet.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/servlets/v1_servlet.py
+++ b/sydent/http/servlets/v1_servlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2018 Travis Ralston
 # Copyright 2018 New Vector Ltd
 #

--- a/sydent/http/servlets/v2_servlet.py
+++ b/sydent/http/servlets/v2_servlet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/http/servlets/v2_servlet.py
+++ b/sydent/http/servlets/v2_servlet.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from twisted.web.resource import Resource
 

--- a/sydent/http/srvresolver.py
+++ b/sydent/http/srvresolver.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014-2016 OpenMarket Ltd
 # Copyright 2019 New Vector Ltd
 #

--- a/sydent/http/srvresolver.py
+++ b/sydent/http/srvresolver.py
@@ -29,7 +29,7 @@ SERVER_CACHE = {}
 
 
 @attr.s
-class Server(object):
+class Server:
     """
     Our record of an individual server which can be tried to reach a destination.
     Attributes:
@@ -80,7 +80,7 @@ def pick_server_from_list(server_list):
     )
 
 
-class SrvResolver(object):
+class SrvResolver:
     """Interface to the dns client to do SRV lookups, with result caching.
     The default resolver in twisted.names doesn't do any caching (it has a CacheResolver,
     but the cache never gets populated), so we add our own caching layer here.

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -14,12 +14,12 @@
 # limitations under the License.
 
 import binascii
+import configparser
 import json
 import logging
 
 import signedjson.key
 import signedjson.sign
-import configparser
 from twisted.internet import defer
 from twisted.web.client import readBody
 from unpaddedbase64 import decode_base64

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import binascii
 import json
@@ -37,7 +36,7 @@ logger = logging.getLogger(__name__)
 SIGNING_KEY_ALGORITHM = "ed25519"
 
 
-class Peer(object):
+class Peer:
     def __init__(self, servername, pubkeys):
         self.servername = servername
         self.pubkeys = pubkeys
@@ -58,7 +57,7 @@ class LocalPeer(Peer):
     """
 
     def __init__(self, sydent):
-        super(LocalPeer, self).__init__(sydent.server_name, {})
+        super().__init__(sydent.server_name, {})
         self.sydent = sydent
         self.hashing_store = HashingMetadataStore(sydent)
 
@@ -85,7 +84,7 @@ class LocalPeer(Peer):
 
                 if assocObj.mxid is not None:
                     # Assign a lookup_hash to this association
-                    str_to_hash = u" ".join(
+                    str_to_hash = " ".join(
                         [
                             assocObj.address,
                             assocObj.medium,
@@ -125,7 +124,7 @@ class RemotePeer(Peer):
         :param lastSentVersion: The ID of the last association sent to the peer.
         :type lastSentVersion: int
         """
-        super(RemotePeer, self).__init__(server_name, pubkeys)
+        super().__init__(server_name, pubkeys)
         self.sydent = sydent
         self.port = port
         self.lastSentVersion = lastSentVersion

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -19,7 +19,7 @@ import logging
 
 import signedjson.key
 import signedjson.sign
-from six.moves import configparser
+import configparser
 from twisted.internet import defer
 from twisted.web.client import readBody
 from unpaddedbase64 import decode_base64

--- a/sydent/replication/peer.py
+++ b/sydent/replication/peer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 # Copyright 2019 New Vector Ltd
 #

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 

--- a/sydent/sign/ed25519.py
+++ b/sydent/sign/ed25519.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/sms/openmarket.py
+++ b/sydent/sms/openmarket.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2016 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/sms/openmarket.py
+++ b/sydent/sms/openmarket.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 from base64 import b64encode

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import configparser
 import copy
 import gc
 import logging
@@ -22,7 +23,6 @@ import os
 from typing import Set
 
 import twisted.internet.reactor
-import configparser
 from twisted.internet import address, task
 from twisted.python import log
 

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import copy
 import gc

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 # Copyright 2018 New Vector Ltd
 # Copyright 2019 The Matrix.org Foundation C.I.C.

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -22,7 +22,7 @@ import os
 from typing import Set
 
 import twisted.internet.reactor
-from six.moves import configparser
+import configparser
 from twisted.internet import address, task
 from twisted.python import log
 

--- a/sydent/terms/terms.py
+++ b/sydent/terms/terms.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/terms/terms.py
+++ b/sydent/terms/terms.py
@@ -19,7 +19,7 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
-class Terms(object):
+class Terms:
     def __init__(self, yamlObj):
         """
         :param yamlObj: The parsed YAML.

--- a/sydent/threepid/__init__.py
+++ b/sydent/threepid/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 # Copyright 2018 New Vector Ltd
 #

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import collections
 import logging
@@ -67,7 +66,7 @@ class ThreepidBinder:
 
         # Hash the medium + address and store that hash for the purposes of
         # later lookups
-        str_to_hash = u" ".join(
+        str_to_hash = " ".join(
             [address, medium, self.hashing_store.get_lookup_pepper()],
         )
         lookup_hash = sha256_and_url_safe_base64(str_to_hash)

--- a/sydent/threepid/signer.py
+++ b/sydent/threepid/signer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/users/accounts.py
+++ b/sydent/users/accounts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/users/accounts.py
+++ b/sydent/users/accounts.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-class Account(object):
+class Account:
     def __init__(self, user_id, creation_ts, consent_version):
         """
         :param user_id: The Matrix user ID for the account.

--- a/sydent/users/tokens.py
+++ b/sydent/users/tokens.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/users/tokens.py
+++ b/sydent/users/tokens.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 import time

--- a/sydent/util/__init__.py
+++ b/sydent/util/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -18,11 +18,10 @@ import random
 import smtplib
 import socket
 import string
+import urllib
+from html import escape
 
 import twisted.python.log
-import urllib
-
-from html import escape
 
 from sydent.util import time_msec
 from sydent.util.tokenutils import generateAlphanumericTokenOfLength

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import email.utils
 import logging
@@ -22,12 +21,9 @@ import string
 
 import six
 import twisted.python.log
-from six.moves import range, urllib
+from six.moves import urllib
 
-if six.PY2:
-    from cgi import escape
-else:
-    from html import escape
+from html import escape
 
 from sydent.util import time_msec
 from sydent.util.tokenutils import generateAlphanumericTokenOfLength

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014-2015 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -19,9 +19,8 @@ import smtplib
 import socket
 import string
 
-import six
 import twisted.python.log
-from six.moves import urllib
+import urllib
 
 from html import escape
 

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -20,10 +20,9 @@ import socket
 import string
 import urllib
 from html import escape
+from typing import TYPE_CHECKING, Any, Dict
 
 import twisted.python.log
-
-from typing import TYPE_CHECKING, Any, Dict
 
 from sydent.util import time_msec
 from sydent.util.tokenutils import generateAlphanumericTokenOfLength

--- a/sydent/util/hash.py
+++ b/sydent/util/hash.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/util/ip_range.py
+++ b/sydent/util/ip_range.py
@@ -1,5 +1,3 @@
-#  Copyright 2021 The Matrix.org Foundation C.I.C.
-#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at

--- a/sydent/util/ip_range.py
+++ b/sydent/util/ip_range.py
@@ -1,3 +1,4 @@
+#  Copyright 2021 The Matrix.org Foundation C.I.C.
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at

--- a/sydent/util/stringutils.py
+++ b/sydent/util/stringutils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2020 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/util/tokenutils.py
+++ b/sydent/util/tokenutils.py
@@ -45,7 +45,7 @@ def generateNumericTokenOfLength(length):
     :return: The generated token.
     :rtype: unicode
     """
-    return u"".join([r.choice(string.digits) for _ in range(length)])
+    return "".join([r.choice(string.digits) for _ in range(length)])
 
 
 def generateAlphanumericTokenOfLength(length):
@@ -58,7 +58,7 @@ def generateAlphanumericTokenOfLength(length):
     :return: The generated token.
     :rtype: unicode
     """
-    return u"".join(
+    return "".join(
         [
             r.choice(string.digits + string.ascii_lowercase + string.ascii_uppercase)
             for _ in range(length)

--- a/sydent/util/tokenutils.py
+++ b/sydent/util/tokenutils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/util/ttlcache.py
+++ b/sydent/util/ttlcache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/util/ttlcache.py
+++ b/sydent/util/ttlcache.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 SENTINEL = object()
 
 
-class TTLCache(object):
+class TTLCache:
     """A key/value cache implementation where each entry has its own TTL"""
 
     def __init__(self, cache_name, timer=time.time):
@@ -139,7 +139,7 @@ class TTLCache(object):
 
 
 @attr.s(frozen=True, slots=True)
-class _CacheEntry(object):
+class _CacheEntry:
     """TTLCache entry"""
 
     # expiry_time is the first attribute, so that entries are sorted by expiry.

--- a/sydent/validators/__init__.py
+++ b/sydent/validators/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/validators/common.py
+++ b/sydent/validators/common.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 
 from sydent.db.valsession import ThreePidValSessionStore

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -14,7 +14,7 @@
 
 import logging
 
-from six.moves import urllib
+import urllib
 
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.util import time_msec

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 
@@ -62,7 +61,7 @@ class EmailValidator:
         valSessionStore = ThreePidValSessionStore(self.sydent)
 
         valSession = valSessionStore.getOrCreateTokenSession(
-            medium=u"email", address=emailAddress, clientSecret=clientSecret
+            medium="email", address=emailAddress, clientSecret=clientSecret
         )
 
         valSessionStore.setMtime(valSession.id, time_msec())
@@ -81,7 +80,7 @@ class EmailValidator:
             )
             return valSession.id
 
-        ipstring = ipaddress if ipaddress else u"an unknown location"
+        ipstring = ipaddress if ipaddress else "an unknown location"
 
         substitutions = {
             "ipaddress": ipstring,

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2014 OpenMarket Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sydent/validators/emailvalidator.py
+++ b/sydent/validators/emailvalidator.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-
 import urllib
 
 from sydent.db.valsession import ThreePidValSessionStore

--- a/sydent/validators/msisdnvalidator.py
+++ b/sydent/validators/msisdnvalidator.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import logging
 
@@ -161,7 +160,7 @@ class MsisdnValidator:
         msisdn = phonenumbers.format_number(
             destPhoneNumber, phonenumbers.PhoneNumberFormat.E164
         )[1:]
-        return origs[sum([int(i) for i in msisdn]) % len(origs)]
+        return origs[sum(int(i) for i in msisdn) % len(origs)]
 
     def validateSessionWithToken(self, sid, clientSecret, token):
         """

--- a/sydent/validators/msisdnvalidator.py
+++ b/sydent/validators/msisdnvalidator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2016 OpenMarket Ltd
 # Copyright 2017 Vector Creations Ltd
 #

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2020 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_blacklisting.py
+++ b/tests/test_blacklisting.py
@@ -11,7 +11,7 @@
 #  limitations under the License.
 
 
-from mock import patch
+from unittest.mock import patch
 from twisted.internet import defer
 from twisted.internet.error import DNSLookupError
 from twisted.test.proto_helpers import StringTransport
@@ -130,7 +130,7 @@ class BlacklistingAgentTest(TestCase):
         self.assertRegex(transport.value(), b"Host: example.com")
 
         # Send it the HTTP response
-        res_json = '{ "sub": "@test:example.com" }'.encode("ascii")
+        res_json = b'{ "sub": "@test:example.com" }'
         protocol.dataReceived(
             b"HTTP/1.1 200 OK\r\n"
             b"Server: Fake\r\n"
@@ -180,7 +180,7 @@ class BlacklistingAgentTest(TestCase):
         self.assertRegex(transport.value(), b"Host: example.com")
 
         # Send it the HTTP response
-        res_json = '{ "sub": "@test:example.com" }'.encode("ascii")
+        res_json = b'{ "sub": "@test:example.com" }'
         protocol.dataReceived(
             b"HTTP/1.1 200 OK\r\n"
             b"Server: Fake\r\n"

--- a/tests/test_blacklisting.py
+++ b/tests/test_blacklisting.py
@@ -1,5 +1,3 @@
-#  Copyright 2021 The Matrix.org Foundation C.I.C.
-#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at

--- a/tests/test_blacklisting.py
+++ b/tests/test_blacklisting.py
@@ -12,6 +12,7 @@
 
 
 from unittest.mock import patch
+
 from twisted.internet import defer
 from twisted.internet.error import DNSLookupError
 from twisted.test.proto_helpers import StringTransport

--- a/tests/test_blacklisting.py
+++ b/tests/test_blacklisting.py
@@ -1,3 +1,4 @@
+#  Copyright 2021 The Matrix.org Foundation C.I.C.
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -11,8 +11,8 @@
 #  limitations under the License.
 
 import os.path
-
 from unittest.mock import patch
+
 from twisted.trial import unittest
 
 from tests.utils import make_request, make_sydent

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -12,7 +12,7 @@
 
 import os.path
 
-from mock import patch
+from unittest.mock import patch
 from twisted.trial import unittest
 
 from tests.utils import make_request, make_sydent

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,5 +1,3 @@
-#  Copyright 2021 The Matrix.org Foundation C.I.C.
-#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,3 +1,4 @@
+#  Copyright 2021 The Matrix.org Foundation C.I.C.
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -1,4 +1,5 @@
 from unittest.mock import Mock
+
 from twisted.trial import unittest
 from twisted.web.client import Response
 

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 from twisted.trial import unittest
 from twisted.web.client import Response
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright 2021 The Matrix.org Foundation C.I.C.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -76,7 +76,7 @@ def make_sydent(test_config={}):
 
 
 @attr.s
-class FakeChannel(object):
+class FakeChannel:
     """
     A fake Twisted Web Channel (the part that interfaces with the
     wire). Mostly copied from Synapse's tests framework.
@@ -214,7 +214,7 @@ def make_request(
 
     if isinstance(content, dict):
         content = json.dumps(content)
-    if isinstance(content, text_type):
+    if isinstance(content, str):
         content = content.encode("utf8")
 
     site = FakeSite()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,6 @@ from typing import Dict
 import attr
 import twisted.logger
 from OpenSSL import crypto
-from six import text_type
 from twisted.internet import address
 from twisted.internet._resolver import SimpleResolverComplexifier
 from twisted.internet.defer import fail, succeed


### PR DESCRIPTION
This PR removes support for Python < 3.6, taking the following actions:
Update setup.py to state a minimum Python version of 3.6 (example from Sygnal)
Update pyproject.toml to state a target Python version for Black (example from Synapse)
Remove all mention and use of six, as we no longer support Python 2
Remove all `# -*- coding: utf-8 -*-` lines from files; Python 3 is UTF-8 by default
Run pyupgrade on Sydent with arguments --py36-plus --keep-percent-format

signed off by H.Shay shaysquared@gmail.com
