### PR TITLE
Add poetry entrypoint for running sydent

### DIFF
--- a/changelog.d/502.misc
+++ b/changelog.d/502.misc
@@ -1,0 +1,1 @@
+Add poetry entrypoint for running sydent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,9 @@ types-PyOpenSSL = "21.0.3"
 types-PyYAML = "6.0.3"
 
 
+[tool.poetry.scripts]
+sydent = "sydent.sydent:main"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/sydent/sydent.py
+++ b/sydent/sydent.py
@@ -359,10 +359,14 @@ def setup_logging(config: SydentConfig) -> None:
     observer.start()
 
 
-if __name__ == "__main__":
+def main() -> None:
     sydent_config = SydentConfig()
     sydent_config.parse_config_file(get_config_file_path())
     setup_logging(sydent_config)
 
     syd = Sydent(sydent_config)
     syd.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This allows one to invoke `poetry run sydent` rather than `poetry run python -m sydent.sydent`.