### PR TITLE
Demote `DestinationRejectedException` to warning

### DIFF
--- a/changelog.d/459.misc
+++ b/changelog.d/459.misc
@@ -1,0 +1,1 @@
+Log a warning (not an error) when we refuse to send an SMS to an unsupported country.

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -100,7 +100,7 @@ class MsisdnRequestCodeServlet(Resource):
                 "intl_fmt": intl_fmt,
             }
         except DestinationRejectedException:
-            logger.error("Destination rejected for number: %s", msisdn)
+            logger.warning("Destination rejected for number: %s", msisdn)
             request.setResponseCode(400)
             resp = {
                 "errcode": "M_DESTINATION_REJECTED",


### PR DESCRIPTION
This is not a bug in our application; we are obeying the configation in
`MsisdnValidator.smsRules` when this exception is raised. It does not
deserve to show up in Sentry.
