### PR TITLE
Fix docker failing to install poetry due to missing /home/sydent directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM docker.io/python:3.8-slim as builder
 
 # Add user sydent
 RUN addgroup --system --gid 993 sydent \
-    && adduser --disabled-login --system --uid 993 --gecos sydent sydent
+    && adduser --disabled-login --system --uid 993 --gecos sydent sydent --home /home/sydent
 USER sydent:sydent
 
 # Install poetry
@@ -42,7 +42,7 @@ FROM docker.io/python:3.8-slim
 
 # Add user sydent and create /data directory
 RUN addgroup --system --gid 993 sydent \
-    && adduser --disabled-login --home /sydent --system --uid 993 --gecos sydent sydent \
+    && adduser --disabled-login --home /home/sydent --system --uid 993 --gecos sydent sydent \
     && mkdir /data \
     && chown sydent:sydent /data
 

--- a/changelog.d/567.docker
+++ b/changelog.d/567.docker
@@ -1,1 +1,1 @@
-Fix docker failing to install poetry due to /home/sydent not created
+Fix an issue where the Docker image would fail to build due to /home/sydent not being created.

--- a/changelog.d/567.docker
+++ b/changelog.d/567.docker
@@ -1,0 +1,1 @@
+Fix docker failing to install poetry due to /home/sydent not created


### PR DESCRIPTION
### Pull Request Checklist

* [x] Pull request includes a [changelog file](https://github.com/matrix-org/sydent/blob/main/CONTRIBUTING.md#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fix a bug that prevented receiving messages from other servers." instead of "Move X method from `EventStore` to `EventWorkerStore`.".
  - Include 'Contributed by *Your Name*.' or 'Contributed by @*your-github-username*.' — unless you would prefer not to be credited in the changelog.
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

The existing Dockerfile does not create the home folder in /home/sydent, which results in the PIP installation of Sydent failing with

`WARNING: The directory '/nonexistent/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag. `

and subsequently

`ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '/nonexistent'`.

This PR changes the home directory of the `sydent` user to /home/sydent instead of /sydent to fix this issue.