### PR TITLE
Fix a typo to properly allow the newsfile job to be skipped

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -59,5 +59,5 @@ jobs:
           needs: ${{ toJSON(needs) }}
           # The newsfile lint may be skipped on non PR builds
           skippable:
-            lint-newsfile
+            check-newsfile
 

--- a/changelog.d/538.misc
+++ b/changelog.d/538.misc
@@ -1,0 +1,1 @@
+Fix a typo to properly allow the newsfile job to be skipped.


### PR DESCRIPTION
CI on `main` is failing because the newsfile check is skipped.

Follows on from #514.

Signed-off-by: Sean Quah <seanq@matrix.org>
