### PR TITLE
Don't block invites containing `invite_client_location` when using "http" in the keyword block list.

### DIFF
--- a/changelog.d/545.misc
+++ b/changelog.d/545.misc
@@ -1,0 +1,1 @@
+Don't block invites containing `invite_client_location` when using "http" in the keyword block list.

--- a/sydent/http/servlets/store_invite_servlet.py
+++ b/sydent/http/servlets/store_invite_servlet.py
@@ -139,6 +139,12 @@ class StoreInviteServlet(SydentResource):
         for keyword in self.sydent.config.email.third_party_invite_keyword_blocklist:
             for (key, value) in args.items():
                 if keyword in value.casefold():
+                    # make sure the blocklist doesn't stomp on invite_client_location url
+                    if key == "org.matrix.web_client_location" and keyword in [
+                        "https",
+                        "http",
+                    ]:
+                        continue
                     logger.info(
                         "Denying invites as %r appears in arg %r: %r",
                         keyword,


### PR DESCRIPTION
It appears that when "http" is used in the keyword blocklist legitimate invites are being dropped if the invite contains an `org.matrix.web_client_location`. This pr attempts to resolve that by allowing the invite in the case that `org.matrix.web_client_location` is provided and the blocked keyword is http or https. Fixes #540.