### PR TITLE
Dockerfile that builds with poetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM docker.io/python:3.8-slim as builder
 
 # Add user sydent
 RUN addgroup --system --gid 993 sydent \
-    && adduser --disabled-password --system --uid 993 --gecos sydent sydent
+    && adduser --disabled-login --system --uid 993 --gecos sydent sydent
 USER sydent:sydent
 
 # Install poetry
@@ -42,8 +42,7 @@ FROM docker.io/python:3.8-slim
 
 # Add user sydent and create /data directory
 RUN addgroup --system --gid 993 sydent \
-    && adduser --disabled-password --home /sydent --system --uid 993 --gecos sydent sydent \
-    && echo "sydent:$(dd if=/dev/random bs=32 count=1 | base64)" | chpasswd \
+    && adduser --disabled-login --home /sydent --system --uid 993 --gecos sydent sydent \
     && mkdir /data \
     && chown sydent:sydent /data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN addgroup --system --gid 993 sydent \
 
 # Copy sydent and the virtualenv
 COPY --from=builder ["/home/sydent/src", "/home/sydent/src"]
-COPY --from=builder ["/home/sydent/venv", "home/sydent/venv"]
+COPY --from=builder ["/home/sydent/venv", "/home/sydent/venv"]
 
 ENV SYDENT_CONF=/data/sydent.conf
 ENV SYDENT_PID_FILE=/data/sydent.pid

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile installs Sydent from source, which is assumed to be in the current
-# working directory. The resulting image contain a single "sydent" user, and populates
+# working directory. The resulting image contains a single "sydent" user, and populates
 # their home area with "src" and "venv" directories. The entrypoint runs Sydent,
 # listening on port 8090.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,8 @@ ENV SYDENT_CONF=/data/sydent.conf
 ENV SYDENT_PID_FILE=/data/sydent.pid
 ENV SYDENT_DB_PATH=/data/sydent.db
 
+WORKDIR /home/sydent
 USER sydent:sydent
 VOLUME ["/data"]
 EXPOSE 8090/tcp
-WORKDIR /home/sydent
 CMD [ "venv/bin/python", "-m", "sydent.sydent" ]

--- a/README.rst
+++ b/README.rst
@@ -80,13 +80,11 @@ Docker
 A Dockerfile is provided for sydent. To use it, run ``docker build -t sydent .`` in a sydent checkout.
 To run it, use ``docker run --env=SYDENT_SERVER_NAME=my-sydent-server -p 8090:8090 sydent``.
 
-Caution: All data will be lost when the container is terminated!
-
 Persistent data
 ---------------
 
-By default, all data is stored in ``/data``.
-The best method is to put the data in a Docker volume.
+By default, all data is stored in ``/data``. To persist this to disk, bind `/data` to a
+Docker volume.
 
 .. code-block:: shell
 

--- a/changelog.d/493.misc
+++ b/changelog.d/493.misc
@@ -1,0 +1,1 @@
+Update Dockerfile to use a fixed poetry environment, rather than `pip install`ing the latest dependencies.


### PR DESCRIPTION
To test:

```
DOCKER_BUILDKIT=1 docker build . -t sydent && docker run -p 8090:8090 sydent
```

I've seen this print sydent's startup lines and persist data to the `/data` volume. I could make a GET request to localhost:8090/ and got a 404 error page for my troubles, together with an entry in Sydent's log. I haven't tested this any more thoroughly than that.


To inspect the container while it's running, get the container id with
`docker ps` and then:

```
$ docker exec -it 001f9bfc6a54 bash
sydent@001f9bfc6a54:/home/sydent$ ls
src  venv
sydent@001f9bfc6a54:/home/sydent$ ls src
README.rst  poetry.lock  pyproject.toml  requirements.txt  res scripts  sydent
sydent@001f9bfc6a54:/home/sydent$ ls venv
bin  lib  pyvenv.cfg
```

### Pull Request Checklist

* [ ] Pull request includes a [changelog file](https://github.com/matrix-org/sydent/blob/main/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fix a bug that prevented receiving messages from other servers." instead of "Move X method from `EventStore` to `EventWorkerStore`.".
  - Include 'Contributed by *Your Name*.' or 'Contributed by @*your-github-username*.' — unless you would prefer not to be credited in the changelog.
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
