### PR TITLE
Require that  "m.server" maps to string

### DIFF
--- a/changelog.d/473.bugfix
+++ b/changelog.d/473.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where federation requests would fail early if a `.well-known/matrix/server` response contains an invalid type for `m.server`. Instead, try finding an SRV record, as mandated by [the spec](https://spec.matrix.org/v1.1/server-server-api/#resolving-server-names).

--- a/sydent/http/matrixfederationagent.py
+++ b/sydent/http/matrixfederationagent.py
@@ -350,6 +350,8 @@ class MatrixFederationAgent:
                 raise Exception("not a dict")
             if "m.server" not in parsed_body:
                 raise Exception("Missing key 'm.server'")
+            if not isinstance(parsed_body["m.server"], str):
+                raise TypeError("m.server must be a string")
         except Exception as e:
             logger.info("Error fetching %s: %s", uri_str, e)
 


### PR DESCRIPTION
This accounts for [this Sentry error](https://sentry.matrix.org/sentry/sydent/issues/236101/).

I haven't written a test for this because a) I'm hungry and b) this
is shared code with Synapse which ought to be pulled out to a common
library and tested there; c.f.
https://github.com/matrix-org/matrix-python-common/issues/3.
