### PR TITLE
Handle errors to contact homeservers in `/unbind`.

### DIFF
--- a/changelog.d/466.misc
+++ b/changelog.d/466.misc
@@ -1,0 +1,1 @@
+Handle errors to contact homeservers in `/unbind`. This returns a better errro message and reduces Sentry spam.

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -64,7 +64,7 @@ class ThreePidUnbindServlet(Resource):
                     request.content.read().decode("UTF-8")
                 )
             except ValueError:
-                request.setResponseCode(400)
+                request.setResponseCode(HTTPStatus.BAD_REQUEST)
                 request.write(
                     dict_to_json_bytes(
                         {"errcode": "M_BAD_JSON", "error": "Malformed JSON"}
@@ -75,7 +75,7 @@ class ThreePidUnbindServlet(Resource):
 
             missing = [k for k in ("threepid", "mxid") if k not in body]
             if len(missing) > 0:
-                request.setResponseCode(400)
+                request.setResponseCode(HTTPStatus.BAD_REQUEST)
                 msg = "Missing parameters: " + (",".join(missing))
                 request.write(
                     dict_to_json_bytes({"errcode": "M_MISSING_PARAMS", "error": msg})
@@ -87,7 +87,7 @@ class ThreePidUnbindServlet(Resource):
             mxid = body["mxid"]
 
             if "medium" not in threepid or "address" not in threepid:
-                request.setResponseCode(400)
+                request.setResponseCode(HTTPStatus.BAD_REQUEST)
                 request.write(
                     dict_to_json_bytes(
                         {
@@ -118,7 +118,7 @@ class ThreePidUnbindServlet(Resource):
                 client_secret = body["client_secret"]
 
                 if not is_valid_client_secret(client_secret):
-                    request.setResponseCode(400)
+                    request.setResponseCode(HTTPStatus.BAD_REQUEST)
                     request.write(
                         dict_to_json_bytes(
                             {
@@ -135,7 +135,7 @@ class ThreePidUnbindServlet(Resource):
                 try:
                     s = valSessionStore.getValidatedSession(sid, client_secret)
                 except (IncorrectClientSecretException, InvalidSessionIdException):
-                    request.setResponseCode(401)
+                    request.setResponseCode(HTTPStatus.UNAUTHORIZED)
                     request.write(
                         dict_to_json_bytes(
                             {
@@ -147,7 +147,7 @@ class ThreePidUnbindServlet(Resource):
                     request.finish()
                     return
                 except SessionNotValidatedException:
-                    request.setResponseCode(403)
+                    request.setResponseCode(HTTPStatus.FORBIDDEN)
                     request.write(
                         dict_to_json_bytes(
                             {
@@ -159,7 +159,7 @@ class ThreePidUnbindServlet(Resource):
                     return
 
                 if s.medium != threepid["medium"] or s.address != threepid["address"]:
-                    request.setResponseCode(403)
+                    request.setResponseCode(HTTPStatus.FORBIDDEN)
                     request.write(
                         dict_to_json_bytes(
                             {
@@ -178,21 +178,21 @@ class ThreePidUnbindServlet(Resource):
                         )
                     )
                 except SignatureVerifyException as ex:
-                    request.setResponseCode(401)
+                    request.setResponseCode(HTTPStatus.UNAUTHORIZED)
                     request.write(
                         dict_to_json_bytes({"errcode": "M_FORBIDDEN", "error": str(ex)})
                     )
                     request.finish()
                     return
                 except NoAuthenticationError as ex:
-                    request.setResponseCode(401)
+                    request.setResponseCode(HTTPStatus.UNAUTHORIZED)
                     request.write(
                         dict_to_json_bytes({"errcode": "M_FORBIDDEN", "error": str(ex)})
                     )
                     request.finish()
                     return
                 except InvalidServerName as ex:
-                    request.setResponseCode(400)
+                    request.setResponseCode(HTTPStatus.BAD_REQUEST)
                     request.write(
                         dict_to_json_bytes(
                             {"errcode": "M_INVALID_PARAM", "error": str(ex)}
@@ -229,7 +229,7 @@ class ThreePidUnbindServlet(Resource):
                     return
 
                 if not mxid.endswith(":" + origin_server_name):
-                    request.setResponseCode(403)
+                    request.setResponseCode(HTTPStatus.FORBIDDEN)
                     request.write(
                         dict_to_json_bytes(
                             {
@@ -247,7 +247,7 @@ class ThreePidUnbindServlet(Resource):
             request.finish()
         except Exception as ex:
             logger.exception("Exception whilst handling unbind")
-            request.setResponseCode(500)
+            request.setResponseCode(HTTPStatus.INTERNAL_SERVER_ERROR)
             request.write(
                 dict_to_json_bytes({"errcode": "M_UNKNOWN", "error": str(ex)})
             )

--- a/sydent/http/servlets/threepidunbindservlet.py
+++ b/sydent/http/servlets/threepidunbindservlet.py
@@ -19,13 +19,12 @@ from typing import TYPE_CHECKING
 
 from signedjson.sign import SignatureVerifyException
 from twisted.internet import defer
-from twisted.internet.error import DNSLookupError
+from twisted.internet.error import ConnectError, DNSLookupError
 from twisted.web import server
 from twisted.web.client import ResponseFailed
 from twisted.web.resource import Resource
 from twisted.web.server import Request
 
-from twisted.internet.error import ConnectError
 from sydent.db.valsession import ThreePidValSessionStore
 from sydent.hs_federation.verifier import InvalidServerName, NoAuthenticationError
 from sydent.http.servlets import dict_to_json_bytes

--- a/tests/test_threepidunbind.py
+++ b/tests/test_threepidunbind.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from http import HTTPStatus
-from json import JSONDecodeError
 from unittest.mock import patch
 
 import twisted.internet.error

--- a/tests/test_threepidunbind.py
+++ b/tests/test_threepidunbind.py
@@ -1,0 +1,67 @@
+# Copyright 2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from http import HTTPStatus
+from json import JSONDecodeError
+from unittest.mock import patch
+
+import twisted.internet.error
+import twisted.web.client
+from parameterized import parameterized
+from twisted.trial import unittest
+
+from tests.utils import make_request, make_sydent
+
+
+class ThreepidUnbindTestCase(unittest.TestCase):
+    """Tests Sydent's threepidunbind servlet"""
+
+    def setUp(self) -> None:
+        # Create a new sydent
+        self.sydent = make_sydent()
+
+    # Duplicated from TestRegisterServelet. Is there a way for us to keep
+    # ourselves DRY?
+    @parameterized.expand(
+        [
+            (twisted.internet.error.DNSLookupError(),),
+            (twisted.internet.error.TimeoutError(),),
+            (twisted.internet.error.ConnectionRefusedError(),),
+            # Naughty: strictly we're supposed to initialise a ResponseNeverReceived
+            # with a list of 1 or more failures.
+            (twisted.web.client.ResponseNeverReceived([]),),
+        ]
+    )
+    def test_connection_failure(self, exc: Exception) -> None:
+        """Check we respond sensibly if we can't contact the homeserver."""
+        self.sydent.run()
+        request, channel = make_request(
+            self.sydent.reactor,
+            "POST",
+            "/_matrix/identity/v2/3pid/unbind",
+            content={
+                "mxid": "@alice:wonderland",
+                "threepid": {
+                    "address": "alice.cooper@wonderland.biz",
+                    "medium": "email",
+                },
+            },
+        )
+
+        with patch.object(
+            self.sydent.sig_verifier, "authenticate_request", side_effect=exc
+        ):
+            request.render(self.sydent.servlets.threepidUnbind)
+        self.assertEqual(channel.code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertEqual(channel.json_body["errcode"], "M_UNKNOWN")
+        self.assertIn("contact", channel.json_body["error"])


### PR DESCRIPTION
Handle failures to contact homeserver in Threepidunbind

Addresses
https://sentry.matrix.org/sentry/sydent/issues/235004/?query=is%3Aunresolved%20event.timestamp%3A%3E%3D2021-11-03T10%3A00%3A00

That issue is rare---it's only occurred twice---but since it's so close
to #456 I thought I may as well throw it in too.

(I suppose this might encounter the problem in #463 as well, though we
haven't seen it in Sentry. I think unbinds are just much less used that
registers. I don't know if there's a better way to handle all this
duplication though?)