### PR TITLE
Don't update an existing config file

### DIFF
--- a/matrix_is_test/launcher.py
+++ b/matrix_is_test/launcher.py
@@ -45,6 +45,9 @@ email.smtphost = localhost
 email.from = Sydent Validation <noreply@localhost>
 email.smtpport = 9925
 email.subject = Your Validation Token
+
+[crypto]
+ed25519.signingkey = ed25519 0 broXDusfghcDAamylh2RmOEHfPJCi4snha7NNCJKOao
 """
 
 

--- a/scripts/generate-key
+++ b/scripts/generate-key
@@ -8,16 +8,14 @@
 
 # The signing key is generally used in "ed25519.signingkey" in the sydent config
 
-import sys
-
 import signedjson.key
 
-signing_key = signedjson.key.generate_signing_key(0);
+signing_key = signedjson.key.generate_signing_key(0)
 sk_str = "%s %s %s" % (
     signing_key.alg,
     signing_key.version,
     signedjson.key.encode_signing_key_base64(signing_key)
     )
-print ("signing key: %s " % sk_str)
+print("signing key: %s " % sk_str)
 pk_str = signedjson.key.encode_verify_key_base64(signing_key.verify_key)
-print ("verify key: %s" % pk_str)
+print("verify key: %s" % pk_str)

--- a/scripts/update-key
+++ b/scripts/update-key
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# Example run
+# ```
+# $ ./scripts/update-key b251d15e720672cbbe73626447a8458ffa1ab1413925cd51ef990e652d48318A
+# Update your sydent config file with the following:
+#
+# [crypto]
+# ed25519.signingkey = ed25519 0 slHRXnIGcsu+c2JkR6hFj/oasUE5Jc1R75kOZS1IMYo
+#
+# For reference, the public (verificiation) key is 53eNltXamSKdvxIgL3Tq4KMrwgR/sQA18xvwvxEYc4o
+# ````
+
+# Use this to update the signing key used in sydent configurations. This doesn't
+# change the key, only the way that it's encoded in the config file.
+
+import sys
+
+import nacl
+import signedjson.key
+
+if len(sys.argv) != 2:
+    print("Usage: updated-key [hex encoded key]")
+else:
+    signing_key_hex = sys.argv[1]
+
+    signing_key = nacl.signing.SigningKey(
+        signing_key_hex, encoder=nacl.encoding.HexEncoder
+    )
+    signing_key.version = "0"
+    signing_key.alg = signedjson.key.NACL_ED25519
+
+    signing_key_str = "%s %s %s" % (
+        signing_key.alg,
+        signing_key.version,
+        signedjson.key.encode_signing_key_base64(signing_key),
+    )
+
+    verify_key_str = signedjson.key.encode_verify_key_base64(signing_key.verify_key)
+
+    print(
+        "Update your sydent config file with the following: \n"
+        "\n"
+        "[crypto]\n"
+        f"ed25519.signingkey = {signing_key_str}\n"
+        "\n"
+        f"For reference, the public (verificiation) key is {verify_key_str}\n"
+    )

--- a/sydent/config/crypto.py
+++ b/sydent/config/crypto.py
@@ -58,3 +58,5 @@ class CryptoConfig(BaseConfig):
             self.signing_key = signedjson.key.decode_signing_key_base64(
                 signing_key_parts[0], signing_key_parts[1], signing_key_parts[2]
             )
+        
+        return False

--- a/sydent/config/crypto.py
+++ b/sydent/config/crypto.py
@@ -33,40 +33,28 @@ class CryptoConfig(BaseConfig):
         signing_key_str = cfg.get("crypto", "ed25519.signingkey")
         signing_key_parts = signing_key_str.split(" ")
 
-        save_key = False
-
         if signing_key_str == "":
-            logger.info(
-                "This server does not yet have an ed25519 signing key. "
-                "Creating one and saving it in the config file."
+            logger.warning(
+                "'ed25519.signingkey' cannot be blank. Please generate a new"
+                " signing key with the 'generate-key' script."
             )
 
             self.signing_key = signedjson.key.generate_signing_key("0")
 
-            save_key = True
+            return True
         elif len(signing_key_parts) == 1:
             # old format key
-            logger.info("Updating signing key format: brace yourselves")
+            logger.warning(
+                "Updating signing key format for this run. Please run the"
+                " 'update-key' script to speedup the next startup"
+            )
 
             self.signing_key = nacl.signing.SigningKey(
                 signing_key_str, encoder=nacl.encoding.HexEncoder
             )
             self.signing_key.version = "0"
             self.signing_key.alg = signedjson.key.NACL_ED25519
-
-            save_key = True
         else:
             self.signing_key = signedjson.key.decode_signing_key_base64(
                 signing_key_parts[0], signing_key_parts[1], signing_key_parts[2]
             )
-
-        if save_key:
-            signing_key_str = "%s %s %s" % (
-                self.signing_key.alg,
-                self.signing_key.version,
-                signedjson.key.encode_signing_key_base64(self.signing_key),
-            )
-            cfg.set("crypto", "ed25519.signingkey", signing_key_str)
-            return True
-        else:
-            return False

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,6 +52,8 @@ tWVEpHfT+G7AjA8=
 -----END CERTIFICATE-----
 """
 
+DEFAULT_SIGNING_KEY = "ed25519 0 broXDusfghcDAamylh2RmOEHfPJCi4snha7NNCJKOao"
+
 
 def make_sydent(test_config={}):
     """Create a new sydent
@@ -67,6 +69,12 @@ def make_sydent(test_config={}):
         test_config["db"] = {"db.file": ":memory:"}
     else:
         test_config["db"].setdefault("db.file", ":memory:")
+
+    # Set a value for the signingkey if it hasn't been set by the test
+    if "db" not in test_config:
+        test_config["crypto"] = {"ed25519.signingkey": DEFAULT_SIGNING_KEY}
+    elif "ed25519.signingkey" not in test_config["db"]:
+        test_config["crypto"] = {"ed25519.signingkey": DEFAULT_SIGNING_KEY}
 
     reactor = ResolvingMemoryReactorClock()
 


### PR DESCRIPTION
Currently, if you delete the signing key from the config file, a new one gets generated and the config file gets updated. 

This causes two issues:
- The config file cannot be set to be read-only.
- You may want a minimal config file (with only the things you're overriding from the defaults) but this update will write all of the default values into your minimal config file as well.

How Sydent will now behave:
- If there is no config file, generate a new one and then stop, with log message telling user to run the generate-key script.
- If there is a config file and it has a base64 encoded signing key, run as normal.
- If there is a config file and it has a hex encoded signing key, run as before but without updating the format of the signing key to base64 (instead log a warning telling the user to run the new update-key script) - note keys haven't been Hex encoded [since 2015](https://github.com/matrix-org/sydent/commit/5abc90b947527e9a3e2daa0a8110515837b54668)
- If there is a config file and it has no signing key, exit with log message telling user to run the generate-key script

The idea is that in the future the user can/must instead run a generate-config script before the first run of Sydent, and there will be documentation on how the configuration works.

For people updating from previous versions:
 - If they have an existing config, the only change they'll experience is having to run the the generate-key script to make new keys instead of just being able to delete their value from the config
 - If they don't have an existing config, they need to run the generate-key script before they can get Sydent to start.