### PR TITLE
Fix a RuntimeWarning exception raised when calling `ThreepidBinder._notify` without awaiting

### DIFF
--- a/changelog.d/552.bugfix
+++ b/changelog.d/552.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where Sydent would not retry attempts to inform homeservers of a successful bind after an initial failure.

--- a/sydent/threepid/bind.py
+++ b/sydent/threepid/bind.py
@@ -215,7 +215,7 @@ class ThreepidBinder:
             "Error notifying on bind for %s: %s - rescheduling", assoc["mxid"], error
         )
         self.sydent.reactor.callLater(
-            math.pow(2, attempt), self._notify, assoc, attempt + 1
+            math.pow(2, attempt), defer.ensureDeferred, self._notify(assoc, attempt + 1)
         )
 
     # The below is lovingly ripped off of synapse/http/endpoint.py


### PR DESCRIPTION
When an error occurred while informing a homeserver of a successful bind between a Matrix ID and a third-party ID, Sydent should log the error and retry the request to the homeserver.

Right now this is broken, and Sydent will raise a `RuntimeWarning` due to `ThreepidBinder._notify` not being await'd:

```
2023-02-28 11:41:47,501 - sydent.threepid.bind - 214 - WARNING - Error notifying on bind for @admin:localhost: Connection was refused by other side: 111: Connection refused. - rescheduling
/home/work/.cache/pypoetry/virtualenvs/matrix-sydent-RILnZfem-py3.10/lib/python3.10/site-packages/twisted/internet/base.py:991: RuntimeWarning: coroutine 'ThreepidBinder._notify' was never awaited
  call.func(*call.args, **call.kw)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

This would call the request to never be retried as well, breaking reliability.

This PR fixes the call to `ThreepidBinder._notify` so that it is properly awaited via `defer.ensureDeferred`. The `self.sydent.reactor.callLater(...)` call is used for backing off purposes, and expects a Callable, not a Coroutine, hence the use of something like `defer.ensureDeferred`.