### PR TITLE
In the casefolding migration script, get the lookup pepper from the hashing store's cache.

### DIFF
--- a/changelog.d/477.misc
+++ b/changelog.d/477.misc
@@ -1,1 +1,1 @@
-In the casefolding migration script, get the lookup pepper from the hashing store's cache.
+Cache the lookup pepper in the `HashingMetadataStore`.

--- a/changelog.d/477.misc
+++ b/changelog.d/477.misc
@@ -1,0 +1,1 @@
+In the casefolding migration script, get the lookup pepper from the hashing store's cache.

--- a/scripts/casefold_db.py
+++ b/scripts/casefold_db.py
@@ -73,10 +73,12 @@ class CantSendEmailException(Exception):
     pass
 
 
-def calculate_lookup_hash(sydent, address):
-    cur = sydent.db.cursor()
-    pepper_result = cur.execute("SELECT lookup_pepper from hashing_metadata")
-    pepper = pepper_result.fetchone()[0]
+def calculate_lookup_hash(sydent: Sydent, address: str) -> str:
+    pepper = sydent.threepidBinder.hashing_store.get_lookup_pepper()
+    if pepper is None:
+        raise RuntimeError(
+            "No lookup pepper found; Sydent should have generated one on startup."
+        )
     combo = "%s %s %s" % (address, "email", pepper)
     lookup_hash = sha256_and_url_safe_base64(combo)
     return lookup_hash


### PR DESCRIPTION
#475 makes the store cache the lookup pepper. This change allows the casefolding script to benefit from that.

