### PR TITLE
Use GHA to publish releases to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,14 @@
+name: "Build and upload to PyPI"
+on:
+  release:
+    types: ["published"]
+  pull_request:
+    branches: ["dmr/publish-workflow"]
+
+jobs:
+  upload:
+    uses: "matrix-org/backend-meta/.github/workflows/release.yml@v1"
+    with:
+      repository: testpypi
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: ["published"]
   pull_request:
-    branches: ["dmr/publish-workflow"]
+    branches: ["dmr/release-gha"]
 
 jobs:
   upload:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,14 +2,11 @@ name: "Build and upload to PyPI"
 on:
   release:
     types: ["published"]
-  pull_request:
-    branches: ["main"]
-
 
 jobs:
   upload:
     uses: "matrix-org/backend-meta/.github/workflows/release.yml@v1"
     with:
-      repository: testpypi
+      repository: pypi
     secrets:
-      PYPI_API_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: ["main"]
 
+
 jobs:
   upload:
     uses: "matrix-org/backend-meta/.github/workflows/release.yml@v1"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: ["published"]
   pull_request:
-    branches: ["dmr/release-gha"]
+    branches: ["main"]
 
 jobs:
   upload:

--- a/changelog.d/499.misc
+++ b/changelog.d/499.misc
@@ -1,0 +1,1 @@
+Publish releases to PyPI using GitHub Actions.


### PR DESCRIPTION
Like https://github.com/matrix-org/synapse-s3-storage-provider/pull/70, but makes use of https://github.com/matrix-org/backend-meta/pull/4.

Needs a `PYPI_API_TOKEN` secret before we do a release.