### PR TITLE
Fix issue with obey_x_forwarded_for not being False when "False"

### DIFF
--- a/changelog.d/403.bugfix
+++ b/changelog.d/403.bugfix
@@ -1,0 +1,1 @@
+Fix issue with obey_x_forwarded_for not being False when "False".

--- a/changelog.d/403.bugfix
+++ b/changelog.d/403.bugfix
@@ -1,1 +1,1 @@
-Fix issue with obey_x_forwarded_for not being False when "False".
+Fix issue with `obey_x_forwarded_for` not being honoured.

--- a/sydent/config/http.py
+++ b/sydent/config/http.py
@@ -53,7 +53,7 @@ class HTTPConfig(BaseConfig):
         )
         self.replication_port = cfg.getint("http", "replication.https.port")
 
-        self.obey_x_forwarded_for = cfg.get("http", "obey_x_forwarded_for")
+        self.obey_x_forwarded_for = cfg.getboolean("http", "obey_x_forwarded_for")
 
         self.verify_federation_certs = cfg.getboolean("http", "federation.verifycerts")
 


### PR DESCRIPTION
Problem was possibly added in #91 or maybe [this commit](https://github.com/matrix-org/sydent/commit/27b757a626692bb2d712d6344b2cf73879e12699)

configparser's get method always returns a string. However `"False"` is `True` in python so it needs to be cast.