### PR TITLE
Fix KeyError on unbinding addresses

### DIFF
--- a/changelog.d/397.bugfix
+++ b/changelog.d/397.bugfix
@@ -1,0 +1,1 @@
+Fix a bug that was causing association unbindings to fail with an Internal Server Error.

--- a/changelog.d/397.bugfix
+++ b/changelog.d/397.bugfix
@@ -1,1 +1,1 @@
-Fix a bug that was causing association unbindings to fail with an Internal Server Error.
+Fix a bug introduced in v2.4.0 that caused association unbindings to fail with an Internal Server Error.

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -124,7 +124,7 @@ class ThreepidBinder:
         """
 
         # ensure we are casefolding email addresses
-        threepid["address"] = normalise_address(threepid["address"], threepid["email"])
+        threepid["address"] = normalise_address(threepid["address"], threepid["medium"])
 
         localAssocStore = LocalAssociationStore(self.sydent)
         localAssocStore.removeAssociation(threepid, mxid)


### PR DESCRIPTION
There was a typo in the `removeBinding` function which seems to be causing unbindings to fail in Sydent.

The function `normalise_address` expects the medium to be passed as the second argument:

https://github.com/matrix-org/sydent/blob/d6db3b1d3615dcb2ff68c54ecd9435adbdc8aad1/sydent/util/stringutils.py#L131-L135

Which in most cases would be "email". The code had `threepid["email"]` instead.

Introduced in https://github.com/matrix-org/sydent/pull/374.