### PR TITLE
Allow the newsfile job to be skipped

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -57,3 +57,7 @@ jobs:
       - uses: matrix-org/done-action@v2
         with:
           needs: ${{ toJSON(needs) }}
+          # The newsfile lint may be skipped on non PR builds
+          skippable:
+            lint-newsfile
+

--- a/changelog.d/514.misc
+++ b/changelog.d/514.misc
@@ -1,0 +1,1 @@
+Allow the newsfile job to be skipped.


### PR DESCRIPTION
`main`'s CI is failing because the newsfile check is skipped on `main`.

Looks like @richvdh used this config in https://github.com/matrix-org/synapse/pull/12161. Let's do the same in sydent.