### PR TITLE
Catch failures to decode JSON in /register

### DIFF
--- a/changelog.d/463.misc
+++ b/changelog.d/463.misc
@@ -1,0 +1,1 @@
+Demote a failure to parse JSON from homeservers in `/register` from an error to a warning.

--- a/sydent/http/httpclient.py
+++ b/sydent/http/httpclient.py
@@ -64,7 +64,7 @@ class HTTPClient(Generic[AgentType]):
             # json.loads doesn't allow bytes in Python 3.5
             json_body = json_decoder.decode(body.decode("UTF-8"))
         except Exception:
-            logger.exception("Error parsing JSON from %s", uri)
+            logger.warning("Error parsing JSON from %s", uri)
             raise
         if not isinstance(json_body, dict):
             raise TypeError

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -15,6 +15,7 @@
 import logging
 import urllib
 from http import HTTPStatus
+from json import JSONDecodeError
 from typing import TYPE_CHECKING, Dict
 
 from twisted.internet.error import ConnectError, DNSLookupError
@@ -79,6 +80,10 @@ class RegisterServlet(Resource):
         except (DNSLookupError, ConnectError, ResponseFailed) as e:
             return federation_request_problem(
                 f"Unable to contact the Matrix homeserver ({type(e).__name__})"
+            )
+        except JSONDecodeError:
+            return federation_request_problem(
+                f"The Matrix homeserver returned invalid JSON"
             )
 
         if "sub" not in result:

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -83,7 +83,7 @@ class RegisterServlet(Resource):
             )
         except JSONDecodeError:
             return federation_request_problem(
-                f"The Matrix homeserver returned invalid JSON"
+                "The Matrix homeserver returned invalid JSON"
             )
 
         if "sub" not in result:


### PR DESCRIPTION
Like #456, but for another error case.

If the remote homeserver fails to give us sensible response, that's not
a problem in our application. We can continue to serve everyone else. We
should tell the requester what happened and log a warning, but not an
error to Sentry.

Most of the examples I saw in Sentry were 404 responses serving up a
generic "page not found" body.