### PR TITLE
Add a config option to specify which homeservers can access Sydent 

### DIFF
--- a/changelog.d/566.feature
+++ b/changelog.d/566.feature
@@ -1,0 +1,1 @@
+Add a config option `homeserver_allow_list` to specify which homeservers can access Sydent.

--- a/sydent/config/__init__.py
+++ b/sydent/config/__init__.py
@@ -52,7 +52,7 @@ CONFIG_DEFAULTS = {
         # The following can be added to your local config file to enable sentry support.
         # 'sentry_dsn': 'https://...'  # The DSN has configured in the sentry instance project.
         # Whether clients and homeservers can register an association using v1 endpoints. This
-        # option is now deprecated and will be superceded by the option `homeserver_allow_list`
+        # option is now deprecated and will be superceded by the option `enable_v1_access`
         "enable_v1_associations": "true",
         "delete_tokens_on_bind": "true",
         # Prevent outgoing requests from being sent to the following blacklisted
@@ -74,11 +74,11 @@ CONFIG_DEFAULTS = {
         # list.
         "ip.whitelist": "",
         # A list of homeservers that are allowed to register with this identity server. Defaults to
-        # allowing all homeservers. If a list is specified, the config option `disable_v1_access` must be
-        # set to 'true'.
+        # allowing all homeservers. If a list is specified, the config option `enable_v1_access` must be
+        # set to 'false'.
         "homeserver_allow_list": "",
-        # If set to 'true`, entirely disable access via the V1 api.
-        "disable_v1_access": "false",
+        # If set to 'false', entirely disable access via the V1 api.
+        "enable_v1_access": "true",
     },
     "db": {
         "db.file": os.environ.get("SYDENT_DB_PATH", "sydent.db"),

--- a/sydent/config/__init__.py
+++ b/sydent/config/__init__.py
@@ -51,7 +51,8 @@ CONFIG_DEFAULTS = {
         # 'prometheus_addr': '',  # The address to bind to. Empty string means bind to all.
         # The following can be added to your local config file to enable sentry support.
         # 'sentry_dsn': 'https://...'  # The DSN has configured in the sentry instance project.
-        # Whether clients and homeservers can register an association using v1 endpoints.
+        # Whether clients and homeservers can register an association using v1 endpoints. This
+        # option is now deprecated and will be superceded by the option `homeserver_allow_list`
         "enable_v1_associations": "true",
         "delete_tokens_on_bind": "true",
         # Prevent outgoing requests from being sent to the following blacklisted
@@ -73,8 +74,11 @@ CONFIG_DEFAULTS = {
         # list.
         "ip.whitelist": "",
         # A list of homeservers that are allowed to register with this identity server. Defaults to
-        # allowing all homeservers.
+        # allowing all homeservers. If a list is specified, the config option `disable_v1_access` must be
+        # set to 'true'.
         "homeserver_allow_list": "",
+        # If set to 'true`, entirely disable access via the V1 api.
+        "disable_v1_access": "false",
     },
     "db": {
         "db.file": os.environ.get("SYDENT_DB_PATH", "sydent.db"),

--- a/sydent/config/__init__.py
+++ b/sydent/config/__init__.py
@@ -72,6 +72,9 @@ CONFIG_DEFAULTS = {
         # This whitelist overrides `ip.blacklist` and defaults to an empty
         # list.
         "ip.whitelist": "",
+        # A list of homeservers that are allowed to register with this identity server. Defaults to
+        # allowing all homeservers.
+        "homeserver_allow_list": "",
     },
     "db": {
         "db.file": os.environ.get("SYDENT_DB_PATH", "sydent.db"),

--- a/sydent/config/general.py
+++ b/sydent/config/general.py
@@ -82,10 +82,6 @@ class GeneralConfig(BaseConfig):
         self.sentry_enabled = cfg.has_option("general", "sentry_dsn")
         self.sentry_dsn = cfg.get("general", "sentry_dsn", fallback=None)
 
-        self.enable_v1_associations = parse_cfg_bool(
-            cfg.get("general", "enable_v1_associations")
-        )
-
         self.delete_tokens_on_bind = parse_cfg_bool(
             cfg.get("general", "delete_tokens_on_bind")
         )
@@ -99,18 +95,25 @@ class GeneralConfig(BaseConfig):
         self.ip_blacklist = generate_ip_set(ip_blacklist)
         self.ip_whitelist = generate_ip_set(ip_whitelist)
 
-        self.disable_v1_access = parse_cfg_bool(cfg.get("general", "disable_v1_access"))
+        self.enable_v1_access = parse_cfg_bool(cfg.get("general", "enable_v1_access"))
 
         homeserver_allow_list = list_from_comma_sep_string(
             cfg.get("general", "homeserver_allow_list")
         )
-        if homeserver_allow_list and not self.disable_v1_access:
+        if homeserver_allow_list and self.enable_v1_access:
             raise RuntimeError(
                 """The V1 api must be disabled for the `homeserver_allow_list` to function, if you have 
                 specified a `homeserver_allow_list` in the config file please ensure that the config 
-                option `disable_v1_access` is set to 'true'."""
+                option `enable_v1_access` is set to 'false'."""
             )
         self.homeserver_allow_list = homeserver_allow_list
+
+        if not self.enable_v1_access:
+            self.enable_v1_associations = False
+        else:
+            self.enable_v1_associations = parse_cfg_bool(
+                cfg.get("general", "enable_v1_associations")
+            )
 
         return False
 

--- a/sydent/config/general.py
+++ b/sydent/config/general.py
@@ -99,9 +99,17 @@ class GeneralConfig(BaseConfig):
         self.ip_blacklist = generate_ip_set(ip_blacklist)
         self.ip_whitelist = generate_ip_set(ip_whitelist)
 
+        self.disable_v1_access = parse_cfg_bool(cfg.get("general", "disable_v1_access"))
+
         homeserver_allow_list = list_from_comma_sep_string(
             cfg.get("general", "homeserver_allow_list")
         )
+        if homeserver_allow_list and not self.disable_v1_access:
+            raise RuntimeError(
+                """The V1 api must be disabled for the `homeserver_allow_list` to function, if you have 
+                specified a `homeserver_allow_list` in the config file please ensure that the config 
+                option `disable_v1_access` is set to 'true'."""
+            )
         self.homeserver_allow_list = homeserver_allow_list
 
         return False

--- a/sydent/config/general.py
+++ b/sydent/config/general.py
@@ -99,6 +99,11 @@ class GeneralConfig(BaseConfig):
         self.ip_blacklist = generate_ip_set(ip_blacklist)
         self.ip_whitelist = generate_ip_set(ip_whitelist)
 
+        homeserver_allow_list = list_from_comma_sep_string(
+            cfg.get("general", "homeserver_allow_list")
+        )
+        self.homeserver_allow_list = homeserver_allow_list
+
         return False
 
 

--- a/sydent/http/httpserver.py
+++ b/sydent/http/httpserver.py
@@ -106,7 +106,7 @@ class ClientApiHttpServer:
         ephemeralPubkey.putChild(b"isvalid", EphemeralPubkeyIsValidServlet(sydent))
 
         # v1
-        if not self.sydent.config.general.disable_v1_access:
+        if self.sydent.config.general.enable_v1_access:
             api.putChild(b"v1", v1)
             validate.putChild(b"email", email)
             validate.putChild(b"msisdn", msisdn)
@@ -131,10 +131,7 @@ class ClientApiHttpServer:
 
             v1.putChild(b"sign-ed25519", BlindlySignStuffServlet(sydent))
 
-        if (
-            self.sydent.config.general.enable_v1_associations
-            or not self.sydent.config.general.disable_v1_access
-        ):
+        if self.sydent.config.general.enable_v1_associations:
             threepid_v1.putChild(b"bind", ThreePidBindServlet(sydent))
 
         # v2

--- a/sydent/http/servlets/registerservlet.py
+++ b/sydent/http/servlets/registerservlet.py
@@ -53,6 +53,14 @@ class RegisterServlet(SydentResource):
 
         matrix_server = args["matrix_server_name"].lower()
 
+        if self.sydent.config.general.homeserver_allow_list:
+            if matrix_server not in self.sydent.config.general.homeserver_allow_list:
+                request.setResponseCode(403)
+                return {
+                    "errcode": "M_UNAUTHORIZED",
+                    "error": "This homeserver is not authorized to access this server.",
+                }
+
         if not is_valid_matrix_server_name(matrix_server):
             request.setResponseCode(400)
             return {

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -102,33 +102,16 @@ class RegisterTestCase(unittest.TestCase):
 
 class RegisterAllowListTestCase(unittest.TestCase):
     """
-    Test registering works with or without the homeserver_allow_list config option specified
+    Test registering works with the `homeserver_allow_list` config option specified
     """
 
-    def test_registering_works_if_no_homeserver_allow_list(self) -> None:
-        # Create a new sydent with no homsever_allow_list
-        self.sydent = make_sydent()
-        self.sydent.run()
-
-        return_val = {"sub": "@user_id:not.example.com"}
-        with patch(
-            "sydent.http.httpclient.FederationHttpClient.get_json",
-            return_value=return_val,
-        ):
-            request, channel = make_request(
-                self.sydent.reactor,
-                self.sydent.clientApiHttpServer.factory,
-                "POST",
-                "/_matrix/identity/v2/account/register",
-                content={
-                    "matrix_server_name": "not.example.com",
-                    "access_token": "foo",
-                },
-            )
-            self.assertEqual(channel.code, 200)
-
     def test_registering_not_allowed_if_homeserver_not_in_allow_list(self) -> None:
-        config = {"general": {"homeserver_allow_list": "friendly.com, example.com"}}
+        config = {
+            "general": {
+                "homeserver_allow_list": "friendly.com, example.com",
+                "disable_v1_access": "true",
+            }
+        }
         # Create a new sydent with a homeserver_allow_list specified
         self.sydent = make_sydent(test_config=config)
         self.sydent.run()

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -109,7 +109,7 @@ class RegisterAllowListTestCase(unittest.TestCase):
         config = {
             "general": {
                 "homeserver_allow_list": "friendly.com, example.com",
-                "disable_v1_access": "true",
+                "enable_v1_access": "false",
             }
         }
         # Create a new sydent with a homeserver_allow_list specified

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -9,3 +9,18 @@ class StartupTestCase(unittest.TestCase):
     def test_start(self):
         sydent = make_sydent()
         sydent.run()
+
+    def test_homeserver_allow_list_refuses_to_start_if_v1_not_disabled(self):
+        """
+        Test that Sydent throws a runtime error if `homeserver_allow_list` is specified
+        but the v1 API has not been disabled
+        """
+        config = {
+            "general": {
+                "homeserver_allow_list": "friendly.com, example.com",
+                "disable_v1_access": "false",
+            }
+        }
+
+        with self.assertRaises(RuntimeError):
+            make_sydent(test_config=config)

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -18,7 +18,7 @@ class StartupTestCase(unittest.TestCase):
         config = {
             "general": {
                 "homeserver_allow_list": "friendly.com, example.com",
-                "disable_v1_access": "false",
+                "enable_v1_access": "true",
             }
         }
 


### PR DESCRIPTION
This PR adds a config option `homeserver_allow_list` which enables a user to specify a list of homeservers which Sydent will work with. The option defaults to allow all homeservers if not set. It works by disabling registration unless the homeserver associated with the registration request is in the `homeserver_allow_list`. The thinking behind this is that without registration an access token cannot be granted - and access tokens are necessary for most functions of Sydent. Fixes #565.  