### PR TITLE
Pin CI to Python 3.11

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -26,7 +26,35 @@ jobs:
       - run: "scripts-dev/check_newsfragment.sh ${{ github.event.number }}"
 
   checks:
-    uses: "matrix-org/backend-meta/.github/workflows/python-poetry-ci.yml@v2"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: matrix-org/setup-python-poetry@v1
+        with:
+          install-project: false
+
+      - name: Import order (isort)
+        run: poetry run isort --check --diff .
+
+      - name: Code style (black)
+        run: poetry run black --check --diff .
+
+      - name: Semantic checks (ruff)
+        # --quiet suppresses the update check.
+        run: poetry run ruff --quiet .
+
+      - name: Restore/persist mypy's cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            .mypy_cache
+          key: mypy-cache-${{ github.context.sha }}
+          restore-keys: mypy-cache-
+
+      - name: Typechecking (mypy)
+        run: poetry run mypy
+
   packaging:
     uses: "matrix-org/backend-meta/.github/workflows/packaging.yml@v1"
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.x']
+        python-version: ['3.7', '3.11']
         test-dir: ['tests', 'matrix_is_tester']
 
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{github.event.pull_request.head.sha}}
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.11"
       - run: python -m pip install towncrier
       - run: "scripts-dev/check_newsfragment.sh ${{ github.event.number }}"
 
@@ -32,6 +32,7 @@ jobs:
 
       - uses: matrix-org/setup-python-poetry@v1
         with:
+          python-version: 3.11
           install-project: false
 
       - name: Import order (isort)

--- a/changelog.d/583.misc
+++ b/changelog.d/583.misc
@@ -1,0 +1,1 @@
+Pin CI to Python 3.11.


### PR DESCRIPTION
To fix failing tests and lints running on Python 3.12 on the main branch.