### PR TITLE
Replace mock with unittest.mock. Resolves #359

### DIFF
--- a/changelog.d/370.misc
+++ b/changelog.d/370.misc
@@ -1,0 +1,1 @@
+Replace mock with unittest.mock

--- a/changelog.d/370.misc
+++ b/changelog.d/370.misc
@@ -1,1 +1,1 @@
-Replace mock with unittest.mock
+Use `mock` module from the standard library.

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "netaddr>=0.7.0",
         "sortedcontainers>=2.1.0",
         "pyyaml>=3.11",
-        "mock>=3.0.5",
         "flake8==3.9.2",
         "black==21.5b1",
         "isort==5.8.0",

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -1,6 +1,6 @@
 import json
+from unittest.mock import Mock
 
-from mock import Mock
 from twisted.internet import defer
 from twisted.trial import unittest
 from twisted.web.client import Response


### PR DESCRIPTION

 This PR removes mock from setup.py and imports mock from unittest instead. 