### PR TITLE
Add config options to drop invites matching certain criteria

### DIFF
--- a/changelog.d/530.feature
+++ b/changelog.d/530.feature
@@ -1,0 +1,2 @@
+Add `email.third_party_invite_homeserver_blocklist` and `email.third_party_invite_room_blocklist` config options to block invites from a list of homeservers or for a list of rooms.
+

--- a/changelog.d/530.feature
+++ b/changelog.d/530.feature
@@ -1,2 +1,1 @@
 Add `email.third_party_invite_homeserver_blocklist` and `email.third_party_invite_room_blocklist` config options to block invites from a list of homeservers or for a list of rooms.
-

--- a/sydent/config/email.py
+++ b/sydent/config/email.py
@@ -70,6 +70,23 @@ class EmailConfig(BaseConfig):
             "email", "email.third_party_invite_domain_obfuscate_characters"
         )
 
+        third_party_invite_homeserver_blocklist = cfg.get(
+            "email", "email.third_party_invite_homeserver_blocklist", fallback=""
+        )
+        third_party_invite_room_blocklist = cfg.get(
+            "email", "email.third_party_invite_room_blocklist", fallback=""
+        )
+        self.third_party_invite_homeserver_blocklist = {
+            server
+            for server in third_party_invite_homeserver_blocklist.split("\n")
+            if server  # filter out empty lines
+        }
+        self.third_party_invite_room_blocklist = {
+            room_id
+            for room_id in third_party_invite_room_blocklist.split("\n")
+            if room_id  # filter out empty lines
+        }
+
         self.email_sender_ratelimit_burst = cfg.getint(
             "email", "email.ratelimit_sender.burst", fallback=5
         )

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -78,6 +78,14 @@ class StoreInviteServlet(Resource):
             "Store invite request from %s to %s, in %s", sender, address, roomId
         )
 
+        sender_homeserver = sender.split(":", 1)[1]
+        if (
+            roomId in self.sydent.config.email.third_party_invite_room_blocklist
+            or sender_homeserver
+            in self.sydent.config.email.third_party_invite_homeserver_blocklist
+        ):
+            raise MatrixRestError(403, "M_UNAUTHORIZED", "Invite not allowed")
+
         globalAssocStore = GlobalAssociationStore(self.sydent)
         mxid = globalAssocStore.getMxid(medium, normalised_address)
         if mxid:


### PR DESCRIPTION
Add `email.third_party_invite_homeserver_blocklist` and
`email.third_party_invite_room_blocklist` config options to block
invites from a list of homeservers or for a list of rooms.
