### PR TITLE
Use a more realistic configuration in tests

### DIFF
--- a/changelog.d/516.misc
+++ b/changelog.d/516.misc
@@ -1,0 +1,1 @@
+Avoid spurious warnings in tests.

--- a/tests/test_casefold_migration.py
+++ b/tests/test_casefold_migration.py
@@ -1,5 +1,17 @@
+# Copyright 2021 Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import json
-import os.path
 from unittest.mock import patch
 
 from twisted.trial import unittest

--- a/tests/test_casefold_migration.py
+++ b/tests/test_casefold_migration.py
@@ -27,17 +27,7 @@ class MigrationTestCase(unittest.TestCase):
 
     def setUp(self):
         # Create a new sydent
-        config = {
-            "general": {
-                "templates.path": os.path.join(
-                    os.path.dirname(os.path.dirname(__file__)), "res"
-                ),
-            },
-            "crypto": {
-                "ed25519.signingkey": "ed25519 0 FJi1Rnpj3/otydngacrwddFvwz/dTDsBv62uZDN2fZM"
-            },
-        }
-        self.sydent = make_sydent(test_config=config)
+        self.sydent = make_sydent()
 
         # create some local associations
         associations = []

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -11,7 +11,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import os.path
 from unittest.mock import patch
 
 from twisted.trial import unittest

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -22,14 +22,7 @@ from tests.utils import make_request, make_sydent
 class TestRequestCode(unittest.TestCase):
     def setUp(self):
         # Create a new sydent
-        config = {
-            "general": {
-                "templates.path": os.path.join(
-                    os.path.dirname(os.path.dirname(__file__)), "res"
-                ),
-            },
-        }
-        self.sydent = make_sydent(test_config=config)
+        self.sydent = make_sydent()
 
     def _render_request(self, request):
         # Patch out the email sending so we can investigate the resulting email.

--- a/tests/test_jinja_templates.py
+++ b/tests/test_jinja_templates.py
@@ -25,14 +25,7 @@ from tests.utils import make_sydent
 class TestTemplate(unittest.TestCase):
     def setUp(self):
         # Create a new sydent
-        config = {
-            "general": {
-                "templates.path": os.path.join(
-                    os.path.dirname(os.path.dirname(__file__)), "res"
-                ),
-            },
-        }
-        self.sydent = make_sydent(test_config=config)
+        self.sydent = make_sydent()
 
     def test_jinja_vector_invite(self):
         substitutions = {

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -15,12 +15,7 @@ class ReplicationTestCase(unittest.TestCase):
 
     def setUp(self):
         # Create a new sydent
-        config = {
-            "crypto": {
-                "ed25519.signingkey": "ed25519 0 FJi1Rnpj3/otydngacrwddFvwz/dTDsBv62uZDN2fZM"
-            }
-        }
-        self.sydent = make_sydent(test_config=config)
+        self.sydent = make_sydent()
 
         # Create a fake peer to replicate to.
         peer_public_key_base64 = "+vB8mTaooD/MA8YYZM8t9+vnGhP1937q2icrqPV9JTs"

--- a/tests/test_store_invite.py
+++ b/tests/test_store_invite.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os.path
 from unittest.mock import patch
 
 from parameterized import parameterized

--- a/tests/test_store_invite.py
+++ b/tests/test_store_invite.py
@@ -27,11 +27,6 @@ class StoreInviteTestCase(unittest.TestCase):
     def setUp(self) -> None:
         # Create a new sydent
         config = {
-            "general": {
-                "templates.path": os.path.join(
-                    os.path.dirname(os.path.dirname(__file__)), "res"
-                ),
-            },
             "email": {
                 "email.from": "Sydent Validation <noreply@hostname>",
             },


### PR DESCRIPTION
Currently the tests print a bunch of warning messages, we can avoid this by providing some better default configuration in the tests.