### PR TITLE
Use `logger.exception` in asyncjsonwrap

### DIFF
--- a/changelog.d/455.misc
+++ b/changelog.d/455.misc
@@ -1,0 +1,1 @@
+Improve exception logging in `asyncjsonwrap` for better Sentry reports.

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -180,8 +180,7 @@ def asyncjsonwrap(f: AsyncRenderer[Res]) -> Callable[[Res, Request], object]:
             request.setResponseCode(e.httpStatus)
             request.write(dict_to_json_bytes({"errcode": e.errcode, "error": e.error}))
         except Exception:
-            fail = failure.Failure()
-            logger.error("Request processing failed: %r, %s", fail, fail.getTraceback())
+            logger.exception("Request processing failed")
             request.setResponseCode(500)
             request.write(
                 dict_to_json_bytes(

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -19,7 +19,6 @@ import logging
 from typing import Any, Awaitable, Callable, Dict, Iterable, TypeVar
 
 from twisted.internet import defer
-from twisted.python import failure
 from twisted.web import server
 from twisted.web.resource import Resource
 from twisted.web.server import Request


### PR DESCRIPTION
instead of `logger.error`. This should hopefully give us a more
meaningful report in sentry (rather than a truncated traceback).

Will help with #452.