### PR TITLE
Explicitly create an SSL context when emailing

### DIFF
--- a/changelog.d/574.bugfix
+++ b/changelog.d/574.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing issue where Sydent would not verify the configured SMTP server's certificates. See [GHSA-p6hw-wm59-3q5q](https://github.com/matrix-org/sydent/security/advisories/GHSA-p6hw-wm59-3g5g) and [CVE-2023-38686](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38686). Reported by Martin Schobert, [Pentagrid AG](https://pentagrid.ch).

--- a/sydent/util/emailutils.py
+++ b/sydent/util/emailutils.py
@@ -16,6 +16,7 @@ import email.utils
 import logging
 import random
 import smtplib
+import ssl
 import string
 import urllib
 from html import escape
@@ -106,11 +107,14 @@ def sendEmail(
     )
     try:
         smtp: smtplib.SMTP
+        # Explicitly create a context, to ensure we verify the server's certificate
+        # and hostname.
+        ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
         if mailTLSMode == "SSL" or mailTLSMode == "TLS":
-            smtp = smtplib.SMTP_SSL(mailServer, mailPort, myHostname)
+            smtp = smtplib.SMTP_SSL(mailServer, mailPort, myHostname, context=ctx)
         elif mailTLSMode == "STARTTLS":
             smtp = smtplib.SMTP(mailServer, mailPort, myHostname)
-            smtp.starttls()
+            smtp.starttls(context=ctx)
         else:
             smtp = smtplib.SMTP(mailServer, mailPort, myHostname)
         if mailUsername != "":


### PR DESCRIPTION
This follows the advice given at https://docs.python.org/3/library/ssl.html?highlight=ssl#security-considerations.