### PR TITLE
Remove invalid await in replication code

### DIFF
--- a/changelog.d/400.bugfix
+++ b/changelog.d/400.bugfix
@@ -1,0 +1,1 @@
+Fix an issue which could cause new local associations to be replicated multiple times to peers.

--- a/sydent/replication/pusher.py
+++ b/sydent/replication/pusher.py
@@ -112,7 +112,7 @@ class Pusher:
             )
             result = await p.pushUpdates(assocs)
 
-            await self.peerStore.setLastSentVersionAndPokeSucceeded(
+            self.peerStore.setLastSentVersionAndPokeSucceeded(
                 p.servername, latest_assoc_id, time_msec()
             )
 


### PR DESCRIPTION
An extra `await` ended up in https://github.com/matrix-org/sydent/pull/364.

This may prevent successful reporting of peer replication results, causing replication payloads to increase over time as the same associations are replicated over and over.

Logs may have many instances of `Error pushing updates to <hostname>:<port>` as well.

Discovered via Sentry: https://sentry.matrix.org/sentry/sydent/issues/230767/?query=is%3Aunresolved.