### PR TITLE
Convert `send_attempt` to an int again

### DIFF
--- a/changelog.d/461.misc
+++ b/changelog.d/461.misc
@@ -1,0 +1,1 @@
+Fix a bug introduced in Sydent 2.5.0 where calls to `/_matrix/identity/api/v1/validate/email/requestToken` would fail with an HTTP 500 Internal Server Error if arguments were given as a query string or as a www-form-urlencoded body.

--- a/sydent/http/servlets/__init__.py
+++ b/sydent/http/servlets/__init__.py
@@ -49,9 +49,13 @@ def get_args(
     Helper function to get arguments for an HTTP request.
     Currently takes args from the top level keys of a json object or
     www-form-urlencoded for backwards compatibility on v1 endpoints only.
-    Returns a tuple (error, args) where if error is non-null,
-    the request is malformed. Otherwise, args contains the
-    parameters passed.
+
+    ⚠️ BEWARE ⚠. If a v1 request provides its args in urlencoded form (either in
+    a POST body or as URL query parameters), then we'll return `Dict[str, str]`.
+    The caller may need to interpret these strings as e.g. an `int`, `bool`, etc.
+    Arguments given as a json body are processed with `json.JSONDecoder.decode`,
+    and so are automatically deserialised to a Python type. The caller should
+    still validate that these have the correct type!
 
     :param request: The request received by the servlet.
     :param args: The args to look for in the request's parameters.
@@ -60,6 +64,10 @@ def get_args(
 
     :raises: MatrixRestError if required is True and a given parameter
         was not found in the request's query parameters.
+    :raises: MatrixRestError if we the request body contains bad JSON.
+    :raises: MatrixRestError if arguments are given in www-form-urlencodedquery
+        form, and some argument name or value is not a valid UTF-8-encoded
+        string.
 
     :return: A dict containing the requested args and their values. String values
         are of type unicode.

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -48,7 +48,7 @@ class TestRequestCode(unittest.TestCase):
         request, channel = make_request(
             self.sydent.reactor,
             "POST",
-            "/_matrix/identity/v1/validate/email/requestToken",
+            "/_matrix/identity/api/v1/validate/email/requestToken",
             {
                 "email": "test@test",
                 "client_secret": "oursecret",
@@ -68,7 +68,7 @@ class TestRequestCode(unittest.TestCase):
         request, channel = make_request(
             self.sydent.reactor,
             "POST",
-            "/_matrix/identity/v1/validate/email/requestToken?brand=vector-im",
+            "/_matrix/identity/api/v1/validate/email/requestToken?brand=vector-im",
             {
                 "email": "test@test",
                 "client_secret": "oursecret",

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -62,6 +62,22 @@ class TestRequestCode(unittest.TestCase):
         email_contents = smtp.sendmail.call_args[0][2].decode("utf-8")
         self.assertIn("Confirm your email address for Matrix", email_contents)
 
+    def test_request_code_via_url_query_params(self):
+        self.sydent.run()
+        url = (
+            "/_matrix/identity/api/v1/validate/email/requestToken?"
+            "email=test@test"
+            "&client_secret=oursecret"
+            "&send_attempt=0"
+        )
+        request, channel = make_request(self.sydent.reactor, "POST", url)
+        smtp = self._render_request(request)
+        self.assertEqual(channel.code, 200)
+
+        # Ensure the email is as expected.
+        email_contents = smtp.sendmail.call_args[0][2].decode("utf-8")
+        self.assertIn("Confirm your email address for Matrix", email_contents)
+
     def test_branded_request_code(self):
         self.sydent.run()
 


### PR DESCRIPTION
A type annotation was incorrect, and this lead me to introduce a regression in Sydent 2.5.0.

This restores the old behaviour, but converts to int at the rest level rather than within the validator. It does re-introduce a spec bug, but at least it's the old behaviour.

Fixes #460.