### PR TITLE
Use logger.exception if SMS sending fails

### DIFF
--- a/changelog.d/467.misc
+++ b/changelog.d/467.misc
@@ -1,0 +1,1 @@
+Log failures to send SMS as exceptions, not errors (to better debug in Sentry).

--- a/sydent/http/servlets/msisdnservlet.py
+++ b/sydent/http/servlets/msisdnservlet.py
@@ -115,8 +115,8 @@ class MsisdnRequestCodeServlet(Resource):
                 "errcode": "M_DESTINATION_REJECTED",
                 "error": "Phone numbers in this country are not currently supported",
             }
-        except Exception as e:
-            logger.error("Exception sending SMS: %r", e)
+        except Exception:
+            logger.exception("Exception sending SMS")
             request.setResponseCode(500)
             resp = {"errcode": "M_UNKNOWN", "error": "Internal Server Error"}
 


### PR DESCRIPTION
so we get local variables reported in Sentry.