### PR TITLE
Convert inline callbacks to async/await

### DIFF
--- a/changelog.d/368.misc
+++ b/changelog.d/368.misc
@@ -1,0 +1,1 @@
+Convert inlineCallbacks to async/await.

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -81,9 +81,9 @@ class Verifier:
                 return self.cache[server_name]["verify_keys"]
 
         client = FederationHttpClient(self.sydent)
-        result = yield client.get_json(
+        result = yield defer.ensureDeffered(client.get_json(
             "matrix://%s/_matrix/key/v2/server/" % server_name, 1024 * 50
-        )
+        ))
 
         if "verify_keys" not in result:
             raise SignatureVerifyException("No key found in response")

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -14,12 +14,11 @@
 
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import signedjson.key  # type: ignore
 import signedjson.sign  # type: ignore
 from signedjson.sign import SignatureVerifyException
-from twisted.internet import defer
 from twisted.web.server import Request
 from unpaddedbase64 import decode_base64
 
@@ -165,9 +164,7 @@ class Verifier:
         )
         raise SignatureVerifyException("No matching signature found")
 
-    async def authenticate_request(
-        self, request: "Request", content: Optional[bytes]
-    ):
+    async def authenticate_request(self, request: "Request", content: Optional[bytes]):
         """Authenticates a Matrix federation request based on the X-Matrix header
         XXX: Copied largely from synapse
 

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -41,8 +41,7 @@ class HTTPClient:
 
     agent: IAgent
 
-    @defer.inlineCallbacks
-    def get_json(self, uri: str, max_size: Optional[int] = None) -> Generator:
+    async def get_json(self, uri: str, max_size: Optional[int] = None) -> Generator:
         """Make a GET request to an endpoint returning JSON and parse result
 
         :param uri: The URI to make a GET request to.
@@ -56,11 +55,11 @@ class HTTPClient:
         """
         logger.debug("HTTP GET %s", uri)
 
-        response = yield self.agent.request(
+        response = await self.agent.request(
             b"GET",
             uri.encode("utf8"),
         )
-        body = yield read_body_with_max_size(response, max_size)
+        body = await read_body_with_max_size(response, max_size)
         try:
             # json.loads doesn't allow bytes in Python 3.5
             json_body = json_decoder.decode(body.decode("UTF-8"))

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -15,9 +15,8 @@
 import json
 import logging
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Dict, Generator, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from twisted.internet import defer
 from twisted.web.client import Agent, FileBodyProducer
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IAgent

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -41,7 +41,7 @@ class HTTPClient:
 
     agent: IAgent
 
-    async def get_json(self, uri: str, max_size: Optional[int] = None) -> Generator:
+    async def get_json(self, uri: str, max_size: Optional[int] = None):
         """Make a GET request to an endpoint returning JSON and parse result
 
         :param uri: The URI to make a GET request to.
@@ -70,7 +70,7 @@ class HTTPClient:
 
     async def post_json_get_nothing(
         self, uri: str, post_json: Dict[Any, Any], opts: Dict[str, Any]
-    ) -> Generator:
+    ):
         """Make a POST request to an endpoint returning JSON and parse result
 
         :param uri: The URI to make a POST request to.

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -69,8 +69,7 @@ class HTTPClient:
             raise
         return json_body
 
-    @defer.inlineCallbacks
-    def post_json_get_nothing(
+    async def post_json_get_nothing(
         self, uri: str, post_json: Dict[Any, Any], opts: Dict[str, Any]
     ) -> Generator:
         """Make a POST request to an endpoint returning JSON and parse result
@@ -102,7 +101,7 @@ class HTTPClient:
 
         logger.debug("HTTP POST %s -> %s", json_bytes, uri)
 
-        response = yield self.agent.request(
+        response = await self.agent.request(
             b"POST",
             uri.encode("utf8"),
             headers,
@@ -114,7 +113,7 @@ class HTTPClient:
         # https://twistedmatrix.com/documents/current/web/howto/client.html
         try:
             # TODO Will this cause the server to think the request was a failure?
-            yield read_body_with_max_size(response, 0)
+            await read_body_with_max_size(response, 0)
         except BodyExceededMaxSize:
             pass
 

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -19,7 +19,6 @@ from typing import Generator, Optional
 
 import attr
 from netaddr import IPAddress  # type: ignore
-from twisted.internet import defer
 from twisted.internet.endpoints import HostnameEndpoint, wrapClientTLS
 from twisted.internet.interfaces import IStreamClientEndpoint
 from twisted.web.client import URI, Agent, HTTPConnectionPool, RedirectAgent

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -57,14 +57,14 @@ class RegisterServlet(Resource):
                 "error": "matrix_server_name must be a valid Matrix server name (IP address or hostname)",
             }
 
-        result = yield self.client.get_json(
+        result = yield defer.ensureDeferred(self.client.get_json(
             "matrix://%s/_matrix/federation/v1/openid/userinfo?access_token=%s"
             % (
                 matrix_server,
                 urllib.parse.quote(args["access_token"]),
             ),
             1024 * 5,
-        )
+        ))
 
         if "sub" not in result:
             raise Exception("Invalid response from homeserver")

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -57,14 +57,16 @@ class RegisterServlet(Resource):
                 "error": "matrix_server_name must be a valid Matrix server name (IP address or hostname)",
             }
 
-        result = yield defer.ensureDeferred(self.client.get_json(
-            "matrix://%s/_matrix/federation/v1/openid/userinfo?access_token=%s"
-            % (
-                matrix_server,
-                urllib.parse.quote(args["access_token"]),
-            ),
-            1024 * 5,
-        ))
+        result = yield defer.ensureDeferred(
+            self.client.get_json(
+                "matrix://%s/_matrix/federation/v1/openid/userinfo?access_token=%s"
+                % (
+                    matrix_server,
+                    urllib.parse.quote(args["access_token"]),
+                ),
+                1024 * 5,
+            )
+        )
 
         if "sub" not in result:
             raise Exception("Invalid response from homeserver")

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -109,7 +109,7 @@ class ThreepidBinder:
         signer = Signer(self.sydent)
         sgassoc = signer.signedThreePidAssociation(assoc)
 
-        self._notify(sgassoc, 0)
+        defer.ensureDeferred(self._notify(sgassoc, 0))
 
         return sgassoc
 
@@ -126,8 +126,7 @@ class ThreepidBinder:
         localAssocStore.removeAssociation(threepid, mxid)
         self.sydent.pusher.doLocalPush()
 
-    @defer.inlineCallbacks
-    def _notify(self, assoc: Dict[str, Any], attempt: int) -> Generator:
+    async def _notify(self, assoc: Dict[str, Any], attempt: int) -> Generator:
         """
         Sends data about a new association (and, if necessary, the associated invites)
         to the associated MXID's homeserver.
@@ -163,7 +162,7 @@ class ThreepidBinder:
         # Make a POST to the chosen Synapse server
         http_client = FederationHttpClient(self.sydent)
         try:
-            response = yield http_client.post_json_get_nothing(post_url, assoc, {})
+            response = await http_client.post_json_get_nothing(post_url, assoc, {})
         except Exception as e:
             self._notifyErrback(assoc, attempt, e)
             return

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -109,7 +109,7 @@ class ThreepidBinder:
         signer = Signer(self.sydent)
         sgassoc = signer.signedThreePidAssociation(assoc)
 
-        defer.ensureDeferred(self._notify(sgassoc, 0))
+        self._notify(sgassoc, 0)
 
         return sgassoc
 
@@ -126,7 +126,8 @@ class ThreepidBinder:
         localAssocStore.removeAssociation(threepid, mxid)
         self.sydent.pusher.doLocalPush()
 
-    async def _notify(self, assoc: Dict[str, Any], attempt: int) -> Generator:
+    @defer.inlineCallbacks
+    def _notify(self, assoc: Dict[str, Any], attempt: int) -> Generator:
         """
         Sends data about a new association (and, if necessary, the associated invites)
         to the associated MXID's homeserver.
@@ -162,7 +163,7 @@ class ThreepidBinder:
         # Make a POST to the chosen Synapse server
         http_client = FederationHttpClient(self.sydent)
         try:
-            response = await http_client.post_json_get_nothing(post_url, assoc, {})
+            response = yield http_client.post_json_get_nothing(post_url, assoc, {})
         except Exception as e:
             self._notifyErrback(assoc, attempt, e)
             return

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -122,7 +122,7 @@ class ThreepidInvitesNoDeleteTestCase(unittest.TestCase):
         def post_json_get_nothing(uri, post_json, opts):
             return Response((b"HTTP", 1, 1), 200, b"OK", None, None)
 
-        FederationHttpClient.post_json_get_nothing = Mock(
+        FederationHttpClient.post_json_get_nothing = AsyncMock(
             side_effect=post_json_get_nothing,
         )
 

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -6,7 +6,7 @@ from twisted.web.client import Response
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.httpclient import FederationHttpClient
 from sydent.http.servlets.store_invite_servlet import StoreInviteServlet
-from tests.utils import make_sydent
+from tests.utils import make_sydent, AsyncMock
 
 
 class ThreepidInvitesTestCase(unittest.TestCase):
@@ -37,7 +37,7 @@ class ThreepidInvitesTestCase(unittest.TestCase):
         def post_json_get_nothing(uri, post_json, opts):
             return Response((b"HTTP", 1, 1), 200, b"OK", None, None)
 
-        FederationHttpClient.post_json_get_nothing = Mock(
+        FederationHttpClient.post_json_get_nothing = AsyncMock(
             side_effect=post_json_get_nothing,
         )
 

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from twisted.trial import unittest
 from twisted.web.client import Response
 
@@ -32,10 +34,10 @@ class ThreepidInvitesTestCase(unittest.TestCase):
         address = "john@example.com"
 
         # Mock post_json_get_nothing so the /onBind call doesn't fail.
-        def post_json_get_nothing(uri, post_json, opts):
+        async def post_json_get_nothing(uri, post_json, opts):
             return Response((b"HTTP", 1, 1), 200, b"OK", None, None)
 
-        FederationHttpClient.post_json_get_nothing = AsyncMock(
+        FederationHttpClient.post_json_get_nothing = Mock(
             side_effect=post_json_get_nothing,
         )
 
@@ -117,10 +119,10 @@ class ThreepidInvitesNoDeleteTestCase(unittest.TestCase):
         address = "john@example.com"
 
         # Mock post_json_get_nothing so the /onBind call doesn't fail.
-        def post_json_get_nothing(uri, post_json, opts):
+        async def post_json_get_nothing(uri, post_json, opts):
             return Response((b"HTTP", 1, 1), 200, b"OK", None, None)
 
-        FederationHttpClient.post_json_get_nothing = AsyncMock(
+        FederationHttpClient.post_json_get_nothing = Mock(
             side_effect=post_json_get_nothing,
         )
 

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -6,7 +6,7 @@ from twisted.web.client import Response
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.httpclient import FederationHttpClient
 from sydent.http.servlets.store_invite_servlet import StoreInviteServlet
-from tests.utils import AsyncMock, make_sydent
+from tests.utils import make_sydent
 
 
 class ThreepidInvitesTestCase(unittest.TestCase):

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -1,12 +1,10 @@
-from unittest.mock import Mock
-
 from twisted.trial import unittest
 from twisted.web.client import Response
 
 from sydent.db.invite_tokens import JoinTokenStore
 from sydent.http.httpclient import FederationHttpClient
 from sydent.http.servlets.store_invite_servlet import StoreInviteServlet
-from tests.utils import make_sydent, AsyncMock
+from tests.utils import AsyncMock, make_sydent
 
 
 class ThreepidInvitesTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR converts some files in sydent to use async/await. I removed the references to the return type `Generator` in the affected functions but didn't add the new return types, I figured that should go in a seprate PR to ease review.  