### PR TITLE
Run tests even if newsfile step fails

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -28,7 +28,8 @@ jobs:
 
   run-tests:
     name: Tests
-    needs: [checks, packaging]
+    if: ${{ !cancelled() && !failure() }} # Allow previous steps to be skipped, but not fail
+    needs: [check-newsfile, checks, packaging]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -28,7 +28,7 @@ jobs:
 
   run-tests:
     name: Tests
-    needs: [check-newsfile, checks, packaging]
+    needs: [checks, packaging]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/changelog.d/507.misc
+++ b/changelog.d/507.misc
@@ -1,0 +1,1 @@
+Ensure CI runs tests on main branch.


### PR DESCRIPTION
At present, if the newsfile step is skipped, then tests are also skipped. This happened on the `main` branch here:
https://github.com/matrix-org/sydent/runs/5306840738?check_suite_focus=true
