### PR TITLE
Fix poetry build

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -5,6 +5,10 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-newsfile:
     name: Check PR has a changelog

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-newsfile:
     name: Check PR has a changelog
-    if: ${{ github.base_ref == 'main' || contains(github.base_ref, 'release-') }}
+    if: ${{ (github.base_ref == 'main' || contains(github.base_ref, 'release-')) && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
       - uses: matrix-org/done-action@v2
         with:
           needs: ${{ toJSON(needs) }}
-          # The newsfile lint may be skipped on non PR builds
+          # The newsfile lint may be skipped on non PR builds or on dependabot builds
           skippable:
             check-newsfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN addgroup --system --gid 993 sydent \
 USER sydent:sydent
 
 # Install poetry
-RUN pip install --user poetry==1.1.12
+RUN pip install --user poetry==1.2.2
 
 # Copy source code and resources
 WORKDIR /home/sydent/src

--- a/changelog.d/548.misc
+++ b/changelog.d/548.misc
@@ -1,0 +1,1 @@
+Build using Poetry 1.2.2, for better dependabot compatability.

--- a/poetry.lock
+++ b/poetry.lock
@@ -727,27 +727,26 @@ files = [
 cffi = ">=1.4.1"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
+docs = ["sphinx (>=1.6.5)", "sphinx_rtd_theme"]
 tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
 name = "pyopenssl"
-version = "21.0.0"
+version = "23.0.0"
 description = "Python wrapper module around the OpenSSL library"
 category = "main"
 optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+python-versions = ">=3.6"
 files = [
-    {file = "pyOpenSSL-21.0.0-py2.py3-none-any.whl", hash = "sha256:8935bd4920ab9abfebb07c41a4f58296407ed77f04bd1a92914044b848ba1ed6"},
-    {file = "pyOpenSSL-21.0.0.tar.gz", hash = "sha256:5e2d8c5e46d0d865ae933bef5230090bdaf5506281e9eec60fa250ee80600cb3"},
+    {file = "pyOpenSSL-23.0.0-py3-none-any.whl", hash = "sha256:df5fc28af899e74e19fccb5510df423581047e10ab6f1f4ba1763ff5fde844c0"},
+    {file = "pyOpenSSL-23.0.0.tar.gz", hash = "sha256:c1cc5f86bcacefc84dada7d31175cae1b1518d5f60d3d0bb595a67822a868a6f"},
 ]
 
 [package.dependencies]
-cryptography = ">=3.3"
-six = ">=1.5.2"
+cryptography = ">=38.0.0,<40"
 
 [package.extras]
-docs = ["sphinx", "sphinx-rtd-theme"]
+docs = ["sphinx (!=5.2.0,!=5.2.0.post0)", "sphinx-rtd-theme"]
 test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 
 [[package]]


### PR DESCRIPTION
Fixes some the mistakes I made in merging #547 too quickly.

1. Because there was no changelog, CI didn't run, so I would have seen the test failure. Fix this by not requiring changelogs on dependabot PRs.
2. Dependabot seems to now be writing the new lockfile format (at least partially), so use Poetry 1.2.2, which understands this.
3. Sneak in "only run CI on the latest commit" to be consistent with our other pipelines.
4. The tests errored---something to do a call into pyOpenSSL. I tried updating that dependency and then the tests :magic_wand: magically passed.

Tested locally that the docker build succeeds.