### PR TITLE
Fix bug in the casefolding script that would cause some deletions to be skipped if e-mail sending was enabled.

### DIFF
--- a/changelog.d/489.bugfix
+++ b/changelog.d/489.bugfix
@@ -1,0 +1,1 @@
+Fix bug in the casefolding script that would cause some deletions to be skipped if e-mail sending was enabled.

--- a/scripts/casefold_db.py
+++ b/scripts/casefold_db.py
@@ -231,19 +231,27 @@ def update_local_associations(
                             test=test,
                         )
 
+                    logger.debug(
+                        "Deleting %s from table local_threepid_associations",
+                        to_delete.address,
+                    )
                     cur = db.cursor()
                     cur.execute(
                         "DELETE FROM local_threepid_associations WHERE medium = 'email' AND address = ?",
                         (to_delete.address,),
                     )
                     db.commit()
-                    logger.debug(
-                        "Deleting %s from table local_threepid_associations",
-                        to_delete.address,
-                    )
 
             # Update the row now that there's no duplicate.
             if not dry_run:
+                logger.debug(
+                    "Updating table local threepid associations setting address to %s, "
+                    "lookup_hash to %s, where medium = email and address = %s and mxid = %s",
+                    casefolded_address,
+                    delta.to_update.lookup_hash,
+                    delta.to_update.address,
+                    delta.to_update.mxid,
+                )
                 cur = db.cursor()
                 cur.execute(
                     "UPDATE local_threepid_associations SET address = ?, lookup_hash = ? WHERE medium = 'email' AND address = ? AND mxid = ?",
@@ -253,14 +261,6 @@ def update_local_associations(
                         delta.to_update.address,
                         delta.to_update.mxid,
                     ),
-                )
-                logger.debug(
-                    "Updating table local threepid associations setting address to %s, "
-                    "lookup_hash to %s, where medium = email and address = %s and mxid = %s",
-                    casefolded_address,
-                    delta.to_update.lookup_hash,
-                    delta.to_update.address,
-                    delta.to_update.mxid,
                 )
                 db.commit()
 

--- a/scripts/casefold_db.py
+++ b/scripts/casefold_db.py
@@ -224,15 +224,13 @@ def update_local_associations(
                     if send_email and not dry_run:
                         # If the MXID is one that will still be associated with this
                         # email address after this run, don't send an email for it.
-                        if to_delete.mxid == delta.to_update.mxid:
-                            continue
-
-                        sendEmailWithBackoff(
-                            sydent,
-                            to_delete.address,
-                            to_delete.mxid,
-                            test=test,
-                        )
+                        if to_delete.mxid != delta.to_update.mxid:
+                            sendEmailWithBackoff(
+                                sydent,
+                                to_delete.address,
+                                to_delete.mxid,
+                                test=test,
+                            )
 
                     if not dry_run:
                         cur = db.cursor()

--- a/scripts/casefold_db.py
+++ b/scripts/casefold_db.py
@@ -219,9 +219,9 @@ def update_local_associations(
 
         try:
             # Delete each association, and send an email mentioning the affected MXID.
-            if delta.to_delete is not None:
+            if delta.to_delete is not None and not dry_run:
                 for to_delete in delta.to_delete:
-                    if send_email and not dry_run:
+                    if send_email:
                         # If the MXID is one that will still be associated with this
                         # email address after this run, don't send an email for it.
                         if to_delete.mxid != delta.to_update.mxid:
@@ -232,17 +232,16 @@ def update_local_associations(
                                 test=test,
                             )
 
-                    if not dry_run:
-                        cur = db.cursor()
-                        cur.execute(
-                            "DELETE FROM local_threepid_associations WHERE medium = 'email' AND address = ?",
-                            (to_delete.address,),
-                        )
-                        db.commit()
-                        logger.debug(
-                            "Deleting %s from table local_threepid_associations",
-                            to_delete.address,
-                        )
+                    cur = db.cursor()
+                    cur.execute(
+                        "DELETE FROM local_threepid_associations WHERE medium = 'email' AND address = ?",
+                        (to_delete.address,),
+                    )
+                    db.commit()
+                    logger.debug(
+                        "Deleting %s from table local_threepid_associations",
+                        to_delete.address,
+                    )
 
             # Update the row now that there's no duplicate.
             if not dry_run:

--- a/scripts/casefold_db.py
+++ b/scripts/casefold_db.py
@@ -221,16 +221,15 @@ def update_local_associations(
             # Delete each association, and send an email mentioning the affected MXID.
             if delta.to_delete is not None and not dry_run:
                 for to_delete in delta.to_delete:
-                    if send_email:
+                    if send_email and to_delete.mxid != delta.to_update.mxid:
                         # If the MXID is one that will still be associated with this
                         # email address after this run, don't send an email for it.
-                        if to_delete.mxid != delta.to_update.mxid:
-                            sendEmailWithBackoff(
-                                sydent,
-                                to_delete.address,
-                                to_delete.mxid,
-                                test=test,
-                            )
+                        sendEmailWithBackoff(
+                            sydent,
+                            to_delete.address,
+                            to_delete.mxid,
+                            test=test,
+                        )
 
                     cur = db.cursor()
                     cur.execute(

--- a/tests/test_casefold_migration.py
+++ b/tests/test_casefold_migration.py
@@ -70,6 +70,18 @@ class MigrationTestCase(unittest.TestCase):
                 }
             )
 
+        associations.append(
+            {
+                "medium": "email",
+                "address": "BoB4@example.com",
+                "lookup_hash": calculate_lookup_hash(self.sydent, "BoB4@example.com"),
+                "mxid": "@otherbob4:example.com",
+                "ts": 42000,
+                "not_before": 0,
+                "not_after": 99999999999,
+            }
+        )
+
         # add all associations to db
         cur = self.sydent.db.cursor()
 


### PR DESCRIPTION
Also have updated a test case to cover this (verified that the test fails originally).

Also have moved the logging to occur before dangerous operations -- but the logging was still extremely useful in the end.

