### PR TITLE
Add type hints to sydent/http/servlets

### DIFF
--- a/changelog.d/360.misc
+++ b/changelog.d/360.misc
@@ -1,0 +1,1 @@
+Fix a mypy error in utils/emailutils. 

--- a/changelog.d/361.misc
+++ b/changelog.d/361.misc
@@ -1,0 +1,1 @@
+Add type hints to sydent/http/servlets/ to support mypy type checking. 

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -23,6 +23,7 @@ from twisted.python.failure import Failure
 from twisted.web import server
 from twisted.web.server import Request
 
+from sydent.types import JsonDict
 from sydent.util import json_decoder
 
 logger = logging.getLogger(__name__)
@@ -240,7 +241,7 @@ def send_cors(request: Request) -> None:
     request.setHeader("Access-Control-Allow-Headers", "*")
 
 
-def dict_to_json_bytes(content: Dict[Any, Any]) -> bytes:
+def dict_to_json_bytes(content: JsonDict) -> bytes:
     """
     Converts a dict into JSON and encodes it to bytes.
 

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -16,15 +16,14 @@ import copy
 import functools
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Tuple
+from typing import Any, Dict, Iterable
 
 from twisted.internet import defer
+from twisted.python.failure import Failure
 from twisted.web import server
 from twisted.web.server import Request
-from twisted.python.failure import Failure
 
 from sydent.util import json_decoder
-
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +41,9 @@ class MatrixRestError(Exception):
         self.error = error
 
 
-def get_args(request: Request, args: Tuple, required: bool = True) -> Dict[str, Any]:
+def get_args(
+    request: Request, args: Iterable[str], required: bool = True
+) -> Dict[str, Any]:
     """
     Helper function to get arguments for an HTTP request.
     Currently takes args from the top level keys of a json object or
@@ -54,7 +55,7 @@ def get_args(request: Request, args: Tuple, required: bool = True) -> Dict[str, 
     :param request: The request received by the servlet.
     :type request: twisted.web.server.Request
     :param args: The args to look for in the request's parameters.
-    :type args: tuple[unicode]
+    :type args: Iterable[str]
     :param required: Whether to raise a MatrixRestError with 400
         M_MISSING_PARAMS if an argument is not found.
     :type required: bool

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -20,12 +20,11 @@ from typing import TYPE_CHECKING, Any, Dict, Tuple
 
 from twisted.internet import defer
 from twisted.web import server
+from twisted.web.server import Request
+from twisted.python.failure import Failure
 
 from sydent.util import json_decoder
 
-if TYPE_CHECKING:
-    from twisted.python.failure import Failure
-    from twisted.web.server import Request
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +42,7 @@ class MatrixRestError(Exception):
         self.error = error
 
 
-def get_args(request: "Request", args: Tuple, required: bool = True) -> Dict[str, Any]:
+def get_args(request: Request, args: Tuple, required: bool = True) -> Dict[str, Any]:
     """
     Helper function to get arguments for an HTTP request.
     Currently takes args from the top level keys of a json object or
@@ -132,7 +131,7 @@ def get_args(request: "Request", args: Tuple, required: bool = True) -> Dict[str
 
 def jsonwrap(f):
     @functools.wraps(f)
-    def inner(self, request: "Request", *args, **kwargs) -> bytes:
+    def inner(self, request: Request, *args, **kwargs) -> bytes:
         """
         Runs a web handler function with the given request and parameters, then
         converts its result into JSON and returns it. If an error happens, also sets
@@ -168,7 +167,7 @@ def jsonwrap(f):
 
 
 def deferjsonwrap(f):
-    def reqDone(resp: Dict[str, Any], request: "Request") -> None:
+    def reqDone(resp: Dict[str, Any], request: Request) -> None:
         """
         Converts the given response content into JSON and encodes it to bytes, then
         writes it as the response to the given request with the right headers.
@@ -182,7 +181,7 @@ def deferjsonwrap(f):
         request.write(dict_to_json_bytes(resp))
         request.finish()
 
-    def reqErr(failure: "Failure", request: "Request") -> None:
+    def reqErr(failure: Failure, request: Request) -> None:
         """
         Logs the given failure. If the failure is a MatrixRestError, writes a response
         using the info it contains, otherwise responds with 500 Internal Server Error.
@@ -234,7 +233,7 @@ def deferjsonwrap(f):
     return inner
 
 
-def send_cors(request: "Request") -> None:
+def send_cors(request: Request) -> None:
     request.setHeader("Access-Control-Allow-Origin", "*")
     request.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
     request.setHeader("Access-Control-Allow-Headers", "*")

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -16,17 +16,16 @@ import copy
 import functools
 import json
 import logging
+from typing import TYPE_CHECKING, Any, Dict, Tuple
 
 from twisted.internet import defer
 from twisted.web import server
 
 from sydent.util import json_decoder
 
-from typing import TYPE_CHECKING, Any, Dict, Tuple
-
 if TYPE_CHECKING:
-    from twisted.web.server import Request
     from twisted.python.failure import Failure
+    from twisted.web.server import Request
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +43,7 @@ class MatrixRestError(Exception):
         self.error = error
 
 
-def get_args(request: 'Request', args: Tuple, required: bool=True) -> Dict[str, Any]:
+def get_args(request: "Request", args: Tuple, required: bool = True) -> Dict[str, Any]:
     """
     Helper function to get arguments for an HTTP request.
     Currently takes args from the top level keys of a json object or
@@ -133,7 +132,7 @@ def get_args(request: 'Request', args: Tuple, required: bool=True) -> Dict[str, 
 
 def jsonwrap(f):
     @functools.wraps(f)
-    def inner(self, request: 'Request', *args, **kwargs) -> bytes:
+    def inner(self, request: "Request", *args, **kwargs) -> bytes:
         """
         Runs a web handler function with the given request and parameters, then
         converts its result into JSON and returns it. If an error happens, also sets
@@ -169,7 +168,7 @@ def jsonwrap(f):
 
 
 def deferjsonwrap(f):
-    def reqDone(resp: Dict[str, Any], request: 'Request') -> None:
+    def reqDone(resp: Dict[str, Any], request: "Request") -> None:
         """
         Converts the given response content into JSON and encodes it to bytes, then
         writes it as the response to the given request with the right headers.
@@ -183,7 +182,7 @@ def deferjsonwrap(f):
         request.write(dict_to_json_bytes(resp))
         request.finish()
 
-    def reqErr(failure: 'Failure', request: 'Request') -> None:
+    def reqErr(failure: "Failure", request: "Request") -> None:
         """
         Logs the given failure. If the failure is a MatrixRestError, writes a response
         using the info it contains, otherwise responds with 500 Internal Server Error.
@@ -235,7 +234,7 @@ def deferjsonwrap(f):
     return inner
 
 
-def send_cors(request: 'Request') -> None:
+def send_cors(request: "Request") -> None:
     request.setHeader("Access-Control-Allow-Origin", "*")
     request.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
     request.setHeader("Access-Control-Allow-Headers", "*")

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -22,6 +22,12 @@ from twisted.web import server
 
 from sydent.util import json_decoder
 
+from typing import TYPE_CHECKING, Any, Dict, Tuple
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from twisted.python.failure import Failure
+
 logger = logging.getLogger(__name__)
 
 
@@ -38,7 +44,7 @@ class MatrixRestError(Exception):
         self.error = error
 
 
-def get_args(request, args, required=True):
+def get_args(request: 'Request', args: Tuple, required: bool=True) -> Dict[str, Any]:
     """
     Helper function to get arguments for an HTTP request.
     Currently takes args from the top level keys of a json object or
@@ -62,6 +68,7 @@ def get_args(request, args, required=True):
         are of type unicode.
     :rtype: dict[unicode, any]
     """
+    assert request.path is not None
     v1_path = request.path.startswith(b"/_matrix/identity/api/v1")
 
     request_args = None
@@ -126,7 +133,7 @@ def get_args(request, args, required=True):
 
 def jsonwrap(f):
     @functools.wraps(f)
-    def inner(self, request, *args, **kwargs):
+    def inner(self, request: 'Request', *args, **kwargs) -> bytes:
         """
         Runs a web handler function with the given request and parameters, then
         converts its result into JSON and returns it. If an error happens, also sets
@@ -162,7 +169,7 @@ def jsonwrap(f):
 
 
 def deferjsonwrap(f):
-    def reqDone(resp, request):
+    def reqDone(resp: Dict[str, Any], request: 'Request') -> None:
         """
         Converts the given response content into JSON and encodes it to bytes, then
         writes it as the response to the given request with the right headers.
@@ -176,7 +183,7 @@ def deferjsonwrap(f):
         request.write(dict_to_json_bytes(resp))
         request.finish()
 
-    def reqErr(failure, request):
+    def reqErr(failure: 'Failure', request: 'Request') -> None:
         """
         Logs the given failure. If the failure is a MatrixRestError, writes a response
         using the info it contains, otherwise responds with 500 Internal Server Error.
@@ -206,7 +213,7 @@ def deferjsonwrap(f):
             )
         request.finish()
 
-    def inner(*args, **kwargs):
+    def inner(*args, **kwargs) -> int:
         """
         Runs an asynchronous web handler function with the given arguments and add
         reqDone and reqErr as the resulting Deferred's callbacks.
@@ -228,13 +235,13 @@ def deferjsonwrap(f):
     return inner
 
 
-def send_cors(request):
+def send_cors(request: 'Request') -> None:
     request.setHeader("Access-Control-Allow-Origin", "*")
     request.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
     request.setHeader("Access-Control-Allow-Headers", "*")
 
 
-def dict_to_json_bytes(content):
+def dict_to_json_bytes(content: Dict[Any, Any]) -> bytes:
     """
     Converts a dict into JSON and encodes it to bytes.
 

--- a/sydent/http/servlets/accountservlet.py
+++ b/sydent/http/servlets/accountservlet.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 from typing import TYPE_CHECKING
-from sydent.types import JsonDict
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.http.auth import authV2
 from sydent.http.servlets import jsonwrap, send_cors
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/http/servlets/accountservlet.py
+++ b/sydent/http/servlets/accountservlet.py
@@ -17,16 +17,21 @@ from twisted.web.resource import Resource
 from sydent.http.auth import authV2
 from sydent.http.servlets import jsonwrap, send_cors
 
+from typing import TYPE_CHECKING, Dict
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+    from twisted.web.server import Request
 
 class AccountServlet(Resource):
     isLeaf = False
 
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent')-> None:
         Resource.__init__(self)
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request')-> Dict[str, str]:
         """
         Return information about the user's account
         (essentially just a 'who am i')
@@ -39,6 +44,7 @@ class AccountServlet(Resource):
             "user_id": account.userId,
         }
 
-    def render_OPTIONS(self, request):
+
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/accountservlet.py
+++ b/sydent/http/servlets/accountservlet.py
@@ -15,13 +15,12 @@
 from typing import TYPE_CHECKING, Dict
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.http.auth import authV2
 from sydent.http.servlets import jsonwrap, send_cors
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 
@@ -33,7 +32,7 @@ class AccountServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: "Request") -> Dict[str, str]:
+    def render_GET(self, request: Request) -> Dict[str, str]:
         """
         Return information about the user's account
         (essentially just a 'who am i')
@@ -46,6 +45,6 @@ class AccountServlet(Resource):
             "user_id": account.userId,
         }
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/accountservlet.py
+++ b/sydent/http/servlets/accountservlet.py
@@ -12,26 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING, Dict
+
 from twisted.web.resource import Resource
 
 from sydent.http.auth import authV2
 from sydent.http.servlets import jsonwrap, send_cors
 
-from typing import TYPE_CHECKING, Dict
-
 if TYPE_CHECKING:
-    from sydent.sydent import Sydent
     from twisted.web.server import Request
+
+    from sydent.sydent import Sydent
+
 
 class AccountServlet(Resource):
     isLeaf = False
 
-    def __init__(self, syd: 'Sydent')-> None:
+    def __init__(self, syd: "Sydent") -> None:
         Resource.__init__(self)
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: 'Request')-> Dict[str, str]:
+    def render_GET(self, request: "Request") -> Dict[str, str]:
         """
         Return information about the user's account
         (essentially just a 'who am i')
@@ -44,7 +46,6 @@ class AccountServlet(Resource):
             "user_id": account.userId,
         }
 
-
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/accountservlet.py
+++ b/sydent/http/servlets/accountservlet.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
+from sydent.types import JsonDict
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -32,7 +33,7 @@ class AccountServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: Request) -> Dict[str, str]:
+    def render_GET(self, request: Request) -> JsonDict:
         """
         Return information about the user's account
         (essentially just a 'who am i')

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING
+
+from sydent.types import JsonDict
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -34,7 +36,7 @@ class AuthenticatedBindThreePidServlet(Resource):
         self.sydent = sydent
 
     @jsonwrap
-    def render_POST(self, request: Request) -> Dict[str, Any]:
+    def render_POST(self, request: Request) -> JsonDict:
         send_cors(request)
         args = get_args(request, ("medium", "address", "mxid"))
 

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -14,12 +14,11 @@
 
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -16,6 +16,11 @@ from twisted.web.resource import Resource
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 
+from typing import TYPE_CHECKING, Dict, Any
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+    from twisted.web.server import Request
 
 class AuthenticatedBindThreePidServlet(Resource):
     """A servlet which allows a caller to bind any 3pid they want to an mxid
@@ -23,12 +28,12 @@ class AuthenticatedBindThreePidServlet(Resource):
     It is assumed that authentication happens out of band
     """
 
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         Resource.__init__(self)
         self.sydent = sydent
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> Dict[str, Any]:
         send_cors(request)
         args = get_args(request, ("medium", "address", "mxid"))
 
@@ -38,6 +43,6 @@ class AuthenticatedBindThreePidServlet(Resource):
             args["mxid"],
         )
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING, Any, Dict
+
 from twisted.web.resource import Resource
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 
-from typing import TYPE_CHECKING, Dict, Any
-
 if TYPE_CHECKING:
-    from sydent.sydent import Sydent
     from twisted.web.server import Request
+
+    from sydent.sydent import Sydent
+
 
 class AuthenticatedBindThreePidServlet(Resource):
     """A servlet which allows a caller to bind any 3pid they want to an mxid
@@ -28,12 +30,12 @@ class AuthenticatedBindThreePidServlet(Resource):
     It is assumed that authentication happens out of band
     """
 
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         Resource.__init__(self)
         self.sydent = sydent
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> Dict[str, Any]:
+    def render_POST(self, request: "Request") -> Dict[str, Any]:
         send_cors(request)
         args = get_args(request, ("medium", "address", "mxid"))
 
@@ -43,6 +45,6 @@ class AuthenticatedBindThreePidServlet(Resource):
             args["mxid"],
         )
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/authenticated_bind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_bind_threepid_servlet.py
@@ -15,12 +15,11 @@
 from typing import TYPE_CHECKING, Any, Dict
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 
@@ -35,7 +34,7 @@ class AuthenticatedBindThreePidServlet(Resource):
         self.sydent = sydent
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> Dict[str, Any]:
+    def render_POST(self, request: Request) -> Dict[str, Any]:
         send_cors(request)
         args = get_args(request, ("medium", "address", "mxid"))
 
@@ -45,6 +44,6 @@ class AuthenticatedBindThreePidServlet(Resource):
             args["mxid"],
         )
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/authenticated_unbind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_unbind_threepid_servlet.py
@@ -16,6 +16,12 @@ from twisted.web.resource import Resource
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+    from twisted.web.server import Request
+
 
 class AuthenticatedUnbindThreePidServlet(Resource):
     """A servlet which allows a caller to unbind any 3pid they want from an mxid
@@ -23,12 +29,12 @@ class AuthenticatedUnbindThreePidServlet(Resource):
     It is assumed that authentication happens out of band
     """
 
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         Resource.__init__(self)
         self.sydent = sydent
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> None:
         send_cors(request)
         args = get_args(request, ("medium", "address", "mxid"))
 
@@ -39,6 +45,6 @@ class AuthenticatedUnbindThreePidServlet(Resource):
             args["mxid"],
         )
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/authenticated_unbind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_unbind_threepid_servlet.py
@@ -15,12 +15,11 @@
 from typing import TYPE_CHECKING
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 
@@ -35,7 +34,7 @@ class AuthenticatedUnbindThreePidServlet(Resource):
         self.sydent = sydent
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> None:
+    def render_POST(self, request: Request) -> None:
         send_cors(request)
         args = get_args(request, ("medium", "address", "mxid"))
 
@@ -46,6 +45,6 @@ class AuthenticatedUnbindThreePidServlet(Resource):
             args["mxid"],
         )
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/authenticated_unbind_threepid_servlet.py
+++ b/sydent/http/servlets/authenticated_unbind_threepid_servlet.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING
+
 from twisted.web.resource import Resource
 
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from sydent.sydent import Sydent
     from twisted.web.server import Request
+
+    from sydent.sydent import Sydent
 
 
 class AuthenticatedUnbindThreePidServlet(Resource):
@@ -29,12 +30,12 @@ class AuthenticatedUnbindThreePidServlet(Resource):
     It is assumed that authentication happens out of band
     """
 
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         Resource.__init__(self)
         self.sydent = sydent
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> None:
+    def render_POST(self, request: "Request") -> None:
         send_cors(request)
         args = get_args(request, ("medium", "address", "mxid"))
 
@@ -45,6 +46,6 @@ class AuthenticatedUnbindThreePidServlet(Resource):
             args["mxid"],
         )
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING
 
 import signedjson.key
 import signedjson.sign
@@ -22,11 +23,10 @@ from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.auth import authV2
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from sydent.sydent import Sydent
     from twisted.web.server import Request
+
+    from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
 
@@ -34,14 +34,14 @@ logger = logging.getLogger(__name__)
 class BlindlySignStuffServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent', require_auth: bool=False) -> None:
+    def __init__(self, syd: "Sydent", require_auth: bool = False) -> None:
         self.sydent = syd
         self.server_name = syd.server_name
         self.tokenStore = JoinTokenStore(syd)
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: 'Request'):
+    def render_POST(self, request: "Request"):
         send_cors(request)
 
         if self.require_auth:
@@ -73,6 +73,6 @@ class BlindlySignStuffServlet(Resource):
 
         return signed
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -14,7 +14,6 @@
 
 import logging
 from typing import TYPE_CHECKING
-from sydent.types import JsonDict
 
 import signedjson.key
 import signedjson.sign
@@ -24,6 +23,7 @@ from twisted.web.server import Request
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.auth import authV2
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -22,20 +22,26 @@ from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.auth import authV2
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+    from twisted.web.server import Request
+
 logger = logging.getLogger(__name__)
 
 
 class BlindlySignStuffServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd, require_auth=False):
+    def __init__(self, syd: 'Sydent', require_auth: bool=False) -> None:
         self.sydent = syd
         self.server_name = syd.server_name
         self.tokenStore = JoinTokenStore(syd)
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request'):
         send_cors(request)
 
         if self.require_auth:
@@ -67,6 +73,6 @@ class BlindlySignStuffServlet(Resource):
 
         return signed
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -14,6 +14,7 @@
 
 import logging
 from typing import TYPE_CHECKING
+from sydent.types import JsonDict
 
 import signedjson.key
 import signedjson.sign
@@ -40,7 +41,7 @@ class BlindlySignStuffServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: Request):
+    def render_POST(self, request: Request) -> JsonDict:
         send_cors(request)
 
         if self.require_auth:

--- a/sydent/http/servlets/blindlysignstuffservlet.py
+++ b/sydent/http/servlets/blindlysignstuffservlet.py
@@ -18,14 +18,13 @@ from typing import TYPE_CHECKING
 import signedjson.key
 import signedjson.sign
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.auth import authV2
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -41,7 +40,7 @@ class BlindlySignStuffServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: "Request"):
+    def render_POST(self, request: Request):
         send_cors(request)
 
         if self.require_auth:
@@ -73,6 +72,6 @@ class BlindlySignStuffServlet(Resource):
 
         return signed
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, Dict, List, Tuple
+from typing import TYPE_CHECKING
+
+from sydent.types import JsonDict
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -34,7 +36,7 @@ class BulkLookupServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_POST(self, request: Request) -> Dict[str, List[Tuple[str, str, str]]]:
+    def render_POST(self, request: Request) -> JsonDict:
         """
         Bulk-lookup for threepids.
         Params: 'threepids': list of threepids, each of which is a list of medium, address

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -15,13 +15,12 @@
 import logging
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -16,13 +16,12 @@ import logging
 from typing import TYPE_CHECKING, Dict, List, Tuple
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -35,7 +34,7 @@ class BulkLookupServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> Dict[str, List[Tuple[str, str, str]]]:
+    def render_POST(self, request: Request) -> Dict[str, List[Tuple[str, str, str]]]:
         """
         Bulk-lookup for threepids.
         Params: 'threepids': list of threepids, each of which is a list of medium, address
@@ -59,6 +58,6 @@ class BulkLookupServlet(Resource):
 
         return {"threepids": results}
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -19,17 +19,23 @@ from twisted.web.resource import Resource
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 
+from typing import TYPE_CHECKING, Dict, List, Tuple
+
+if TYPE_CHECKING:
+    from sydent.sydent import Sydent
+    from twisted.web.server import Request
+
 logger = logging.getLogger(__name__)
 
 
 class BulkLookupServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> Dict[str, List[Tuple[str, str, str]]]:
         """
         Bulk-lookup for threepids.
         Params: 'threepids': list of threepids, each of which is a list of medium, address
@@ -53,6 +59,6 @@ class BulkLookupServlet(Resource):
 
         return {"threepids": results}
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/bulklookupservlet.py
+++ b/sydent/http/servlets/bulklookupservlet.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 from twisted.web.resource import Resource
 
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 
-from typing import TYPE_CHECKING, Dict, List, Tuple
-
 if TYPE_CHECKING:
-    from sydent.sydent import Sydent
     from twisted.web.server import Request
+
+    from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +31,11 @@ logger = logging.getLogger(__name__)
 class BulkLookupServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> Dict[str, List[Tuple[str, str, str]]]:
+    def render_POST(self, request: "Request") -> Dict[str, List[Tuple[str, str, str]]]:
         """
         Bulk-lookup for threepids.
         Params: 'threepids': list of threepids, each of which is a list of medium, address
@@ -59,6 +59,6 @@ class BulkLookupServlet(Resource):
 
         return {"threepids": results}
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Dict, Union
+from typing import TYPE_CHECKING
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -141,7 +141,7 @@ class EmailValidateCodeServlet(Resource):
 
         return self.do_validate_request(request)
 
-    def do_validate_request(self, request: Request) -> Dict[str, Union[bool, str]]:
+    def do_validate_request(self, request: Request) -> JsonDict:
         """
         Extracts information about a validation session from the request and
         attempts to validate that session.

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -14,6 +14,8 @@
 
 from typing import TYPE_CHECKING, Dict, Union
 
+from sydent.types import JsonDict
+
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
@@ -40,7 +42,7 @@ class EmailRequestCodeServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: Request) -> Dict:
+    def render_POST(self, request: Request) -> JsonDict:
         send_cors(request)
 
         if self.require_auth:
@@ -132,7 +134,7 @@ class EmailValidateCodeServlet(Resource):
         return res.encode("UTF-8")
 
     @jsonwrap
-    def render_POST(self, request: Request) -> Dict[str, Union[bool, str]]:
+    def render_POST(self, request: Request) -> JsonDict:
         send_cors(request)
 
         if self.require_auth:

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING, Dict, Union
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.http.auth import authV2
 from sydent.http.servlets import get_args, jsonwrap, send_cors
@@ -28,8 +29,6 @@ from sydent.validators import (
 )
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 
@@ -41,7 +40,7 @@ class EmailRequestCodeServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> Dict:
+    def render_POST(self, request: Request) -> Dict:
         send_cors(request)
 
         if self.require_auth:
@@ -90,7 +89,7 @@ class EmailRequestCodeServlet(Resource):
 
         return resp
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""
 
@@ -102,7 +101,7 @@ class EmailValidateCodeServlet(Resource):
         self.sydent = syd
         self.require_auth = require_auth
 
-    def render_GET(self, request: "Request") -> bytes:
+    def render_GET(self, request: Request) -> bytes:
         args = get_args(request, ("nextLink",), required=False)
 
         resp = None
@@ -133,7 +132,7 @@ class EmailValidateCodeServlet(Resource):
         return res.encode("UTF-8")
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> Dict[str, Union[bool, str]]:
+    def render_POST(self, request: Request) -> Dict[str, Union[bool, str]]:
         send_cors(request)
 
         if self.require_auth:
@@ -141,7 +140,7 @@ class EmailValidateCodeServlet(Resource):
 
         return self.do_validate_request(request)
 
-    def do_validate_request(self, request: "Request") -> Dict[str, Union[bool, str]]:
+    def do_validate_request(self, request: Request) -> Dict[str, Union[bool, str]]:
         """
         Extracts information about a validation session from the request and
         attempts to validate that session.
@@ -196,6 +195,6 @@ class EmailValidateCodeServlet(Resource):
                 "error": "No session could be found with this sid",
             }
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -25,16 +25,21 @@ from sydent.validators import (
     SessionExpiredException,
 )
 
+from typing import TYPE_CHECKING, Union, Dict
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
 
 class EmailRequestCodeServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd, require_auth=False):
+    def __init__(self, syd: 'Sydent', require_auth: bool=False) -> None:
         self.sydent = syd
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> Dict:
         send_cors(request)
 
         if self.require_auth:
@@ -83,7 +88,7 @@ class EmailRequestCodeServlet(Resource):
 
         return resp
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""
 
@@ -91,11 +96,11 @@ class EmailRequestCodeServlet(Resource):
 class EmailValidateCodeServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd, require_auth=False):
+    def __init__(self, syd: 'Sydent', require_auth: bool=False) -> None:
         self.sydent = syd
         self.require_auth = require_auth
 
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request') -> bytes:
         args = get_args(request, ("nextLink",), required=False)
 
         resp = None
@@ -122,10 +127,11 @@ class EmailValidateCodeServlet(Resource):
 
         request.setHeader("Content-Type", "text/html")
         res = open(templateFile).read() % {"message": msg}
+
         return res.encode("UTF-8")
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> Dict[str, Union[bool, str]]:
         send_cors(request)
 
         if self.require_auth:
@@ -133,7 +139,7 @@ class EmailValidateCodeServlet(Resource):
 
         return self.do_validate_request(request)
 
-    def do_validate_request(self, request):
+    def do_validate_request(self, request: 'Request') -> Dict[str, Union[bool, str]]:
         """
         Extracts information about a validation session from the request and
         attempts to validate that session.
@@ -188,6 +194,6 @@ class EmailValidateCodeServlet(Resource):
                 "error": "No session could be found with this sid",
             }
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -14,13 +14,12 @@
 
 from typing import TYPE_CHECKING, Dict, Union
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.http.auth import authV2
 from sydent.http.servlets import get_args, jsonwrap, send_cors
+from sydent.types import JsonDict
 from sydent.util.emailutils import EmailAddressException, EmailSendException
 from sydent.util.stringutils import MAX_EMAIL_ADDRESS_LENGTH, is_valid_client_secret
 from sydent.validators import (

--- a/sydent/http/servlets/emailservlet.py
+++ b/sydent/http/servlets/emailservlet.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING, Dict, Union
+
 from twisted.web.resource import Resource
 
 from sydent.http.auth import authV2
@@ -25,21 +27,21 @@ from sydent.validators import (
     SessionExpiredException,
 )
 
-from typing import TYPE_CHECKING, Union, Dict
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
+
 
 class EmailRequestCodeServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent', require_auth: bool=False) -> None:
+    def __init__(self, syd: "Sydent", require_auth: bool = False) -> None:
         self.sydent = syd
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> Dict:
+    def render_POST(self, request: "Request") -> Dict:
         send_cors(request)
 
         if self.require_auth:
@@ -88,7 +90,7 @@ class EmailRequestCodeServlet(Resource):
 
         return resp
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""
 
@@ -96,11 +98,11 @@ class EmailRequestCodeServlet(Resource):
 class EmailValidateCodeServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent', require_auth: bool=False) -> None:
+    def __init__(self, syd: "Sydent", require_auth: bool = False) -> None:
         self.sydent = syd
         self.require_auth = require_auth
 
-    def render_GET(self, request: 'Request') -> bytes:
+    def render_GET(self, request: "Request") -> bytes:
         args = get_args(request, ("nextLink",), required=False)
 
         resp = None
@@ -131,7 +133,7 @@ class EmailValidateCodeServlet(Resource):
         return res.encode("UTF-8")
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> Dict[str, Union[bool, str]]:
+    def render_POST(self, request: "Request") -> Dict[str, Union[bool, str]]:
         send_cors(request)
 
         if self.require_auth:
@@ -139,7 +141,7 @@ class EmailValidateCodeServlet(Resource):
 
         return self.do_validate_request(request)
 
-    def do_validate_request(self, request: 'Request') -> Dict[str, Union[bool, str]]:
+    def do_validate_request(self, request: "Request") -> Dict[str, Union[bool, str]]:
         """
         Extracts information about a validation session from the request and
         attempts to validate that session.
@@ -194,6 +196,6 @@ class EmailValidateCodeServlet(Resource):
                 "error": "No session could be found with this sid",
             }
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -14,14 +14,13 @@
 
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.http.auth import authV2
 from sydent.http.servlets import get_args, jsonwrap, send_cors
+from sydent.types import JsonDict
 from sydent.util.stringutils import is_valid_client_secret
 from sydent.validators import (
     IncorrectClientSecretException,

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
+
+from sydent.types import JsonDict
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -40,7 +42,7 @@ class GetValidated3pidServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_GET(self, request: Request) -> Dict:
+    def render_GET(self, request: Request) -> JsonDict:
         send_cors(request)
         if self.require_auth:
             authV2(self.sydent, request)

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -25,16 +25,22 @@ from sydent.validators import (
     SessionNotValidatedException,
 )
 
+from typing import TYPE_CHECKING, Dict
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 
 class GetValidated3pidServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd, require_auth=False):
+    def __init__(self, syd: 'Sydent', require_auth: bool =False) -> None:
         self.sydent = syd
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request') -> Dict:
         send_cors(request)
         if self.require_auth:
             authV2(self.sydent, request)
@@ -78,6 +84,6 @@ class GetValidated3pidServlet(Resource):
 
         return {"medium": s.medium, "address": s.address, "validated_at": s.mtime}
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING, Dict
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.http.auth import authV2
@@ -28,8 +29,6 @@ from sydent.validators import (
 )
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 
@@ -41,7 +40,7 @@ class GetValidated3pidServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_GET(self, request: "Request") -> Dict:
+    def render_GET(self, request: Request) -> Dict:
         send_cors(request)
         if self.require_auth:
             authV2(self.sydent, request)
@@ -85,6 +84,6 @@ class GetValidated3pidServlet(Resource):
 
         return {"medium": s.medium, "address": s.address, "validated_at": s.mtime}
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/getvalidated3pidservlet.py
+++ b/sydent/http/servlets/getvalidated3pidservlet.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING, Dict
+
 from twisted.web.resource import Resource
 
 from sydent.db.valsession import ThreePidValSessionStore
@@ -25,22 +27,21 @@ from sydent.validators import (
     SessionNotValidatedException,
 )
 
-from typing import TYPE_CHECKING, Dict
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 
 class GetValidated3pidServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent', require_auth: bool =False) -> None:
+    def __init__(self, syd: "Sydent", require_auth: bool = False) -> None:
         self.sydent = syd
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_GET(self, request: 'Request') -> Dict:
+    def render_GET(self, request: "Request") -> Dict:
         send_cors(request)
         if self.require_auth:
             authV2(self.sydent, request)
@@ -84,6 +85,6 @@ class GetValidated3pidServlet(Resource):
 
         return {"medium": s.medium, "address": s.address, "validated_at": s.mtime}
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/hashdetailsservlet.py
+++ b/sydent/http/servlets/hashdetailsservlet.py
@@ -19,6 +19,12 @@ from twisted.web.resource import Resource
 from sydent.http.auth import authV2
 from sydent.http.servlets import jsonwrap, send_cors
 
+from typing import TYPE_CHECKING, Any, Dict, Tuple
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,12 +32,12 @@ class HashDetailsServlet(Resource):
     isLeaf = True
     known_algorithms = ["sha256", "none"]
 
-    def __init__(self, syd, lookup_pepper):
+    def __init__(self, syd: 'Sydent', lookup_pepper: str) -> None:
         self.sydent = syd
         self.lookup_pepper = lookup_pepper
 
     @jsonwrap
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request') -> Dict:
         """
         Return the hashing algorithms and pepper that this IS supports. The
         pepper included in the response is stored in the database, or
@@ -51,6 +57,6 @@ class HashDetailsServlet(Resource):
             "lookup_pepper": self.lookup_pepper,
         }
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/hashdetailsservlet.py
+++ b/sydent/http/servlets/hashdetailsservlet.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
+
+from sydent.types import JsonDict
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -36,7 +38,7 @@ class HashDetailsServlet(Resource):
         self.lookup_pepper = lookup_pepper
 
     @jsonwrap
-    def render_GET(self, request: Request) -> Dict:
+    def render_GET(self, request: Request) -> JsonDict:
         """
         Return the hashing algorithms and pepper that this IS supports. The
         pepper included in the response is stored in the database, or

--- a/sydent/http/servlets/hashdetailsservlet.py
+++ b/sydent/http/servlets/hashdetailsservlet.py
@@ -15,13 +15,12 @@
 import logging
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.http.auth import authV2
 from sydent.http.servlets import jsonwrap, send_cors
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/http/servlets/hashdetailsservlet.py
+++ b/sydent/http/servlets/hashdetailsservlet.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING, Dict
 
 from twisted.web.resource import Resource
 
 from sydent.http.auth import authV2
 from sydent.http.servlets import jsonwrap, send_cors
 
-from typing import TYPE_CHECKING, Any, Dict, Tuple
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -32,12 +32,12 @@ class HashDetailsServlet(Resource):
     isLeaf = True
     known_algorithms = ["sha256", "none"]
 
-    def __init__(self, syd: 'Sydent', lookup_pepper: str) -> None:
+    def __init__(self, syd: "Sydent", lookup_pepper: str) -> None:
         self.sydent = syd
         self.lookup_pepper = lookup_pepper
 
     @jsonwrap
-    def render_GET(self, request: 'Request') -> Dict:
+    def render_GET(self, request: "Request") -> Dict:
         """
         Return the hashing algorithms and pepper that this IS supports. The
         pepper included in the response is stored in the database, or
@@ -57,6 +57,6 @@ class HashDetailsServlet(Resource):
             "lookup_pepper": self.lookup_pepper,
         }
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/hashdetailsservlet.py
+++ b/sydent/http/servlets/hashdetailsservlet.py
@@ -16,13 +16,12 @@ import logging
 from typing import TYPE_CHECKING, Dict
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.http.auth import authV2
 from sydent.http.servlets import jsonwrap, send_cors
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -37,7 +36,7 @@ class HashDetailsServlet(Resource):
         self.lookup_pepper = lookup_pepper
 
     @jsonwrap
-    def render_GET(self, request: "Request") -> Dict:
+    def render_GET(self, request: Request) -> Dict:
         """
         Return the hashing algorithms and pepper that this IS supports. The
         pepper included in the response is stored in the database, or
@@ -57,6 +56,6 @@ class HashDetailsServlet(Resource):
             "lookup_pepper": self.lookup_pepper,
         }
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -16,14 +16,13 @@ import logging
 from typing import TYPE_CHECKING
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.db.accounts import AccountStore
 from sydent.http.auth import authV2, tokenFromRequest
 from sydent.http.servlets import jsonwrap, send_cors
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -15,14 +15,13 @@
 import logging
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.db.accounts import AccountStore
 from sydent.http.auth import authV2, tokenFromRequest
 from sydent.http.servlets import jsonwrap, send_cors
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -15,6 +15,8 @@
 import logging
 from typing import TYPE_CHECKING
 
+from sydent.types import JsonDict
+
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
@@ -35,7 +37,7 @@ class LogoutServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_POST(self, request: Request) -> dict:
+    def render_POST(self, request: Request) -> JsonDict:
         """
         Invalidate the given access token
         """

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING
 
 from twisted.web.resource import Resource
 
@@ -20,10 +21,9 @@ from sydent.db.accounts import AccountStore
 from sydent.http.auth import authV2, tokenFromRequest
 from sydent.http.servlets import jsonwrap, send_cors
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -32,11 +32,11 @@ logger = logging.getLogger(__name__)
 class LogoutServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> dict:
+    def render_POST(self, request: "Request") -> dict:
         """
         Invalidate the given access token
         """
@@ -50,6 +50,6 @@ class LogoutServlet(Resource):
         accountStore.delToken(token)
         return {}
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -36,7 +36,7 @@ class LogoutServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> dict:
+    def render_POST(self, request: Request) -> dict:
         """
         Invalidate the given access token
         """
@@ -50,6 +50,6 @@ class LogoutServlet(Resource):
         accountStore.delToken(token)
         return {}
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/logoutservlet.py
+++ b/sydent/http/servlets/logoutservlet.py
@@ -20,17 +20,23 @@ from sydent.db.accounts import AccountStore
 from sydent.http.auth import authV2, tokenFromRequest
 from sydent.http.servlets import jsonwrap, send_cors
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
 class LogoutServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> dict:
         """
         Invalidate the given access token
         """
@@ -44,6 +50,6 @@ class LogoutServlet(Resource):
         accountStore.delToken(token)
         return {}
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING, Optional, Union
 
 import signedjson.sign
 from twisted.web.resource import Resource
@@ -22,10 +23,9 @@ from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.util import json_decoder
 
-from typing import TYPE_CHECKING, Union, Optional
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -34,11 +34,11 @@ logger = logging.getLogger(__name__)
 class LookupServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: 'Request') -> Union[dict, Optional[str]]:
+    def render_GET(self, request: "Request") -> Union[dict, Optional[str]]:
         """
         Look up an individual threepid.
 
@@ -86,6 +86,6 @@ class LookupServlet(Resource):
             )
         return sgassoc
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -18,14 +18,13 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import signedjson.sign
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.util import json_decoder
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -38,7 +37,7 @@ class LookupServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: "Request") -> Union[dict, Optional[str]]:
+    def render_GET(self, request: Request) -> Union[dict, Optional[str]]:
         """
         Look up an individual threepid.
 
@@ -86,6 +85,6 @@ class LookupServlet(Resource):
             )
         return sgassoc
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
+
+from sydent.types import JsonDict
 
 import signedjson.sign
 from twisted.web.resource import Resource
@@ -37,7 +39,7 @@ class LookupServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: Request) -> Union[dict, Optional[str]]:
+    def render_GET(self, request: Request) -> JsonDict:
         """
         Look up an individual threepid.
 

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -22,17 +22,23 @@ from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.util import json_decoder
 
+from typing import TYPE_CHECKING, Union, Optional
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
 class LookupServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request') -> Union[dict, Optional[str]]:
         """
         Look up an individual threepid.
 
@@ -80,6 +86,6 @@ class LookupServlet(Resource):
             )
         return sgassoc
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/lookupservlet.py
+++ b/sydent/http/servlets/lookupservlet.py
@@ -16,14 +16,13 @@
 import logging
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 import signedjson.sign
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.servlets import get_args, jsonwrap, send_cors
+from sydent.types import JsonDict
 from sydent.util import json_decoder
 
 if TYPE_CHECKING:

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -21,19 +21,25 @@ from sydent.http.auth import authV2
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.http.servlets.hashdetailsservlet import HashDetailsServlet
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
 class LookupV2Servlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd, lookup_pepper):
+    def __init__(self, syd: 'Sydent', lookup_pepper: str) -> None:
         self.sydent = syd
         self.globalAssociationStore = GlobalAssociationStore(self.sydent)
         self.lookup_pepper = lookup_pepper
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> dict:
         """
         Perform lookups with potentially hashed 3PID details.
 
@@ -136,6 +142,6 @@ class LookupV2Servlet(Resource):
         request.setResponseCode(400)
         return {"errcode": "M_INVALID_PARAM", "error": "algorithm is not supported"}
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -15,6 +15,8 @@
 import logging
 from typing import TYPE_CHECKING
 
+from sydent.types import JsonDict
+
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
@@ -38,7 +40,7 @@ class LookupV2Servlet(Resource):
         self.lookup_pepper = lookup_pepper
 
     @jsonwrap
-    def render_POST(self, request: Request) -> dict:
+    def render_POST(self, request: Request) -> JsonDict:
         """
         Perform lookups with potentially hashed 3PID details.
 

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -16,6 +16,8 @@ import logging
 from typing import TYPE_CHECKING
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
+
 
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.auth import authV2
@@ -23,8 +25,6 @@ from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.http.servlets.hashdetailsservlet import HashDetailsServlet
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ class LookupV2Servlet(Resource):
         self.lookup_pepper = lookup_pepper
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> dict:
+    def render_POST(self, request: Request) -> dict:
         """
         Perform lookups with potentially hashed 3PID details.
 
@@ -142,6 +142,6 @@ class LookupV2Servlet(Resource):
         request.setResponseCode(400)
         return {"errcode": "M_INVALID_PARAM", "error": "algorithm is not supported"}
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -15,8 +15,6 @@
 import logging
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
@@ -24,6 +22,7 @@ from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.auth import authV2
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.http.servlets.hashdetailsservlet import HashDetailsServlet
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
-
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.auth import authV2
 from sydent.http.servlets import get_args, jsonwrap, send_cors

--- a/sydent/http/servlets/lookupv2servlet.py
+++ b/sydent/http/servlets/lookupv2servlet.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING
 
 from twisted.web.resource import Resource
 
@@ -21,10 +22,9 @@ from sydent.http.auth import authV2
 from sydent.http.servlets import get_args, jsonwrap, send_cors
 from sydent.http.servlets.hashdetailsservlet import HashDetailsServlet
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -33,13 +33,13 @@ logger = logging.getLogger(__name__)
 class LookupV2Servlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent', lookup_pepper: str) -> None:
+    def __init__(self, syd: "Sydent", lookup_pepper: str) -> None:
         self.sydent = syd
         self.globalAssociationStore = GlobalAssociationStore(self.sydent)
         self.lookup_pepper = lookup_pepper
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> dict:
+    def render_POST(self, request: "Request") -> dict:
         """
         Perform lookups with potentially hashed 3PID details.
 
@@ -142,6 +142,6 @@ class LookupV2Servlet(Resource):
         request.setResponseCode(400)
         return {"errcode": "M_INVALID_PARAM", "error": "algorithm is not supported"}
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -29,18 +29,24 @@ from sydent.validators import (
     SessionExpiredException,
 )
 
+from typing import TYPE_CHECKING, Dict, Union
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
 class MsisdnRequestCodeServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd, require_auth=False):
+    def __init__(self, syd: 'Sydent', require_auth: bool =False) -> None:
         self.sydent = syd
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> dict:
         send_cors(request)
 
         if self.require_auth:
@@ -107,7 +113,7 @@ class MsisdnRequestCodeServlet(Resource):
 
         return resp
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""
 
@@ -115,11 +121,11 @@ class MsisdnRequestCodeServlet(Resource):
 class MsisdnValidateCodeServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd, require_auth=False):
+    def __init__(self, syd: 'Sydent', require_auth: bool =False) -> None:
         self.sydent = syd
         self.require_auth = require_auth
 
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request') -> str:
         send_cors(request)
 
         err, args = get_args(request, ("token", "sid", "client_secret"))
@@ -148,7 +154,7 @@ class MsisdnValidateCodeServlet(Resource):
         return open(templateFile).read() % {"message": msg}
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> Dict[str, Union[bool, str]]:
         send_cors(request)
 
         if self.require_auth:
@@ -156,7 +162,7 @@ class MsisdnValidateCodeServlet(Resource):
 
         return self.do_validate_request(request)
 
-    def do_validate_request(self, request):
+    def do_validate_request(self, request: 'Request') -> Dict[str, Union[bool, str]]:
         """
         Extracts information about a validation session from the request and
         attempts to validate that session.
@@ -216,6 +222,6 @@ class MsisdnValidateCodeServlet(Resource):
                 "error": "No session could be found with this sid",
             }
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -46,7 +46,7 @@ class MsisdnRequestCodeServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: Request) -> dict:
+    def render_POST(self, request: Request) -> JsonDict:
         send_cors(request)
 
         if self.require_auth:

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, Dict, Union
+from typing import TYPE_CHECKING
+
+from sydent.types import JsonDict
 
 import phonenumbers
 from twisted.web.resource import Resource
@@ -153,7 +155,7 @@ class MsisdnValidateCodeServlet(Resource):
         return open(templateFile).read() % {"message": msg}
 
     @jsonwrap
-    def render_POST(self, request: Request) -> Dict[str, Union[bool, str]]:
+    def render_POST(self, request: Request) -> JsonDict:
         send_cors(request)
 
         if self.require_auth:
@@ -161,7 +163,7 @@ class MsisdnValidateCodeServlet(Resource):
 
         return self.do_validate_request(request)
 
-    def do_validate_request(self, request: Request) -> Dict[str, Union[bool, str]]:
+    def do_validate_request(self, request: Request) -> JsonDict:
         """
         Extracts information about a validation session from the request and
         attempts to validate that session.

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING, Dict, Union
 
 import phonenumbers
 from twisted.web.resource import Resource
@@ -29,10 +30,9 @@ from sydent.validators import (
     SessionExpiredException,
 )
 
-from typing import TYPE_CHECKING, Dict, Union
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -41,12 +41,12 @@ logger = logging.getLogger(__name__)
 class MsisdnRequestCodeServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent', require_auth: bool =False) -> None:
+    def __init__(self, syd: "Sydent", require_auth: bool = False) -> None:
         self.sydent = syd
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> dict:
+    def render_POST(self, request: "Request") -> dict:
         send_cors(request)
 
         if self.require_auth:
@@ -113,7 +113,7 @@ class MsisdnRequestCodeServlet(Resource):
 
         return resp
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""
 
@@ -121,11 +121,11 @@ class MsisdnRequestCodeServlet(Resource):
 class MsisdnValidateCodeServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent', require_auth: bool =False) -> None:
+    def __init__(self, syd: "Sydent", require_auth: bool = False) -> None:
         self.sydent = syd
         self.require_auth = require_auth
 
-    def render_GET(self, request: 'Request') -> str:
+    def render_GET(self, request: "Request") -> str:
         send_cors(request)
 
         err, args = get_args(request, ("token", "sid", "client_secret"))
@@ -154,7 +154,7 @@ class MsisdnValidateCodeServlet(Resource):
         return open(templateFile).read() % {"message": msg}
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> Dict[str, Union[bool, str]]:
+    def render_POST(self, request: "Request") -> Dict[str, Union[bool, str]]:
         send_cors(request)
 
         if self.require_auth:
@@ -162,7 +162,7 @@ class MsisdnValidateCodeServlet(Resource):
 
         return self.do_validate_request(request)
 
-    def do_validate_request(self, request: 'Request') -> Dict[str, Union[bool, str]]:
+    def do_validate_request(self, request: "Request") -> Dict[str, Union[bool, str]]:
         """
         Extracts information about a validation session from the request and
         attempts to validate that session.
@@ -222,6 +222,6 @@ class MsisdnValidateCodeServlet(Resource):
                 "error": "No session could be found with this sid",
             }
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -16,14 +16,13 @@
 import logging
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 import phonenumbers
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.http.auth import authV2
 from sydent.http.servlets import get_args, jsonwrap, send_cors
+from sydent.types import JsonDict
 from sydent.util.stringutils import is_valid_client_secret
 from sydent.validators import (
     DestinationRejectedException,

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Dict, Union
 
 import phonenumbers
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.http.auth import authV2
 from sydent.http.servlets import get_args, jsonwrap, send_cors
@@ -31,8 +32,6 @@ from sydent.validators import (
 )
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -46,7 +45,7 @@ class MsisdnRequestCodeServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> dict:
+    def render_POST(self, request: Request) -> dict:
         send_cors(request)
 
         if self.require_auth:
@@ -113,7 +112,7 @@ class MsisdnRequestCodeServlet(Resource):
 
         return resp
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""
 
@@ -125,7 +124,7 @@ class MsisdnValidateCodeServlet(Resource):
         self.sydent = syd
         self.require_auth = require_auth
 
-    def render_GET(self, request: "Request") -> str:
+    def render_GET(self, request: Request) -> str:
         send_cors(request)
 
         err, args = get_args(request, ("token", "sid", "client_secret"))
@@ -154,7 +153,7 @@ class MsisdnValidateCodeServlet(Resource):
         return open(templateFile).read() % {"message": msg}
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> Dict[str, Union[bool, str]]:
+    def render_POST(self, request: Request) -> Dict[str, Union[bool, str]]:
         send_cors(request)
 
         if self.require_auth:
@@ -162,7 +161,7 @@ class MsisdnValidateCodeServlet(Resource):
 
         return self.do_validate_request(request)
 
-    def do_validate_request(self, request: "Request") -> Dict[str, Union[bool, str]]:
+    def do_validate_request(self, request: Request) -> Dict[str, Union[bool, str]]:
         """
         Extracts information about a validation session from the request and
         attempts to validate that session.
@@ -222,6 +221,6 @@ class MsisdnValidateCodeServlet(Resource):
                 "error": "No session could be found with this sid",
             }
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -14,14 +14,13 @@
 
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 from unpaddedbase64 import encode_base64
 
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.servlets import get_args, jsonwrap
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -14,6 +14,8 @@
 
 from typing import TYPE_CHECKING
 
+from sydent.types import JsonDict
+
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 from unpaddedbase64 import encode_base64
@@ -46,7 +48,7 @@ class PubkeyIsValidServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: Request) -> dict:
+    def render_GET(self, request: Request) -> JsonDict:
         args = get_args(request, ("public_key",))
 
         pubKey = self.sydent.keyring.ed25519.verify_key
@@ -62,7 +64,7 @@ class EphemeralPubkeyIsValidServlet(Resource):
         self.joinTokenStore = JoinTokenStore(syd)
 
     @jsonwrap
-    def render_GET(self, request: Request) -> dict:
+    def render_GET(self, request: Request) -> JsonDict:
         args = get_args(request, ("public_key",))
         publicKey = args["public_key"]
 

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -18,15 +18,21 @@ from unpaddedbase64 import encode_base64
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.servlets import get_args, jsonwrap
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 
 class Ed25519Servlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request') -> dict:
         pubKey = self.sydent.keyring.ed25519.verify_key
         pubKeyBase64 = encode_base64(pubKey.encode())
 
@@ -36,11 +42,11 @@ class Ed25519Servlet(Resource):
 class PubkeyIsValidServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request') -> dict:
         args = get_args(request, ("public_key",))
 
         pubKey = self.sydent.keyring.ed25519.verify_key
@@ -52,11 +58,11 @@ class PubkeyIsValidServlet(Resource):
 class EphemeralPubkeyIsValidServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         self.joinTokenStore = JoinTokenStore(syd)
 
     @jsonwrap
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request') -> dict:
         args = get_args(request, ("public_key",))
         publicKey = args["public_key"]
 

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -33,7 +33,7 @@ class Ed25519Servlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: Request) -> dict:
+    def render_GET(self, request: Request) -> JsonDict:
         pubKey = self.sydent.keyring.ed25519.verify_key
         pubKeyBase64 = encode_base64(pubKey.encode())
 

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -14,6 +14,7 @@
 
 from typing import TYPE_CHECKING
 
+from twisted.web.server import Request
 from twisted.web.resource import Resource
 from unpaddedbase64 import encode_base64
 
@@ -21,8 +22,6 @@ from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.servlets import get_args, jsonwrap
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 
@@ -33,7 +32,7 @@ class Ed25519Servlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: "Request") -> dict:
+    def render_GET(self, request: Request) -> dict:
         pubKey = self.sydent.keyring.ed25519.verify_key
         pubKeyBase64 = encode_base64(pubKey.encode())
 
@@ -47,7 +46,7 @@ class PubkeyIsValidServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: "Request") -> dict:
+    def render_GET(self, request: Request) -> dict:
         args = get_args(request, ("public_key",))
 
         pubKey = self.sydent.keyring.ed25519.verify_key
@@ -63,7 +62,7 @@ class EphemeralPubkeyIsValidServlet(Resource):
         self.joinTokenStore = JoinTokenStore(syd)
 
     @jsonwrap
-    def render_GET(self, request: "Request") -> dict:
+    def render_GET(self, request: Request) -> dict:
         args = get_args(request, ("public_key",))
         publicKey = args["public_key"]
 

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -12,27 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING
+
 from twisted.web.resource import Resource
 from unpaddedbase64 import encode_base64
 
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.servlets import get_args, jsonwrap
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 
 class Ed25519Servlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: 'Request') -> dict:
+    def render_GET(self, request: "Request") -> dict:
         pubKey = self.sydent.keyring.ed25519.verify_key
         pubKeyBase64 = encode_base64(pubKey.encode())
 
@@ -42,11 +43,11 @@ class Ed25519Servlet(Resource):
 class PubkeyIsValidServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: 'Request') -> dict:
+    def render_GET(self, request: "Request") -> dict:
         args = get_args(request, ("public_key",))
 
         pubKey = self.sydent.keyring.ed25519.verify_key
@@ -58,11 +59,11 @@ class PubkeyIsValidServlet(Resource):
 class EphemeralPubkeyIsValidServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         self.joinTokenStore = JoinTokenStore(syd)
 
     @jsonwrap
-    def render_GET(self, request: 'Request') -> dict:
+    def render_GET(self, request: "Request") -> dict:
         args = get_args(request, ("public_key",))
         publicKey = args["public_key"]
 

--- a/sydent/http/servlets/pubkeyservlets.py
+++ b/sydent/http/servlets/pubkeyservlets.py
@@ -14,8 +14,8 @@
 
 from typing import TYPE_CHECKING
 
-from twisted.web.server import Request
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 from unpaddedbase64 import encode_base64
 
 from sydent.db.invite_tokens import JoinTokenStore

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -14,6 +14,7 @@
 
 import logging
 import urllib
+from typing import TYPE_CHECKING, Generator
 
 from twisted.internet import defer
 from twisted.web.resource import Resource
@@ -23,10 +24,9 @@ from sydent.http.servlets import deferjsonwrap, get_args, send_cors
 from sydent.users.tokens import issueToken
 from sydent.util.stringutils import is_valid_matrix_server_name
 
-from typing import TYPE_CHECKING, Generator
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -35,13 +35,13 @@ logger = logging.getLogger(__name__)
 class RegisterServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         self.sydent = syd
         self.client = FederationHttpClient(self.sydent)
 
     @deferjsonwrap
     @defer.inlineCallbacks
-    def render_POST(self, request: 'Request') -> Generator:
+    def render_POST(self, request: "Request") -> Generator:
         """
         Register with the Identity Server
         """
@@ -117,6 +117,6 @@ class RegisterServlet(Resource):
             }
         )
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Generator
 
 from twisted.internet import defer
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.http.httpclient import FederationHttpClient
 from sydent.http.servlets import deferjsonwrap, get_args, send_cors
@@ -25,8 +26,6 @@ from sydent.users.tokens import issueToken
 from sydent.util.stringutils import is_valid_matrix_server_name
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -41,7 +40,7 @@ class RegisterServlet(Resource):
 
     @deferjsonwrap
     @defer.inlineCallbacks
-    def render_POST(self, request: "Request") -> Generator:
+    def render_POST(self, request: Request) -> Generator:
         """
         Register with the Identity Server
         """
@@ -117,6 +116,6 @@ class RegisterServlet(Resource):
             }
         )
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -23,19 +23,25 @@ from sydent.http.servlets import deferjsonwrap, get_args, send_cors
 from sydent.users.tokens import issueToken
 from sydent.util.stringutils import is_valid_matrix_server_name
 
+from typing import TYPE_CHECKING, Generator
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
 class RegisterServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         self.sydent = syd
         self.client = FederationHttpClient(self.sydent)
 
     @deferjsonwrap
     @defer.inlineCallbacks
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> Generator:
         """
         Register with the Identity Server
         """
@@ -111,6 +117,6 @@ class RegisterServlet(Resource):
             }
         )
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -16,8 +16,6 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 import twisted.python.log
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -27,6 +25,7 @@ from sydent.db.peers import PeerStore
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.servlets import MatrixRestError, jsonwrap
 from sydent.threepid import threePidAssocFromDict
+from sydent.types import JsonDict
 from sydent.util import json_decoder
 from sydent.util.hash import sha256_and_url_safe_base64
 

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -26,16 +26,22 @@ from sydent.threepid import threePidAssocFromDict
 from sydent.util import json_decoder
 from sydent.util.hash import sha256_and_url_safe_base64
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
 class ReplicationPushServlet(Resource):
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
         self.hashing_store = HashingMetadataStore(sydent)
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> dict:
         peerCert = request.transport.getPeerCertificate()
         peerCertCn = peerCert.get_subject().commonName
 

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -16,6 +16,8 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
+from sydent.types import JsonDict
+
 import twisted.python.log
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -40,7 +42,7 @@ class ReplicationPushServlet(Resource):
         self.hashing_store = HashingMetadataStore(sydent)
 
     @jsonwrap
-    def render_POST(self, request: Request) -> dict:
+    def render_POST(self, request: Request) -> JsonDict:
         peerCert = request.transport.getPeerCertificate()
         peerCertCn = peerCert.get_subject().commonName
 

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 import twisted.python.log
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.db.hashing_metadata import HashingMetadataStore
 from sydent.db.peers import PeerStore
@@ -28,8 +29,6 @@ from sydent.util import json_decoder
 from sydent.util.hash import sha256_and_url_safe_base64
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -41,7 +40,7 @@ class ReplicationPushServlet(Resource):
         self.hashing_store = HashingMetadataStore(sydent)
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> dict:
+    def render_POST(self, request: Request) -> dict:
         peerCert = request.transport.getPeerCertificate()
         peerCertCn = peerCert.get_subject().commonName
 

--- a/sydent/http/servlets/replication.py
+++ b/sydent/http/servlets/replication.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+from typing import TYPE_CHECKING
 
 import twisted.python.log
 from twisted.web.resource import Resource
@@ -26,22 +27,21 @@ from sydent.threepid import threePidAssocFromDict
 from sydent.util import json_decoder
 from sydent.util.hash import sha256_and_url_safe_base64
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
 
 
 class ReplicationPushServlet(Resource):
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
         self.hashing_store = HashingMetadataStore(sydent)
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> dict:
+    def render_POST(self, request: "Request") -> dict:
         peerCert = request.transport.getPeerCertificate()
         peerCertCn = peerCert.get_subject().commonName
 

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -17,6 +17,8 @@ import string
 from email.header import Header
 from typing import TYPE_CHECKING
 
+from sydent.types import JsonDict
+
 import nacl.signing
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -40,7 +42,7 @@ class StoreInviteServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: Request) -> dict:
+    def render_POST(self, request: Request) -> JsonDict:
         send_cors(request)
 
         args = get_args(

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -17,8 +17,6 @@ import string
 from email.header import Header
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 import nacl.signing
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -28,6 +26,7 @@ from sydent.db.invite_tokens import JoinTokenStore
 from sydent.db.threepid_associations import GlobalAssociationStore
 from sydent.http.auth import authV2
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
+from sydent.types import JsonDict
 from sydent.util.emailutils import sendEmail
 from sydent.util.stringutils import MAX_EMAIL_ADDRESS_LENGTH
 

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -15,6 +15,7 @@
 import random
 import string
 from email.header import Header
+from typing import TYPE_CHECKING
 
 import nacl.signing
 from twisted.web.resource import Resource
@@ -27,21 +28,20 @@ from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 from sydent.util.emailutils import sendEmail
 from sydent.util.stringutils import MAX_EMAIL_ADDRESS_LENGTH
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 
 class StoreInviteServlet(Resource):
-    def __init__(self, syd: 'Sydent', require_auth: bool =False) -> None:
+    def __init__(self, syd: "Sydent", require_auth: bool = False) -> None:
         self.sydent = syd
         self.random = random.SystemRandom()
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> dict:
+    def render_POST(self, request: "Request") -> dict:
         send_cors(request)
 
         args = get_args(

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -27,15 +27,21 @@ from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 from sydent.util.emailutils import sendEmail
 from sydent.util.stringutils import MAX_EMAIL_ADDRESS_LENGTH
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 
 class StoreInviteServlet(Resource):
-    def __init__(self, syd, require_auth=False):
+    def __init__(self, syd: 'Sydent', require_auth: bool =False) -> None:
         self.sydent = syd
         self.random = random.SystemRandom()
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> dict:
         send_cors(request)
 
         args = get_args(
@@ -176,7 +182,7 @@ class StoreInviteServlet(Resource):
 
         return resp
 
-    def redact_email_address(self, address):
+    def redact_email_address(self, address: str) -> str:
         """
         Redacts the content of a 3PID address. Redacts both the email's username and
         domain independently.
@@ -198,7 +204,7 @@ class StoreInviteServlet(Resource):
 
         return redacted_username + "@" + redacted_domain
 
-    def _redact(self, s, characters_to_reveal):
+    def _redact(self, s: str, characters_to_reveal: int) -> str:
         """
         Redacts the content of a string, using a given amount of characters to reveal.
         If the string is shorter than the given threshold, redact it based on length.
@@ -224,7 +230,7 @@ class StoreInviteServlet(Resource):
         # Otherwise truncate it and add an ellipses
         return s[:characters_to_reveal] + "..."
 
-    def _randomString(self, length):
+    def _randomString(self, length: int) -> str:
         """
         Generate a random string of the given length.
 

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 import nacl.signing
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 from unpaddedbase64 import encode_base64
 
 from sydent.db.invite_tokens import JoinTokenStore
@@ -29,8 +30,6 @@ from sydent.util.emailutils import sendEmail
 from sydent.util.stringutils import MAX_EMAIL_ADDRESS_LENGTH
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 
@@ -41,7 +40,7 @@ class StoreInviteServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> dict:
+    def render_POST(self, request: Request) -> dict:
         send_cors(request)
 
         args = get_args(

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
+
+from sydent.types import JsonDict
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -37,7 +39,7 @@ class TermsServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: Request) -> Dict[str, dict]:
+    def render_GET(self, request: Request) -> JsonDict:
         """
         Get the terms that must be agreed to in order to use this service
         Returns: Object describing the terms that require agreement
@@ -49,7 +51,7 @@ class TermsServlet(Resource):
         return terms.getForClient()
 
     @jsonwrap
-    def render_POST(self, request: Request) -> dict:
+    def render_POST(self, request: Request) -> JsonDict:
         """
         Mark a set of terms and conditions as having been agreed to
         """

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -16,6 +16,7 @@ import logging
 from typing import TYPE_CHECKING, Dict
 
 from twisted.web.resource import Resource
+ from twisted.web.server import Request
 
 from sydent.db.accounts import AccountStore
 from sydent.db.terms import TermsStore
@@ -24,8 +25,6 @@ from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 from sydent.terms.terms import get_terms
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -38,7 +37,7 @@ class TermsServlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: "Request") -> Dict[str, dict]:
+    def render_GET(self, request: Request) -> Dict[str, dict]:
         """
         Get the terms that must be agreed to in order to use this service
         Returns: Object describing the terms that require agreement
@@ -50,7 +49,7 @@ class TermsServlet(Resource):
         return terms.getForClient()
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> dict:
+    def render_POST(self, request: Request) -> dict:
         """
         Mark a set of terms and conditions as having been agreed to
         """
@@ -80,6 +79,6 @@ class TermsServlet(Resource):
 
         return {}
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -15,8 +15,6 @@
 import logging
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
@@ -25,6 +23,7 @@ from sydent.db.terms import TermsStore
 from sydent.http.auth import authV2
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 from sydent.terms.terms import get_terms
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -16,7 +16,7 @@ import logging
 from typing import TYPE_CHECKING, Dict
 
 from twisted.web.resource import Resource
- from twisted.web.server import Request
+from twisted.web.server import Request
 
 from sydent.db.accounts import AccountStore
 from sydent.db.terms import TermsStore

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING, Dict
 
 from twisted.web.resource import Resource
 
@@ -22,10 +23,9 @@ from sydent.http.auth import authV2
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 from sydent.terms.terms import get_terms
 
-from typing import TYPE_CHECKING, Dict
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -34,11 +34,11 @@ logger = logging.getLogger(__name__)
 class TermsServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: 'Request') -> Dict[str, dict]:
+    def render_GET(self, request: "Request") -> Dict[str, dict]:
         """
         Get the terms that must be agreed to in order to use this service
         Returns: Object describing the terms that require agreement
@@ -50,7 +50,7 @@ class TermsServlet(Resource):
         return terms.getForClient()
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> dict:
+    def render_POST(self, request: "Request") -> dict:
         """
         Mark a set of terms and conditions as having been agreed to
         """
@@ -80,6 +80,6 @@ class TermsServlet(Resource):
 
         return {}
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/termsservlet.py
+++ b/sydent/http/servlets/termsservlet.py
@@ -22,17 +22,23 @@ from sydent.http.auth import authV2
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
 from sydent.terms.terms import get_terms
 
+from typing import TYPE_CHECKING, Dict
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
 class TermsServlet(Resource):
     isLeaf = True
 
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request') -> Dict[str, dict]:
         """
         Get the terms that must be agreed to in order to use this service
         Returns: Object describing the terms that require agreement
@@ -44,7 +50,7 @@ class TermsServlet(Resource):
         return terms.getForClient()
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> dict:
         """
         Mark a set of terms and conditions as having been agreed to
         """
@@ -74,6 +80,6 @@ class TermsServlet(Resource):
 
         return {}
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -26,14 +26,20 @@ from sydent.validators import (
     SessionNotValidatedException,
 )
 
+from typing import TYPE_CHECKING, Dict, Any
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 
 class ThreePidBindServlet(Resource):
-    def __init__(self, sydent, require_auth=False):
+    def __init__(self, sydent: 'Sydent', require_auth: bool =False) -> None:
         self.sydent = sydent
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request):
+    def render_POST(self, request: 'Request') -> Dict[str, Any]:
         send_cors(request)
 
         account = None
@@ -88,6 +94,6 @@ class ThreePidBindServlet(Resource):
         res = self.sydent.threepidBinder.addBinding(s.medium, s.address, mxid)
         return res
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -15,14 +15,13 @@
 
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.http.auth import authV2
 from sydent.http.servlets import MatrixRestError, get_args, jsonwrap, send_cors
+from sydent.types import JsonDict
 from sydent.util.stringutils import is_valid_client_secret
 from sydent.validators import (
     IncorrectClientSecretException,

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -16,6 +16,7 @@
 from typing import TYPE_CHECKING, Any, Dict
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.http.auth import authV2
@@ -29,8 +30,6 @@ from sydent.validators import (
 )
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 
@@ -40,7 +39,7 @@ class ThreePidBindServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: "Request") -> Dict[str, Any]:
+    def render_POST(self, request: Request) -> Dict[str, Any]:
         send_cors(request)
 
         account = None
@@ -95,6 +94,6 @@ class ThreePidBindServlet(Resource):
         res = self.sydent.threepidBinder.addBinding(s.medium, s.address, mxid)
         return res
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING, Any, Dict
+
 from twisted.web.resource import Resource
 
 from sydent.db.valsession import ThreePidValSessionStore
@@ -26,20 +28,19 @@ from sydent.validators import (
     SessionNotValidatedException,
 )
 
-from typing import TYPE_CHECKING, Dict, Any
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 
 class ThreePidBindServlet(Resource):
-    def __init__(self, sydent: 'Sydent', require_auth: bool =False) -> None:
+    def __init__(self, sydent: "Sydent", require_auth: bool = False) -> None:
         self.sydent = sydent
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: 'Request') -> Dict[str, Any]:
+    def render_POST(self, request: "Request") -> Dict[str, Any]:
         send_cors(request)
 
         account = None
@@ -94,6 +95,6 @@ class ThreePidBindServlet(Resource):
         res = self.sydent.threepidBinder.addBinding(s.medium, s.address, mxid)
         return res
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/threepidbindservlet.py
+++ b/sydent/http/servlets/threepidbindservlet.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING
+
+from sydent.types import JsonDict
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request
@@ -39,7 +41,7 @@ class ThreePidBindServlet(Resource):
         self.require_auth = require_auth
 
     @jsonwrap
-    def render_POST(self, request: Request) -> Dict[str, Any]:
+    def render_POST(self, request: Request) -> JsonDict:
         send_cors(request)
 
         account = None

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -31,19 +31,25 @@ from sydent.validators import (
     SessionNotValidatedException,
 )
 
+from typing import TYPE_CHECKING, Generator, Any
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 logger = logging.getLogger(__name__)
 
 
 class ThreePidUnbindServlet(Resource):
-    def __init__(self, sydent):
+    def __init__(self, sydent: 'Sydent') -> None:
         self.sydent = sydent
 
-    def render_POST(self, request):
-        self._async_render_POST(request)
+    def render_POST(self, request: 'Request') -> Any: #from the twisted docs: @type NOT_DONE_YET:
+        self._async_render_POST(request)              #Opaque; do not depend on any particular type for this                                                    #value.
         return server.NOT_DONE_YET
 
     @defer.inlineCallbacks
-    def _async_render_POST(self, request):
+    def _async_render_POST(self, request: 'Request') -> Generator:
         try:
             try:
                 # json.loads doesn't allow bytes in Python 3.5

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING, Generator
 
 from signedjson.sign import SignatureVerifyException
 from twisted.internet import defer
@@ -45,10 +45,10 @@ class ThreePidUnbindServlet(Resource):
 
     def render_POST(
         self, request: Request
-    ) -> Any:  # from the twisted docs: @type NOT_DONE_YET:
+    ) -> int:  # from the twisted docs: @type NOT_DONE_YET:
         self._async_render_POST(
             request
-        )  # Opaque; do not depend on any particular type for this                                                    #value.
+        )
         return server.NOT_DONE_YET
 
     @defer.inlineCallbacks

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING, Any, Generator
 
 from signedjson.sign import SignatureVerifyException
 from twisted.internet import defer
@@ -31,25 +32,28 @@ from sydent.validators import (
     SessionNotValidatedException,
 )
 
-from typing import TYPE_CHECKING, Generator, Any
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
 
 
 class ThreePidUnbindServlet(Resource):
-    def __init__(self, sydent: 'Sydent') -> None:
+    def __init__(self, sydent: "Sydent") -> None:
         self.sydent = sydent
 
-    def render_POST(self, request: 'Request') -> Any: #from the twisted docs: @type NOT_DONE_YET:
-        self._async_render_POST(request)              #Opaque; do not depend on any particular type for this                                                    #value.
+    def render_POST(
+        self, request: "Request"
+    ) -> Any:  # from the twisted docs: @type NOT_DONE_YET:
+        self._async_render_POST(
+            request
+        )  # Opaque; do not depend on any particular type for this                                                    #value.
         return server.NOT_DONE_YET
 
     @defer.inlineCallbacks
-    def _async_render_POST(self, request: 'Request') -> Generator:
+    def _async_render_POST(self, request: "Request") -> Generator:
         try:
             try:
                 # json.loads doesn't allow bytes in Python 3.5

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -20,6 +20,7 @@ from signedjson.sign import SignatureVerifyException
 from twisted.internet import defer
 from twisted.web import server
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.hs_federation.verifier import InvalidServerName, NoAuthenticationError
@@ -33,8 +34,6 @@ from sydent.validators import (
 )
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 logger = logging.getLogger(__name__)
@@ -45,7 +44,7 @@ class ThreePidUnbindServlet(Resource):
         self.sydent = sydent
 
     def render_POST(
-        self, request: "Request"
+        self, request: Request
     ) -> Any:  # from the twisted docs: @type NOT_DONE_YET:
         self._async_render_POST(
             request
@@ -53,7 +52,7 @@ class ThreePidUnbindServlet(Resource):
         return server.NOT_DONE_YET
 
     @defer.inlineCallbacks
-    def _async_render_POST(self, request: "Request") -> Generator:
+    def _async_render_POST(self, request: Request) -> Generator:
         try:
             try:
                 # json.loads doesn't allow bytes in Python 3.5

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, Generator
+from typing import TYPE_CHECKING
 
 from signedjson.sign import SignatureVerifyException
 from twisted.internet import defer
@@ -45,7 +45,7 @@ class ThreePidUnbindServlet(Resource):
 
     def render_POST(
         self, request: Request
-    ) -> int: # from the twisted docs: @type NOT_DONE_YET:
+    ) -> int:  # from the twisted docs: @type NOT_DONE_YET:
         defer.ensureDeferred(self._async_render_POST(request))
         return server.NOT_DONE_YET
 

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -46,9 +46,7 @@ class ThreePidUnbindServlet(Resource):
     def render_POST(
         self, request: Request
     ) -> int:  # from the twisted docs: @type NOT_DONE_YET:
-        self._async_render_POST(
-            request
-        )
+        self._async_render_POST(request)
         return server.NOT_DONE_YET
 
     @defer.inlineCallbacks

--- a/sydent/http/servlets/v1_servlet.py
+++ b/sydent/http/servlets/v1_servlet.py
@@ -17,19 +17,25 @@ from twisted.web.resource import Resource
 
 from sydent.http.servlets import jsonwrap, send_cors
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 
 class V1Servlet(Resource):
     isLeaf = False
 
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         Resource.__init__(self)
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request') -> dict:
         send_cors(request)
         return {}
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/v1_servlet.py
+++ b/sydent/http/servlets/v1_servlet.py
@@ -16,12 +16,11 @@
 from typing import TYPE_CHECKING
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.http.servlets import jsonwrap, send_cors
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 
@@ -33,10 +32,10 @@ class V1Servlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: "Request") -> dict:
+    def render_GET(self, request: Request) -> dict:
         send_cors(request)
         return {}
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/v1_servlet.py
+++ b/sydent/http/servlets/v1_servlet.py
@@ -15,12 +15,11 @@
 
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.http.servlets import jsonwrap, send_cors
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/http/servlets/v1_servlet.py
+++ b/sydent/http/servlets/v1_servlet.py
@@ -15,6 +15,8 @@
 
 from typing import TYPE_CHECKING
 
+from sydent.types import JsonDict
+
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
@@ -32,7 +34,7 @@ class V1Servlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: Request) -> dict:
+    def render_GET(self, request: Request) -> JsonDict:
         send_cors(request)
         return {}
 

--- a/sydent/http/servlets/v1_servlet.py
+++ b/sydent/http/servlets/v1_servlet.py
@@ -13,29 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING
+
 from twisted.web.resource import Resource
 
 from sydent.http.servlets import jsonwrap, send_cors
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 
 class V1Servlet(Resource):
     isLeaf = False
 
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         Resource.__init__(self)
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: 'Request') -> dict:
+    def render_GET(self, request: "Request") -> dict:
         send_cors(request)
         return {}
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/v2_servlet.py
+++ b/sydent/http/servlets/v2_servlet.py
@@ -16,19 +16,25 @@ from twisted.web.resource import Resource
 
 from sydent.http.servlets import jsonwrap, send_cors
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from twisted.web.server import Request
+    from sydent.sydent import Sydent
+
 
 class V2Servlet(Resource):
     isLeaf = False
 
-    def __init__(self, syd):
+    def __init__(self, syd: 'Sydent') -> None:
         Resource.__init__(self)
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request):
+    def render_GET(self, request: 'Request') -> dict:
         send_cors(request)
         return {}
 
-    def render_OPTIONS(self, request):
+    def render_OPTIONS(self, request: 'Request') -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/v2_servlet.py
+++ b/sydent/http/servlets/v2_servlet.py
@@ -12,29 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING
+
 from twisted.web.resource import Resource
 
 from sydent.http.servlets import jsonwrap, send_cors
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from twisted.web.server import Request
+
     from sydent.sydent import Sydent
 
 
 class V2Servlet(Resource):
     isLeaf = False
 
-    def __init__(self, syd: 'Sydent') -> None:
+    def __init__(self, syd: "Sydent") -> None:
         Resource.__init__(self)
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: 'Request') -> dict:
+    def render_GET(self, request: "Request") -> dict:
         send_cors(request)
         return {}
 
-    def render_OPTIONS(self, request: 'Request') -> bytes:
+    def render_OPTIONS(self, request: "Request") -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/v2_servlet.py
+++ b/sydent/http/servlets/v2_servlet.py
@@ -14,6 +14,8 @@
 
 from typing import TYPE_CHECKING
 
+from sydent.types import JsonDict
+
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
@@ -31,7 +33,7 @@ class V2Servlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: Request) -> dict:
+    def render_GET(self, request: Request) -> JsonDict:
         send_cors(request)
         return {}
 

--- a/sydent/http/servlets/v2_servlet.py
+++ b/sydent/http/servlets/v2_servlet.py
@@ -15,12 +15,11 @@
 from typing import TYPE_CHECKING
 
 from twisted.web.resource import Resource
+from twisted.web.server import Request
 
 from sydent.http.servlets import jsonwrap, send_cors
 
 if TYPE_CHECKING:
-    from twisted.web.server import Request
-
     from sydent.sydent import Sydent
 
 
@@ -32,10 +31,10 @@ class V2Servlet(Resource):
         self.sydent = syd
 
     @jsonwrap
-    def render_GET(self, request: "Request") -> dict:
+    def render_GET(self, request: Request) -> dict:
         send_cors(request)
         return {}
 
-    def render_OPTIONS(self, request: "Request") -> bytes:
+    def render_OPTIONS(self, request: Request) -> bytes:
         send_cors(request)
         return b""

--- a/sydent/http/servlets/v2_servlet.py
+++ b/sydent/http/servlets/v2_servlet.py
@@ -14,12 +14,11 @@
 
 from typing import TYPE_CHECKING
 
-from sydent.types import JsonDict
-
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.http.servlets import jsonwrap, send_cors
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent

--- a/sydent/types.py
+++ b/sydent/types.py
@@ -1,0 +1,3 @@
+from typing import Dict, Any
+
+JsonDict = Dict[str, Any]

--- a/sydent/types.py
+++ b/sydent/types.py
@@ -1,3 +1,3 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 JsonDict = Dict[str, Any]

--- a/sydent/types.py
+++ b/sydent/types.py
@@ -1,3 +1,17 @@
+# Copyright 2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict
 
 JsonDict = Dict[str, Any]

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -20,7 +20,7 @@ import socket
 import string
 import urllib
 from html import escape
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Dict
 
 import twisted.python.log
 
@@ -120,9 +120,7 @@ def sendEmail(
         smtp.quit()
     except Exception as origException:
         twisted.python.log.err()
-        ese = EmailSendException()
-        ese.cause = origException
-        raise ese
+        raise EmailSendException() from origException
 
 
 class EmailAddressException(Exception):
@@ -130,5 +128,4 @@ class EmailAddressException(Exception):
 
 
 class EmailSendException(Exception):
-    cause: Any  # type hint added to prevent ""EmailSendException" has no attribute "cause"" error in Mypy
     pass


### PR DESCRIPTION

This PR request adds type hints to sydent/http/servlets. There were very few docstrings/comments so I did my best to figure out what the types were and add them. 