### PR TITLE
Convert http/servlets/registerservlet.py to use async/await

### DIFF
--- a/changelog.d/372.misc
+++ b/changelog.d/372.misc
@@ -1,0 +1,1 @@
+Convert inlineCallbacks to async/await.

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -162,7 +162,7 @@ def jsonwrap(f):
     return inner
 
 
-def deferjsonwrap(f):
+def asyncjsonwrap(f):
     def reqDone(resp: Dict[str, Any], request: Request) -> None:
         """
         Converts the given response content into JSON and encodes it to bytes, then
@@ -216,7 +216,7 @@ def deferjsonwrap(f):
         """
         request = args[1]
 
-        d = defer.maybeDeferred(f, *args, **kwargs)
+        d = defer.ensureDeferred(f(*args, **kwargs))
         d.addCallback(reqDone, request)
         d.addErrback(reqErr, request)
         return server.NOT_DONE_YET

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -21,9 +21,10 @@ from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.http.httpclient import FederationHttpClient
-from sydent.http.servlets import deferjsonwrap, get_args, send_cors
+from sydent.http.servlets import asyncjsonwrap, get_args, send_cors
 from sydent.users.tokens import issueToken
 from sydent.util.stringutils import is_valid_matrix_server_name
+from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
@@ -38,9 +39,8 @@ class RegisterServlet(Resource):
         self.sydent = syd
         self.client = FederationHttpClient(self.sydent)
 
-    @deferjsonwrap
-    @defer.inlineCallbacks
-    def render_POST(self, request: Request) -> Generator:
+    @asyncjsonwrap
+    async def render_POST(self, request: Request) -> JsonDict:
         """
         Register with the Identity Server
         """
@@ -57,8 +57,7 @@ class RegisterServlet(Resource):
                 "error": "matrix_server_name must be a valid Matrix server name (IP address or hostname)",
             }
 
-        result = yield defer.ensureDeferred(
-            self.client.get_json(
+        result = await self.client.get_json(
                 "matrix://%s/_matrix/federation/v1/openid/userinfo?access_token=%s"
                 % (
                     matrix_server,
@@ -66,7 +65,6 @@ class RegisterServlet(Resource):
                 ),
                 1024 * 5,
             )
-        )
 
         if "sub" not in result:
             raise Exception("Invalid response from homeserver")
@@ -106,7 +104,7 @@ class RegisterServlet(Resource):
                 "error": "The Matrix homeserver returned a MXID belonging to another homeserver",
             }
 
-        tok = yield issueToken(self.sydent, user_id)
+        tok = issueToken(self.sydent, user_id)
 
         # XXX: `token` is correct for the spec, but we released with `access_token`
         # for a substantial amount of time. Serve both to make spec-compliant clients

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -14,17 +14,16 @@
 
 import logging
 import urllib
-from typing import TYPE_CHECKING, Generator
+from typing import TYPE_CHECKING
 
-from twisted.internet import defer
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from sydent.http.httpclient import FederationHttpClient
 from sydent.http.servlets import asyncjsonwrap, get_args, send_cors
+from sydent.types import JsonDict
 from sydent.users.tokens import issueToken
 from sydent.util.stringutils import is_valid_matrix_server_name
-from sydent.types import JsonDict
 
 if TYPE_CHECKING:
     from sydent.sydent import Sydent
@@ -58,13 +57,13 @@ class RegisterServlet(Resource):
             }
 
         result = await self.client.get_json(
-                "matrix://%s/_matrix/federation/v1/openid/userinfo?access_token=%s"
-                % (
-                    matrix_server,
-                    urllib.parse.quote(args["access_token"]),
-                ),
-                1024 * 5,
-            )
+            "matrix://%s/_matrix/federation/v1/openid/userinfo?access_token=%s"
+            % (
+                matrix_server,
+                urllib.parse.quote(args["access_token"]),
+            ),
+            1024 * 5,
+        )
 
         if "sub" not in result:
             raise Exception("Invalid response from homeserver")


### PR DESCRIPTION
This PR converts a function in http/servlets/registerservlet.py to use async/await. A few other files/functions needed to be changed as well. 
One note: on `line 109` of `http/servlets/registerservlet.py`, I removed the keyword `yield` from the call to `issueToken` because when I substituted `await` there, a few of the tests failed. After adding a breakpoint, I discovered that the call to `renderPost` was failing with the following message: `twisted.python.failure.Failure builtins.TypeError: object str can't be used in 'await' expression`. Mypy had also flagged this as a problem. I checked the function definition of `issueToken` and as far as I can tell it is not an asynchronous function so I am unclear as to why is was ever yielded to/awaited in the first place. Removing the `await` resulted in the tests all passing, so perhaps it was the right thing to do?   