### PR TITLE
Update return types of converted async/await functions

### DIFF
--- a/changelog.d/371.misc
+++ b/changelog.d/371.misc
@@ -1,0 +1,1 @@
+Update return types on converted async functions.

--- a/changelog.d/371.misc
+++ b/changelog.d/371.misc
@@ -1,1 +1,1 @@
-Update return types on converted async functions.
+Add type hints and validate with mypy.

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -160,7 +160,9 @@ class Verifier:
         )
         raise SignatureVerifyException("No matching signature found")
 
-    async def authenticate_request(self, request: "Request", content: Optional[bytes]) -> str:
+    async def authenticate_request(
+        self, request: "Request", content: Optional[bytes]
+    ) -> str:
         """Authenticates a Matrix federation request based on the X-Matrix header
         XXX: Copied largely from synapse
 

--- a/sydent/hs_federation/verifier.py
+++ b/sydent/hs_federation/verifier.py
@@ -62,13 +62,12 @@ class Verifier:
             # server_name: <result from keys query>,
         }
 
-    async def _getKeysForServer(self, server_name: str):
+    async def _getKeysForServer(self, server_name: str) -> Dict[str, Dict[str, str]]:
         """Get the signing key data from a homeserver.
 
         :param server_name: The name of the server to request the keys from.
 
         :return: The verification keys returned by the server.
-        :rtype: twisted.internet.defer.Deferred[dict[unicode, dict[unicode, unicode]]]
         """
 
         if server_name in self.cache:
@@ -107,7 +106,7 @@ class Verifier:
         self,
         signed_json: Dict[str, Any],
         acceptable_server_names: Optional[List[str]] = None,
-    ):
+    ) -> Tuple[str, str]:
         """Given a signed json object, try to verify any one
         of the signatures on it
 
@@ -121,7 +120,6 @@ class Verifier:
 
         :return a tuple of the server name and key name that was
         successfully verified.
-        :rtype: twisted.internet.defer.Deferred[tuple[unicode]]
 
         :raise SignatureVerifyException: The json cannot be verified.
         """
@@ -162,7 +160,7 @@ class Verifier:
         )
         raise SignatureVerifyException("No matching signature found")
 
-    async def authenticate_request(self, request: "Request", content: Optional[bytes]):
+    async def authenticate_request(self, request: "Request", content: Optional[bytes]) -> str:
         """Authenticates a Matrix federation request based on the X-Matrix header
         XXX: Copied largely from synapse
 
@@ -170,7 +168,6 @@ class Verifier:
         :param content: The content of the request, if any
 
         :return: The origin of the server whose signature was validated
-        :rtype: twisted.internet.defer.Deferred[unicode]
         """
         json_request = {
             "method": request.method,

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -17,8 +17,6 @@ import logging
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from sydent.types import JsonDict
-
 from twisted.web.client import Agent, FileBodyProducer
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IAgent, IResponse
@@ -27,6 +25,7 @@ from sydent.http.blacklisting_reactor import BlacklistingReactorWrapper
 from sydent.http.federation_tls_options import ClientTLSOptionsFactory
 from sydent.http.httpcommon import BodyExceededMaxSize, read_body_with_max_size
 from sydent.http.matrixfederationagent import MatrixFederationAgent
+from sydent.types import JsonDict
 from sydent.util import json_decoder
 
 if TYPE_CHECKING:

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -17,9 +17,11 @@ import logging
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from sydent.types import JsonDict
+
 from twisted.web.client import Agent, FileBodyProducer
 from twisted.web.http_headers import Headers
-from twisted.web.iweb import IAgent
+from twisted.web.iweb import IAgent, IResponse
 
 from sydent.http.blacklisting_reactor import BlacklistingReactorWrapper
 from sydent.http.federation_tls_options import ClientTLSOptionsFactory
@@ -40,7 +42,7 @@ class HTTPClient:
 
     agent: IAgent
 
-    async def get_json(self, uri: str, max_size: Optional[int] = None):
+    async def get_json(self, uri: str, max_size: Optional[int] = None) -> JsonDict:
         """Make a GET request to an endpoint returning JSON and parse result
 
         :param uri: The URI to make a GET request to.
@@ -48,7 +50,6 @@ class HTTPClient:
         :param max_size: The maximum size (in bytes) to allow as a response.
 
         :return: A deferred containing JSON parsed into a Python object.
-        :rtype: twisted.internet.defer.Deferred[dict[any, any]]
         """
         logger.debug("HTTP GET %s", uri)
 
@@ -67,7 +68,7 @@ class HTTPClient:
 
     async def post_json_get_nothing(
         self, uri: str, post_json: Dict[Any, Any], opts: Dict[str, Any]
-    ):
+    ) -> IResponse:
         """Make a POST request to an endpoint returning JSON and parse result
 
         :param uri: The URI to make a POST request to.
@@ -79,7 +80,6 @@ class HTTPClient:
             is supported.
 
         :return: a response from the remote server.
-        :rtype: twisted.internet.defer.Deferred[twisted.web.iweb.IResponse]
         """
         json_bytes = json.dumps(post_json).encode("utf8")
 

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -15,7 +15,7 @@
 import logging
 import random
 import time
-from typing import Generator, Optional, Callable, Union, Tuple
+from typing import Optional, Tuple, Union
 
 import attr
 from netaddr import IPAddress  # type: ignore
@@ -184,7 +184,7 @@ class MatrixFederationAgent:
 
     async def _route_matrix_uri(
         self, parsed_uri: "URI", lookup_well_known: bool = True
-    ) -> '_RoutingResult':
+    ) -> "_RoutingResult":
         """Helper for `request`: determine the routing for a Matrix URI
 
         :param parsed_uri: uri to route. Note that it should be parsed with
@@ -307,7 +307,9 @@ class MatrixFederationAgent:
 
         return result
 
-    async def _do_get_well_known(self, server_name: bytes) -> Tuple[Union[bytes,None,object],int]:
+    async def _do_get_well_known(
+        self, server_name: bytes
+    ) -> Tuple[Union[bytes, None, object], int]:
         """Actually fetch and parse a .well-known, without checking the cache
 
         :param server_name: Name of the server, from the requested url

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -183,7 +183,7 @@ class MatrixFederationAgent:
 
     async def _route_matrix_uri(
         self, parsed_uri: "URI", lookup_well_known: bool = True
-    ) -> '_RoutingResult':
+    ) -> "_RoutingResult":
         """Helper for `request`: determine the routing for a Matrix URI
 
         :param parsed_uri: uri to route. Note that it should be parsed with

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -139,7 +139,6 @@ class MatrixFederationAgent:
             been received (regardless of the response status code). Fails if
             there is any problem which prevents that response from being received
             (including problems that prevent the request from being sent).
-        :rtype: Deferred[twisted.web.iweb.IResponse]
         """
         parsed_uri = URI.fromBytes(uri, defaultPort=-1)
         res = yield defer.ensureDeferred(self._route_matrix_uri(parsed_uri))
@@ -184,7 +183,7 @@ class MatrixFederationAgent:
 
     async def _route_matrix_uri(
         self, parsed_uri: "URI", lookup_well_known: bool = True
-    ) -> "_RoutingResult":
+    ) -> '_RoutingResult':
         """Helper for `request`: determine the routing for a Matrix URI
 
         :param parsed_uri: uri to route. Note that it should be parsed with

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -15,7 +15,7 @@
 import logging
 import random
 import time
-from typing import Generator, Optional
+from typing import Generator, Optional, Callable, Union, Tuple
 
 import attr
 from netaddr import IPAddress  # type: ignore
@@ -25,7 +25,7 @@ from twisted.internet.interfaces import IStreamClientEndpoint
 from twisted.web.client import URI, Agent, HTTPConnectionPool, RedirectAgent
 from twisted.web.http import stringToDatetime
 from twisted.web.http_headers import Headers
-from twisted.web.iweb import IAgent, IBodyProducer
+from twisted.web.iweb import IAgent, IBodyProducer, IResponse
 from zope.interface import implementer
 
 from sydent.http.httpcommon import read_body_with_max_size
@@ -121,7 +121,7 @@ class MatrixFederationAgent:
         uri: bytes,
         headers: Optional["Headers"] = None,
         bodyProducer: Optional["IBodyProducer"] = None,
-    ) -> Generator:
+    ) -> IResponse:
         """
         :param method: HTTP method (GET/POST/etc).
 
@@ -184,7 +184,7 @@ class MatrixFederationAgent:
 
     async def _route_matrix_uri(
         self, parsed_uri: "URI", lookup_well_known: bool = True
-    ):
+    ) -> '_RoutingResult':
         """Helper for `request`: determine the routing for a Matrix URI
 
         :param parsed_uri: uri to route. Note that it should be parsed with
@@ -194,7 +194,6 @@ class MatrixFederationAgent:
             file if there is no SRV record.
 
         :returns a routing result.
-        :rtype: Deferred[_RoutingResult]
         """
         # check for an IP literal
         try:
@@ -288,14 +287,13 @@ class MatrixFederationAgent:
             target_port=port,
         )
 
-    async def _get_well_known(self, server_name: bytes):
+    async def _get_well_known(self, server_name: bytes) -> Optional[bytes]:
         """Attempt to fetch and parse a .well-known file for the given server
 
         :param server_name: Name of the server, from the requested url.
 
         :returns either the new server name, from the .well-known, or None if
             there was no .well-known file.
-        :rtype: Deferred[bytes|None]
         """
         try:
             result = self._well_known_cache[server_name]
@@ -309,7 +307,7 @@ class MatrixFederationAgent:
 
         return result
 
-    async def _do_get_well_known(self, server_name: bytes):
+    async def _do_get_well_known(self, server_name: bytes) -> Tuple[Union[bytes,None,object],int]:
         """Actually fetch and parse a .well-known, without checking the cache
 
         :param server_name: Name of the server, from the requested url
@@ -318,7 +316,6 @@ class MatrixFederationAgent:
             - the new server name from the .well-known (as a `bytes`)
             - None if there was no .well-known file.
             - INVALID_WELL_KNOWN if the .well-known was invalid
-        :rtype: Deferred[Tuple[bytes|None|object],int]
         """
         uri = b"https://%s/.well-known/matrix/server" % (server_name,)
         uri_str = uri.decode("ascii")

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -16,7 +16,7 @@
 import collections
 import logging
 import math
-from typing import TYPE_CHECKING, Any, Dict, Generator, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Union, cast
 
 import signedjson.sign  # type: ignore
 from twisted.internet import defer

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -120,7 +120,7 @@ class ThreepidBinder:
         localAssocStore.removeAssociation(threepid, mxid)
         self.sydent.pusher.doLocalPush()
 
-    async def _notify(self, assoc: Dict[str, Any], attempt: int) -> Generator:
+    async def _notify(self, assoc: Dict[str, Any], attempt: int) -> None:
         """
         Sends data about a new association (and, if necessary, the associated invites)
         to the associated MXID's homeserver.


### PR DESCRIPTION
This PR updates the return types of functions that were converted from inlineCallbacks to async/await. 